### PR TITLE
Register paper lifecycle states

### DIFF
--- a/scripts/register_paper_strategies.py
+++ b/scripts/register_paper_strategies.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Register paper-only strategy versions in lifecycle metadata."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+
+sys.path.append(os.getcwd())
+
+from src.strategy.lifecycle import LifecycleManager
+
+
+async def main() -> None:
+    db_config = {
+        "host": os.getenv("DB_HOST", "timescaledb"),
+        "port": int(os.getenv("DB_PORT", "5432")),
+        "database": os.getenv("DB_NAME", "marketdata"),
+        "user": os.getenv("DB_USER", "trading"),
+        "password": os.getenv("DB_PASSWORD", ""),
+    }
+
+    strategies = [
+        {
+            "name": "SentimentMeanReversionStrategy",
+            "version": "1.0",
+            "metrics": {
+                "notes": "Paper-only validation strategy wired through settings.sentiment_macro.yaml",
+            },
+        },
+        {
+            "name": "MTFStrategyTemplate",
+            "version": "1.0",
+            "metrics": {
+                "notes": "Paper-only validation strategy wired through settings.btc_1h_mtf.yaml",
+            },
+        },
+    ]
+
+    async with LifecycleManager(db_config) as lifecycle:
+        for strategy in strategies:
+            await lifecycle.register_paper_strategy(
+                strategy["name"],
+                strategy["version"],
+                strategy["metrics"],
+            )
+
+    print("Paper strategies registered")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/src/strategy/lifecycle.py
+++ b/src/strategy/lifecycle.py
@@ -72,18 +72,58 @@ class LifecycleManager:
             unknown_message="Strategy %s has no lifecycle row yet (allowed in paper mode)",
         )
 
-    async def promote_strategy(self, name: str, version: str, metrics: dict):
-        """Promote strategy to next state."""
+    async def set_strategy_status(
+        self,
+        name: str,
+        version: str,
+        status: str,
+        metrics: dict | None = None,
+    ) -> None:
+        """Insert or update a strategy lifecycle row."""
+        metrics = metrics or {}
         await self.conn.execute(
             """
-            INSERT INTO strategy_versions (name, version, status, config, backtest_sharpe, backtest_win_rate)
-            VALUES ($1, $2, 'validated', $3, $4, $5)
-            ON CONFLICT (name, version) DO NOTHING
+            INSERT INTO strategy_versions (
+                name,
+                version,
+                status,
+                promoted_at,
+                config,
+                backtest_sharpe,
+                backtest_win_rate,
+                backtest_max_drawdown,
+                backtest_total_trades,
+                notes
+            )
+            VALUES ($1, $2, $3, NOW(), $4, $5, $6, $7, $8, $9)
+            ON CONFLICT (name, version) DO UPDATE SET
+                status = EXCLUDED.status,
+                promoted_at = NOW(),
+                config = EXCLUDED.config,
+                backtest_sharpe = EXCLUDED.backtest_sharpe,
+                backtest_win_rate = EXCLUDED.backtest_win_rate,
+                backtest_max_drawdown = EXCLUDED.backtest_max_drawdown,
+                backtest_total_trades = EXCLUDED.backtest_total_trades,
+                notes = EXCLUDED.notes
             """,
             name,
             version,
+            status,
             metrics.get("config", "{}"),
             metrics.get("sharpe"),
             metrics.get("win_rate"),
+            metrics.get("max_drawdown"),
+            metrics.get("total_trades"),
+            metrics.get("notes"),
         )
-        logger.info(f"Promoted {name}:{version} with Sharpe {metrics.get('sharpe')}")
+        logger.info("Set %s:%s to %s", name, version, status)
+
+    async def promote_strategy(self, name: str, version: str, metrics: dict):
+        """Promote strategy to next state."""
+        await self.set_strategy_status(name, version, "validated", metrics)
+
+    async def register_paper_strategy(
+        self, name: str, version: str, metrics: dict | None = None
+    ) -> None:
+        """Mark a strategy version as approved for paper validation."""
+        await self.set_strategy_status(name, version, "paper", metrics)

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -57,3 +57,44 @@ async def test_is_paper_ready_still_blocks_rejected_status(caplog) -> None:
 
     assert allowed is False
     assert "status: archived (blocked)" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_set_strategy_status_upserts_requested_status() -> None:
+    lifecycle = LifecycleManager({})
+    lifecycle.conn = AsyncMock()
+
+    await lifecycle.set_strategy_status(
+        "SentimentMeanReversionStrategy",
+        "1.0",
+        "paper",
+        {
+            "sharpe": 0.42,
+            "win_rate": 0.55,
+            "max_drawdown": 8.5,
+            "total_trades": 12,
+            "notes": "paper validation",
+        },
+    )
+
+    execute_args = lifecycle.conn.execute.await_args.args
+    assert execute_args[1] == "SentimentMeanReversionStrategy"
+    assert execute_args[2] == "1.0"
+    assert execute_args[3] == "paper"
+    assert execute_args[5] == 0.42
+    assert execute_args[6] == 0.55
+    assert execute_args[7] == 8.5
+    assert execute_args[8] == 12
+
+
+@pytest.mark.asyncio
+async def test_register_paper_strategy_delegates_to_paper_status() -> None:
+    lifecycle = LifecycleManager({})
+    lifecycle.conn = AsyncMock()
+
+    await lifecycle.register_paper_strategy("MTFStrategyTemplate", "1.0")
+
+    execute_args = lifecycle.conn.execute.await_args.args
+    assert execute_args[1] == "MTFStrategyTemplate"
+    assert execute_args[2] == "1.0"
+    assert execute_args[3] == "paper"


### PR DESCRIPTION
## Summary
- add explicit lifecycle upsert helpers for paper strategy registration
- add a server-safe script to register current paper validation strategies as paper
- add lifecycle regression tests for paper registration

## Testing
- .venv/bin/pytest
- .venv/bin/python -m ruff check src/strategy/lifecycle.py scripts/register_paper_strategies.py tests/test_lifecycle.py
- .venv/bin/python -m black --check --diff src/strategy/lifecycle.py scripts/register_paper_strategies.py tests/test_lifecycle.py