### PR TITLE
fix(features): repair indicator insert SQL

### DIFF
--- a/src/features/writer.py
+++ b/src/features/writer.py
@@ -181,11 +181,9 @@ class IndicatorWriter:
                     volume_regime, price_vs_weekly, price_vs_monthly,
                     rsi_slope, trend_consistency
                 ) VALUES (
-                ) VALUES (
                     $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13,
-                    $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25,
-                    $26, $27, $28, $29, $30, $31, $32
-                    $14, $15, $16, $17, $18, $19, $20, $21, $22, $23
+                    $14, $15, $16, $17, $18, $19, $20, $21, $22, $23,
+                    $24, $25, $26, $27, $28, $29, $30, $31
                 )
                 ON CONFLICT (time, symbol, timeframe) DO UPDATE SET
                     rsi_14 = EXCLUDED.rsi_14,

--- a/tests/test_indicator_writer.py
+++ b/tests/test_indicator_writer.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.features.writer import IndicatorWriter, StoredIndicator
+
+
+@pytest.mark.asyncio
+async def test_insert_row_uses_single_values_block_with_expected_placeholders(monkeypatch):
+    writer = IndicatorWriter({})
+    connection = AsyncMock()
+
+    class FakeAcquire:
+        async def __aenter__(self):
+            return connection
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    pool = MagicMock()
+    pool.acquire.return_value = FakeAcquire()
+    monkeypatch.setattr("src.features.writer.get_pool", lambda: pool)
+
+    indicator = StoredIndicator(
+        time=datetime(2026, 3, 18, 0, 0, tzinfo=UTC),
+        symbol="BTCUSDT",
+        timeframe="1h",
+        rsi_14=50.0,
+        rsi_7=48.0,
+        macd=0.1,
+        macd_signal=0.05,
+        macd_hist=0.05,
+        bb_upper_dist=0.02,
+        bb_lower_dist=0.01,
+        atr_14=100.0,
+        atr_pct=0.01,
+        ema_12=1000.0,
+        ema_26=999.0,
+        ema_50=995.0,
+        ema_200=900.0,
+        sma_20=998.0,
+        sma_50=990.0,
+        sma_200=880.0,
+        vwap=997.0,
+        stoch_k=60.0,
+        stoch_d=58.0,
+        cci=120.0,
+        ema_slope_50=0.006,
+        volatility_percentile=65.0,
+        atr_percentile=55.0,
+        volume_regime=10.0,
+        price_vs_weekly=0.02,
+        price_vs_monthly=0.03,
+        rsi_slope=5.0,
+        trend_consistency=70.0,
+    )
+
+    await writer._insert_row(indicator)
+
+    query = connection.execute.await_args.args[0]
+    values = connection.execute.await_args.args[1:]
+
+    assert query.count(") VALUES (") == 1
+    assert "$31" in query
+    assert "$32" not in query
+    assert len(values) == 31


### PR DESCRIPTION
## Summary
- remove the duplicated VALUES block and placeholder tail from the indicator insert query
- add a regression test that locks the insert statement shape and value count
- fix the runtime indicator-computation failure seen after deploying agent_btc_mtf

## Testing
- .venv/bin/pytest tests/test_indicator_writer.py tests/test_mtf_integration.py tests/test_strategy_integration.py
- .venv/bin/python -m black --check --diff src/features/writer.py tests/test_indicator_writer.py
- .venv/bin/python -m ruff check src/features/writer.py tests/test_indicator_writer.py

Task: T022