### PR TITLE
chore(config): restore EMA periods for simple_ma

### DIFF
--- a/config/settings.yaml
+++ b/config/settings.yaml
@@ -59,8 +59,8 @@ strategy:
   strategies:
     - name: simple_ma
       config:
-        ema_short_period: 5
-        ema_long_period: 13
+        ema_short_period: 12
+        ema_long_period: 26
     - name: rsi_reversal
       config:
         rsi_period: 14


### PR DESCRIPTION
## Summary\n- Restore EMA(12/26) for simple_ma to match computed indicators\n\n## Testing\n- Not run (config change)