### PR TITLE
fix(execution): salvage timing and staged-order followups

### DIFF
--- a/src/execution/guards.py
+++ b/src/execution/guards.py
@@ -179,8 +179,8 @@ class CooldownGuard(Guard):
         portfolio_value: float,
         context: dict[str, Any],
     ) -> GuardResponse:
-        last_time = self._last_trade_time.get(symbol, 0)
-        elapsed = time.time() - last_time
+        last_time = self._last_trade_time.get(symbol, 0.0)
+        elapsed = time.monotonic() - last_time
 
         if elapsed < self.cooldown_seconds:
             remaining = self.cooldown_seconds - elapsed
@@ -199,7 +199,7 @@ class CooldownGuard(Guard):
         )
 
     def record_trade(self, symbol: str) -> None:
-        self._last_trade_time[symbol] = time.time()
+        self._last_trade_time[symbol] = time.monotonic()
 
     def reset(self) -> None:
         self._last_trade_time.clear()

--- a/src/execution/retry.py
+++ b/src/execution/retry.py
@@ -54,7 +54,7 @@ class CircuitBreaker:
     @property
     def state(self) -> CircuitState:
         if self._state == CircuitState.OPEN:
-            if time.time() - self._last_failure_time >= self.recovery_timeout:
+            if time.monotonic() - self._last_failure_time >= self.recovery_timeout:
                 self._state = CircuitState.HALF_OPEN
                 self._half_open_calls = 0
                 self._logger.info("Circuit breaker transitioning to HALF_OPEN")
@@ -62,9 +62,10 @@ class CircuitBreaker:
 
     def can_execute(self) -> bool:
         """Check if execution is allowed."""
-        if self._state == CircuitState.CLOSED:
+        current_state = self.state
+        if current_state == CircuitState.CLOSED:
             return True
-        if self._state == CircuitState.OPEN:
+        if current_state == CircuitState.OPEN:
             return False
         # HALF_OPEN
         return self._half_open_calls < self.half_open_max_calls
@@ -83,7 +84,7 @@ class CircuitBreaker:
     def record_failure(self) -> None:
         """Record failed call."""
         self._failure_count += 1
-        self._last_failure_time = time.time()
+        self._last_failure_time = time.monotonic()
 
         if self._state == CircuitState.HALF_OPEN:
             self._state = CircuitState.OPEN
@@ -121,6 +122,10 @@ class RetryConfig:
     max_delay: float = 30.0
     exponential_base: float = 2.0
     jitter: float = 0.1
+
+    def __post_init__(self) -> None:
+        if self.max_attempts < 1:
+            raise ValueError(f"max_attempts must be >= 1, got {self.max_attempts}")
 
 
 async def retry_with_backoff(

--- a/src/execution/staged.py
+++ b/src/execution/staged.py
@@ -5,7 +5,7 @@ providing an additional safety layer before any exchange interaction.
 
 Workflow:
 1. stage(order)   - Order created and queued for review
-2. commit(hash)   - Order explicitly approved, ready for execution
+2. commit(order_id) -> hash  - Order explicitly approved, ready for execution
 3. push(order)    - Order sent to exchange
 
 Each commit generates an 8-character hash for traceability.
@@ -53,6 +53,7 @@ class StagedOrder:
         created_at: Timestamp when staged
         committed_at: Timestamp when committed
         pushed_at: Timestamp when pushed to exchange
+        filled_at: Timestamp when order was filled
         exchange_order_id: Exchange order ID (after push)
         error: Error message if failed
         metadata: Additional context
@@ -71,6 +72,7 @@ class StagedOrder:
     created_at: datetime = field(default_factory=lambda: datetime.now(UTC))
     committed_at: datetime | None = None
     pushed_at: datetime | None = None
+    filled_at: datetime | None = None
     exchange_order_id: str | None = None
     error: str | None = None
     metadata: dict[str, Any] = field(default_factory=dict)
@@ -91,6 +93,7 @@ class StagedOrder:
             "created_at": self.created_at.isoformat(),
             "committed_at": self.committed_at.isoformat() if self.committed_at else None,
             "pushed_at": self.pushed_at.isoformat() if self.pushed_at else None,
+            "filled_at": self.filled_at.isoformat() if self.filled_at else None,
             "exchange_order_id": self.exchange_order_id,
             "error": self.error,
             "metadata": self.metadata,
@@ -158,6 +161,9 @@ class StagedOrderQueue:
         )
 
         self._orders[order_id] = order
+        if len(self._orders) > self._max_history:
+            oldest_id = next(iter(self._orders))
+            del self._orders[oldest_id]
         self._logger.info(
             "Order staged: %s %s %.4f %s (id=%s, confidence=%.2f)",
             side.value if isinstance(side, SignalType) else side,
@@ -268,7 +274,13 @@ class StagedOrderQueue:
         if new_stage == OrderStage.PUSHED:
             order.pushed_at = datetime.now(UTC)
         if new_stage == OrderStage.FILLED:
-            order.pushed_at = order.pushed_at or datetime.now(UTC)
+            if order.filled_at is None:
+                order.filled_at = datetime.now(UTC)
+            if order.pushed_at is None:
+                self._logger.warning(
+                    "Order %s filled without pushed_at set; missing PUSHED transition.",
+                    order_id,
+                )
 
         self._logger.info(
             "Order stage updated: %s %s -> %s",

--- a/tests/test_guards.py
+++ b/tests/test_guards.py
@@ -1,7 +1,5 @@
 """Tests for guard pipeline."""
 
-import time
-
 from src.execution.guards import (
     CooldownGuard,
     GuardPipeline,
@@ -53,9 +51,13 @@ class TestMaxPositionsGuard:
 
 
 class TestCooldownGuard:
-    def test_pass_after_cooldown(self):
-        guard = CooldownGuard(cooldown_seconds=0.5)
-        time.sleep(0.6)
+    def test_pass_after_cooldown(self, monkeypatch):
+        guard = CooldownGuard(cooldown_seconds=60.0)
+        guard.record_trade("BTCUSDT")
+        monkeypatch.setattr(
+            "src.execution.guards.time.monotonic",
+            lambda: guard._last_trade_time["BTCUSDT"] + 61.0,
+        )
         response = guard.check(
             symbol="BTCUSDT",
             side="BUY",

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -1,0 +1,203 @@
+"""Tests for retry logic, circuit breaker, and dead letter queue."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.execution.retry import (
+    CircuitBreaker,
+    CircuitState,
+    DeadLetterQueue,
+    RetryConfig,
+    retry_with_backoff,
+)
+
+
+class TestRetryConfig:
+    def test_valid_config(self) -> None:
+        config = RetryConfig(max_attempts=3)
+        assert config.max_attempts == 3
+
+    def test_max_attempts_zero_raises(self) -> None:
+        with pytest.raises(ValueError, match="max_attempts must be >= 1"):
+            RetryConfig(max_attempts=0)
+
+    def test_max_attempts_negative_raises(self) -> None:
+        with pytest.raises(ValueError, match="max_attempts must be >= 1"):
+            RetryConfig(max_attempts=-1)
+
+    def test_max_attempts_one_is_valid(self) -> None:
+        config = RetryConfig(max_attempts=1)
+        assert config.max_attempts == 1
+
+
+class TestCircuitBreaker:
+    def test_initial_state_is_closed(self) -> None:
+        cb = CircuitBreaker()
+        assert cb.state == CircuitState.CLOSED
+        assert cb.can_execute() is True
+
+    def test_closed_to_open_after_threshold(self) -> None:
+        cb = CircuitBreaker(failure_threshold=3)
+        for _ in range(3):
+            cb.record_failure()
+        assert cb.state == CircuitState.OPEN
+        assert cb.can_execute() is False
+
+    def test_open_to_half_open_after_recovery_timeout(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        cb = CircuitBreaker(failure_threshold=1, recovery_timeout=30.0)
+        cb.record_failure()
+        assert cb.state == CircuitState.OPEN
+
+        monkeypatch.setattr(
+            "src.execution.retry.time.monotonic",
+            lambda: cb._last_failure_time + 31.0,
+        )
+        assert cb.state == CircuitState.HALF_OPEN
+        assert cb.can_execute() is True
+
+    def test_half_open_to_closed_after_enough_successes(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        cb = CircuitBreaker(failure_threshold=1, recovery_timeout=30.0, half_open_max_calls=2)
+        cb.record_failure()
+
+        monkeypatch.setattr(
+            "src.execution.retry.time.monotonic",
+            lambda: cb._last_failure_time + 31.0,
+        )
+        assert cb.state == CircuitState.HALF_OPEN
+
+        cb.record_success()
+        cb.record_success()
+        assert cb.state == CircuitState.CLOSED
+
+    def test_half_open_to_open_on_failure(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        cb = CircuitBreaker(failure_threshold=1, recovery_timeout=30.0)
+        cb.record_failure()
+
+        monkeypatch.setattr(
+            "src.execution.retry.time.monotonic",
+            lambda: cb._last_failure_time + 31.0,
+        )
+        assert cb.state == CircuitState.HALF_OPEN
+
+        cb.record_failure()
+        assert cb._state == CircuitState.OPEN
+
+    def test_reset_returns_to_closed(self) -> None:
+        cb = CircuitBreaker(failure_threshold=1)
+        cb.record_failure()
+        assert cb.state == CircuitState.OPEN
+
+        cb.reset()
+        assert cb.state == CircuitState.CLOSED
+        assert cb.can_execute() is True
+
+    def test_success_in_closed_resets_failure_count(self) -> None:
+        cb = CircuitBreaker(failure_threshold=3)
+        cb.record_failure()
+        cb.record_failure()
+        assert cb._failure_count == 2
+
+        cb.record_success()
+        assert cb._failure_count == 0
+
+    def test_half_open_limits_calls(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        cb = CircuitBreaker(failure_threshold=1, recovery_timeout=30.0, half_open_max_calls=2)
+        cb.record_failure()
+
+        monkeypatch.setattr(
+            "src.execution.retry.time.monotonic",
+            lambda: cb._last_failure_time + 31.0,
+        )
+        assert cb.state == CircuitState.HALF_OPEN
+        assert cb.can_execute() is True
+
+        cb._half_open_calls = 2
+        assert cb.can_execute() is False
+
+
+class TestRetryWithBackoff:
+    @pytest.mark.asyncio
+    async def test_succeeds_on_first_attempt(self) -> None:
+        async def always_ok() -> int:
+            return 42
+
+        result = await retry_with_backoff(always_ok, RetryConfig(max_attempts=3))
+        assert result == 42
+
+    @pytest.mark.asyncio
+    async def test_retries_and_succeeds(self) -> None:
+        call_count = 0
+
+        async def fails_twice() -> str:
+            nonlocal call_count
+            call_count += 1
+            if call_count < 3:
+                raise ValueError("transient")
+            return "ok"
+
+        config = RetryConfig(max_attempts=3, base_delay=0.0, jitter=0.0)
+        result = await retry_with_backoff(fails_twice, config)
+        assert result == "ok"
+        assert call_count == 3
+
+    @pytest.mark.asyncio
+    async def test_raises_after_all_attempts_exhausted(self) -> None:
+        async def always_fails() -> None:
+            raise RuntimeError("boom")
+
+        config = RetryConfig(max_attempts=3, base_delay=0.0, jitter=0.0)
+        with pytest.raises(RuntimeError, match="boom"):
+            await retry_with_backoff(always_fails, config)
+
+    @pytest.mark.asyncio
+    async def test_single_attempt_no_retry(self) -> None:
+        call_count = 0
+
+        async def fails() -> None:
+            nonlocal call_count
+            call_count += 1
+            raise ValueError("only once")
+
+        config = RetryConfig(max_attempts=1, base_delay=0.0, jitter=0.0)
+        with pytest.raises(ValueError):
+            await retry_with_backoff(fails, config)
+        assert call_count == 1
+
+
+class TestDeadLetterQueue:
+    def test_add_and_retrieve(self) -> None:
+        dlq = DeadLetterQueue()
+        dlq.add("order1", "submit_order", (), {}, 3, "Exchange error")
+        entries = dlq.get_all()
+        assert len(entries) == 1
+        assert entries[0].id == "order1"
+        assert entries[0].last_error == "Exchange error"
+
+    def test_max_size_trims_oldest(self) -> None:
+        dlq = DeadLetterQueue(max_size=3)
+        for i in range(4):
+            dlq.add(f"order{i}", "fn", (), {}, 3, "err")
+
+        entries = dlq.get_all()
+        assert len(entries) == 3
+        assert entries[0].id == "order1"
+
+    def test_clear(self) -> None:
+        dlq = DeadLetterQueue()
+        dlq.add("order1", "fn", (), {}, 3, "err")
+        assert len(dlq) == 1
+
+        dlq.clear()
+        assert len(dlq) == 0
+
+    def test_len(self) -> None:
+        dlq = DeadLetterQueue()
+        assert len(dlq) == 0
+        dlq.add("a", "fn", (), {}, 1, "e")
+        dlq.add("b", "fn", (), {}, 2, "e")
+        assert len(dlq) == 2

--- a/tests/test_staged_orders.py
+++ b/tests/test_staged_orders.py
@@ -42,6 +42,7 @@ class TestStagedOrder:
         assert data["quantity"] == 0.01
         assert data["stage"] == "staged"
         assert data["signal_confidence"] == 0.75
+        assert data["filled_at"] is None
 
 
 class TestStagedOrderQueue:
@@ -154,6 +155,41 @@ class TestStagedOrderQueue:
         stats = queue.get_stats()
         assert stats["staged"] == 1
         assert stats["committed"] == 1
+
+    def test_stage_trims_oldest_when_history_limit_exceeded(self):
+        queue = StagedOrderQueue(max_history=2)
+        first = queue.stage(symbol="BTCUSDT", side=SignalType.BUY, quantity=0.01)
+        queue.stage(symbol="ETHUSDT", side=SignalType.BUY, quantity=0.1)
+        third = queue.stage(symbol="SOLUSDT", side=SignalType.BUY, quantity=0.2)
+
+        assert first.id not in queue._orders
+        assert third.id in queue._orders
+        assert len(queue._orders) == 2
+
+    def test_update_stage_filled_sets_filled_at_without_overwriting_pushed_at(self):
+        queue = StagedOrderQueue()
+        order = queue.stage(symbol="BTCUSDT", side=SignalType.BUY, quantity=0.01)
+        queue.update_stage(order.id, OrderStage.PUSHED, exchange_order_id="12345")
+        pushed_at = queue._orders[order.id].pushed_at
+
+        success = queue.update_stage(order.id, OrderStage.FILLED)
+
+        assert success is True
+        updated = queue._orders[order.id]
+        assert updated.stage == OrderStage.FILLED
+        assert updated.filled_at is not None
+        assert updated.pushed_at == pushed_at
+
+    def test_update_stage_filled_without_pushed_logs_warning(self):
+        queue = StagedOrderQueue()
+        order = queue.stage(symbol="BTCUSDT", side=SignalType.BUY, quantity=0.01)
+
+        success = queue.update_stage(order.id, OrderStage.FILLED)
+
+        assert success is True
+        updated = queue._orders[order.id]
+        assert updated.pushed_at is None
+        assert updated.filled_at is not None
 
 
 class TestGlobalQueue:


### PR DESCRIPTION
## Summary\n- salvage the remaining execution correctness fixes from the stale PR19 review branch onto a clean branch from main\n- switch cooldown and circuit-breaker recovery timing to monotonic clocks and validate invalid retry configs early\n- extend staged-order lifecycle/history behavior and add focused regression coverage\n\n## Testing\n- .venv/bin/pytest tests/test_guards.py tests/test_retry.py tests/test_staged_orders.py\n\nTask: T016