### PR TITLE
Add opt-in TWAP order slicing

### DIFF
--- a/src/execution/executor.py
+++ b/src/execution/executor.py
@@ -464,6 +464,71 @@ class TradingExecutor:
             self._metrics.record_api_error("cancel_all_orders", str(type(exc).__name__))
             raise
 
+    async def place_twap_order(
+        self,
+        symbol: str,
+        side: str,
+        total_quantity: float,
+        num_slices: int = 5,
+        interval_seconds: float = 30.0,
+    ) -> list[OrderInfo]:
+        """Place a TWAP order as sequential market-order slices.
+
+        This is opt-in execution behavior for callers that want to reduce
+        market impact on thin books. Existing signal handling remains unchanged.
+        """
+        if total_quantity <= 0:
+            raise ValueError("total_quantity must be positive")
+        if num_slices < 1:
+            num_slices = 1
+
+        slice_quantity = total_quantity / num_slices
+        filled_orders: list[OrderInfo] = []
+
+        self._logger.info(
+            "TWAP order: %s %s %.6f in %d slices (%.1fs apart)",
+            side,
+            symbol,
+            total_quantity,
+            num_slices,
+            interval_seconds,
+        )
+
+        for slice_index in range(num_slices):
+            try:
+                order = await self.place_market_order(symbol, side, slice_quantity)
+            except Exception as exc:
+                self._logger.error(
+                    "TWAP slice %d/%d failed: %s; aborting remaining slices",
+                    slice_index + 1,
+                    num_slices,
+                    exc,
+                )
+                break
+
+            filled_orders.append(order)
+            self._logger.info(
+                "TWAP slice %d/%d: %s (status: %s)",
+                slice_index + 1,
+                num_slices,
+                order.order_id,
+                order.status,
+            )
+
+            if slice_index < num_slices - 1:
+                await asyncio.sleep(interval_seconds)
+
+        total_filled = sum(
+            order.executed_quantity for order in filled_orders if order.status == "FILLED"
+        )
+        self._logger.info(
+            "TWAP complete: %d/%d slices filled, total qty=%.6f",
+            len(filled_orders),
+            num_slices,
+            total_filled,
+        )
+        return filled_orders
+
     def _calculate_quantity(self, symbol: str, portfolio_value: float) -> float:
         """Calculate order quantity based on config and portfolio value.
 

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import time
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -287,3 +288,89 @@ async def test_on_signal_sell_skips_dust_balance_silently():
     mock_client.normalize_sell_quantity.assert_called_once_with("XRPUSDT", 0.0292)
     executor.place_market_order.assert_not_called()
     notifier.send_trade_alert.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_place_twap_order_splits_into_equal_slices():
+    config = TradingConfig(api_key="key", api_secret="secret", enabled=True, symbols=["BTCUSDT"])
+    risk_manager = MagicMock(spec=RiskManager)
+    metrics = MagicMock(spec=ExecutionMetrics)
+    executor = TradingExecutor(config, risk_manager, metrics)
+
+    filled_order = OrderInfo(
+        order_id="123",
+        symbol="BTCUSDT",
+        side="BUY",
+        order_type="MARKET",
+        quantity=20.0,
+        price=None,
+        status="FILLED",
+        executed_quantity=20.0,
+        create_time=int(time.time() * 1000),
+    )
+    executor.place_market_order = AsyncMock(return_value=filled_order)
+
+    orders = await executor.place_twap_order(
+        "BTCUSDT",
+        "BUY",
+        total_quantity=100.0,
+        num_slices=5,
+        interval_seconds=0.01,
+    )
+
+    assert len(orders) == 5
+    assert executor.place_market_order.await_count == 5
+    for call in executor.place_market_order.await_args_list:
+        assert call.args == ("BTCUSDT", "BUY", 20.0)
+
+
+@pytest.mark.asyncio
+async def test_place_twap_order_aborts_after_first_failed_slice():
+    config = TradingConfig(api_key="key", api_secret="secret", enabled=True, symbols=["BTCUSDT"])
+    risk_manager = MagicMock(spec=RiskManager)
+    metrics = MagicMock(spec=ExecutionMetrics)
+    executor = TradingExecutor(config, risk_manager, metrics)
+
+    filled_order = OrderInfo(
+        order_id="123",
+        symbol="BTCUSDT",
+        side="BUY",
+        order_type="MARKET",
+        quantity=50.0,
+        price=None,
+        status="FILLED",
+        executed_quantity=50.0,
+        create_time=int(time.time() * 1000),
+    )
+
+    call_count = 0
+
+    async def side_effect(*_args, **_kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count >= 3:
+            raise RuntimeError("Trading blocked")
+        return filled_order
+
+    executor.place_market_order = AsyncMock(side_effect=side_effect)
+
+    orders = await executor.place_twap_order(
+        "BTCUSDT",
+        "BUY",
+        total_quantity=100.0,
+        num_slices=5,
+        interval_seconds=0.01,
+    )
+
+    assert len(orders) == 2
+
+
+@pytest.mark.asyncio
+async def test_place_twap_order_rejects_non_positive_quantity():
+    config = TradingConfig(api_key="key", api_secret="secret", enabled=True, symbols=["BTCUSDT"])
+    risk_manager = MagicMock(spec=RiskManager)
+    metrics = MagicMock(spec=ExecutionMetrics)
+    executor = TradingExecutor(config, risk_manager, metrics)
+
+    with pytest.raises(ValueError, match="total_quantity must be positive"):
+        await executor.place_twap_order("BTCUSDT", "BUY", total_quantity=0.0)


### PR DESCRIPTION
## Summary
- salvage the safe execution-only slice from PR #26 onto current `main`
- add `TradingExecutor.place_twap_order()` as an opt-in helper
- add targeted executor tests for slice splitting, abort-on-failure, and quantity validation

## Why
PR #26 is based on an old main and removes current live/runtime paths. This PR keeps all existing strategy, lifecycle, and paper-trading behavior intact and only carries forward the additive execution change that can be reviewed independently.

## Testing
- `.venv/bin/pytest tests/test_executor.py tests/test_strategy_integration.py`

Task: T018