### PR TITLE
feat(config): add BTC multi-timeframe paper sidecar

### DIFF
--- a/config/prometheus/agents.json
+++ b/config/prometheus/agents.json
@@ -22,6 +22,13 @@
 	},
 	{
 		"labels": {
+			"service": "agent_btc_mtf",
+			"agent_id": "btc-1h-mtf"
+		},
+		"targets": ["agent_btc_mtf:8000"]
+	},
+	{
+		"labels": {
 			"service": "agent_sol_sparse",
 			"agent_id": "sol-trend-pullback-sparse"
 		},

--- a/config/settings.btc_1h_mtf.yaml
+++ b/config/settings.btc_1h_mtf.yaml
@@ -1,0 +1,87 @@
+mode: paper
+agent_id: btc-1h-mtf
+log_level: INFO
+
+trading:
+  pairs:
+    - BTCUSDT
+  timeframe: 1h
+
+ingest:
+  use_websocket: true
+
+database:
+  host: timescaledb
+  port: 5432
+  name: marketdata
+  user: trading
+  password: ""
+
+telegram:
+  enabled: false
+  bot_token: ""
+  chat_id: ""
+  rate_limit_seconds: 5
+  allowed_updates:
+    - message
+
+ai:
+  enabled: false
+
+prometheus:
+  port: 8000
+
+trading_execution:
+  enabled: true
+  api_key: ""
+  api_secret: ""
+  test_mode: true
+  order_size_usdt: 100.0
+  stop_loss_pct: 0.02
+  take_profit_pct: 0.05
+  sl_atr_multiplier: 2.0
+  tp_atr_multiplier: 4.5
+  trailing_activate_atr: 1.5
+  trailing_offset_atr: 1.0
+  use_atr_sizing: true
+  atr_multiplier: 1.0
+  risk_per_trade_pct: 0.02
+  exit_rules:
+    time_stop_minutes: 240
+
+futures:
+  enabled: true
+  symbols:
+    - BTCUSDT
+  default_leverage: 3
+  max_leverage: 10
+  margin_mode: isolated
+  position_mode: one-way
+  test_mode: true
+  liquidation_buffer_pct: 5.0
+
+strategy:
+  evaluation_interval_seconds: 3600
+  cooldown_candles: 1
+  default_trading_mode: futures
+  strategies:
+    - name: mtf_template
+      config:
+        regime_threshold: 0.005
+        trend_consistency_threshold: 50.0
+        volatility_percentile_threshold: 40.0
+        entry_pullback_pct: 0.01
+        rsi_oversold: 40.0
+        rsi_overbought: 60.0
+        confidence_boost: 1.2
+  global_trend_filter_enabled: true
+  aggregator:
+    min_agreement: 1
+    buy_threshold: 0.7
+    buy_threshold_uptrend: 0.7
+    sell_threshold: -0.6
+    btc_regime_filter_enabled: false
+    btc_reference_symbol: BTCUSDT
+    btc_dump_threshold_pct: -1.0
+    btc_dump_require_below_ema200: true
+  per_symbol_aggregator_config: {}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -132,6 +132,29 @@ services:
       start_period: 60s
     restart: unless-stopped
 
+  agent_btc_mtf:
+    build: .
+    depends_on:
+      timescaledb:
+        condition: service_healthy
+      prometheus:
+        condition: service_healthy
+    env_file:
+      - .env
+    environment:
+      - AGENT_ID=btc-1h-mtf
+      - SETTINGS_PATH=config/settings.btc_1h_mtf.yaml
+    volumes:
+      - ./:/app
+    command: ["python", "-m", "src.main"]
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 60s
+    restart: unless-stopped
+
   agent_sol_sparse:
     build: .
     depends_on:

--- a/tests/test_prometheus_config.py
+++ b/tests/test_prometheus_config.py
@@ -38,17 +38,20 @@ def test_file_sd_targets_cover_all_current_agent_services() -> None:
         "agent",
         "agent_2",
         "agent_btc",
+        "agent_btc_mtf",
         "agent_sol_sparse",
         "agent_sentiment_macro",
     }
     assert targets_by_service["agent"] == ["agent:8000"]
     assert targets_by_service["agent_2"] == ["agent_2:8000"]
     assert targets_by_service["agent_btc"] == ["agent_btc:8000"]
+    assert targets_by_service["agent_btc_mtf"] == ["agent_btc_mtf:8000"]
     assert targets_by_service["agent_sol_sparse"] == ["agent_sol_sparse:8000"]
     assert targets_by_service["agent_sentiment_macro"] == ["agent_sentiment_macro:8000"]
     assert labels_by_service["agent"]["agent_id"] == "default"
     assert labels_by_service["agent_2"]["agent_id"] == "agent2"
     assert labels_by_service["agent_btc"]["agent_id"] == "btc-4h"
+    assert labels_by_service["agent_btc_mtf"]["agent_id"] == "btc-1h-mtf"
     assert labels_by_service["agent_sol_sparse"]["agent_id"] == "sol-trend-pullback-sparse"
     assert labels_by_service["agent_sentiment_macro"]["agent_id"] == "sentiment-macro-bot"
 

--- a/tests/test_settings_integration.py
+++ b/tests/test_settings_integration.py
@@ -27,6 +27,7 @@ from src.strategy import (
     TrendPullbackStrategy,
     VWAPReversionStrategy,
 )
+from src.strategy.mtf_template import MTFStrategyTemplate
 
 
 def test_settings_default_safe():
@@ -149,6 +150,22 @@ def test_sentiment_macro_config_resolves_sentiment_strategy_only():
     assert settings.telegram.enabled is False
     assert settings.ai.enabled is True
     assert aggregator_config["buy_threshold"] == 0.6
+
+
+def test_btc_mtf_paper_config_resolves_mtf_template():
+    settings = load_settings(Path("config/settings.btc_1h_mtf.yaml"))
+    strategy_classes, strategy_configs, aggregator_config, _per_symbol = _resolve_strategy_config(
+        settings.strategy
+    )
+
+    assert settings.agent_id == "btc-1h-mtf"
+    assert settings.trading_pairs == ["BTCUSDT"]
+    assert settings.timeframe == "1h"
+    assert settings.ai.enabled is False
+    assert settings.trading_execution.enabled is True
+    assert strategy_classes == [MTFStrategyTemplate]
+    assert len(strategy_configs) == 1
+    assert aggregator_config["buy_threshold"] == 0.7
 
 
 def test_optional_strategy_registry_skips_missing_modules(monkeypatch):


### PR DESCRIPTION
## Summary
- add a dedicated BTC 1h entry / 4h regime paper config for runtime MTF validation
- wire a new isolated agent_btc_mtf Compose service without changing agent_btc
- expose the new service through Prometheus file_sd coverage and config regression tests

## Testing
- .venv/bin/pytest tests/test_settings_integration.py tests/test_prometheus_config.py tests/test_strategy_integration.py tests/test_mtf_integration.py
- docker compose config --services
- .venv/bin/python -m black --check --diff tests/test_settings_integration.py tests/test_prometheus_config.py
- .venv/bin/python -m ruff check tests/test_settings_integration.py tests/test_prometheus_config.py

Task: T021