### PR TITLE
fix(config): clean paper AI ops warnings

### DIFF
--- a/scripts/register_paper_strategies.py
+++ b/scripts/register_paper_strategies.py
@@ -11,6 +11,30 @@ sys.path.append(os.getcwd())
 
 from src.strategy.lifecycle import LifecycleManager
 
+PAPER_STRATEGIES = [
+    {
+        "name": "SentimentMeanReversionStrategy",
+        "version": "1.0",
+        "metrics": {
+            "notes": "Paper-only validation strategy wired through settings.sentiment_macro.yaml",
+        },
+    },
+    {
+        "name": "MTFStrategyTemplate",
+        "version": "1.0",
+        "metrics": {
+            "notes": "Paper-only validation strategy wired through settings.btc_1h_mtf.yaml",
+        },
+    },
+    {
+        "name": "SimpleMACrossoverStrategy",
+        "version": "1.0",
+        "metrics": {
+            "notes": "Paper-only validation strategy wired through settings.avax_4h_ma.yaml",
+        },
+    },
+]
+
 
 async def main() -> None:
     db_config = {
@@ -21,25 +45,8 @@ async def main() -> None:
         "password": os.getenv("DB_PASSWORD", ""),
     }
 
-    strategies = [
-        {
-            "name": "SentimentMeanReversionStrategy",
-            "version": "1.0",
-            "metrics": {
-                "notes": "Paper-only validation strategy wired through settings.sentiment_macro.yaml",
-            },
-        },
-        {
-            "name": "MTFStrategyTemplate",
-            "version": "1.0",
-            "metrics": {
-                "notes": "Paper-only validation strategy wired through settings.btc_1h_mtf.yaml",
-            },
-        },
-    ]
-
     async with LifecycleManager(db_config) as lifecycle:
-        for strategy in strategies:
+        for strategy in PAPER_STRATEGIES:
             await lifecycle.register_paper_strategy(
                 strategy["name"],
                 strategy["version"],

--- a/src/main.py
+++ b/src/main.py
@@ -101,6 +101,26 @@ def _resolve_signal_routing(
     return signal, True
 
 
+def _resolve_overseer_launch(
+    settings: Settings,
+) -> tuple[bool, str | None]:
+    """Decide whether the chat overseer should start.
+
+    Strategy-side AI usage via xAI is allowed without Telegram. Only the chat
+    overseer requires Telegram to be enabled and configured.
+    """
+    if not settings.ai.enabled:
+        return False, None
+
+    if not settings.telegram.enabled:
+        return False, None
+
+    if not settings.telegram.bot_token:
+        return False, "AI overseer enabled but TELEGRAM_BOT_TOKEN missing; overseer disabled"
+
+    return True, None
+
+
 @dataclass(frozen=True)
 class StrategySettings:
     evaluation_interval_seconds: int
@@ -796,11 +816,11 @@ async def run() -> None:
                 "AI features enabled without XAI_API_KEY; sentiment falls back to neutral"
             )
 
-        if not settings.telegram.enabled:
-            logger.warning("AI overseer enabled but telegram.enabled=false; overseer disabled")
-        elif not settings.telegram.bot_token:
-            logger.warning("AI overseer enabled but TELEGRAM_BOT_TOKEN missing; overseer disabled")
-        else:
+        start_overseer, overseer_warning = _resolve_overseer_launch(settings)
+        if overseer_warning:
+            logger.warning(overseer_warning)
+
+        if start_overseer:
             overseer_agent = OverseerAgent(
                 mode=settings.mode,
                 poll_interval_seconds=settings.ai.polling_interval,

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
+from scripts.register_paper_strategies import PAPER_STRATEGIES
 from src.strategy.lifecycle import LifecycleManager
 
 
@@ -98,3 +99,11 @@ async def test_register_paper_strategy_delegates_to_paper_status() -> None:
     assert execute_args[1] == "MTFStrategyTemplate"
     assert execute_args[2] == "1.0"
     assert execute_args[3] == "paper"
+
+
+def test_register_paper_strategies_includes_simple_ma_candidate() -> None:
+    strategy_names = {strategy["name"] for strategy in PAPER_STRATEGIES}
+
+    assert "SentimentMeanReversionStrategy" in strategy_names
+    assert "MTFStrategyTemplate" in strategy_names
+    assert "SimpleMACrossoverStrategy" in strategy_names

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -2,7 +2,16 @@ import asyncio
 
 import pytest
 
-from src.main import _cancel_background_tasks, _resolve_signal_routing
+from src.execution import TradingConfig
+from src.main import (
+    AISettings,
+    Settings,
+    StrategySettings,
+    _cancel_background_tasks,
+    _resolve_overseer_launch,
+    _resolve_signal_routing,
+)
+from src.notifications.telegram import TelegramConfig
 from src.strategy.signals import Signal, SignalType
 
 
@@ -71,3 +80,79 @@ def test_resolve_signal_routing_preserves_explicit_futures_signal() -> None:
 
     assert should_mirror is False
     assert routed is signal
+
+
+def _make_settings(
+    *, ai_enabled: bool = True, telegram_enabled: bool = False, bot_token: str = ""
+) -> Settings:
+    return Settings(
+        agent_id="test-agent",
+        mode="paper",
+        log_level="INFO",
+        trading_pairs=["BTCUSDT"],
+        timeframe="1h",
+        database={"host": "timescaledb", "port": 5432, "name": "marketdata", "user": "trading"},
+        prometheus_port=8000,
+        trading_execution=TradingConfig(
+            api_key="",
+            api_secret="",
+            test_mode=True,
+            enabled=True,
+            symbols=["BTCUSDT"],
+            order_size_usdt=100.0,
+            stop_loss_pct=0.02,
+            take_profit_pct=0.05,
+            sl_atr_multiplier=2.0,
+            tp_atr_multiplier=4.5,
+            trailing_activate_atr=1.5,
+            trailing_offset_atr=1.0,
+            use_atr_sizing=False,
+            atr_multiplier=1.0,
+            risk_per_trade_pct=0.02,
+        ),
+        strategy=StrategySettings(evaluation_interval_seconds=60),
+        telegram=TelegramConfig(
+            bot_token=bot_token,
+            chat_id="",
+            enabled=telegram_enabled,
+            rate_limit_seconds=5,
+            allowed_updates=("message",),
+        ),
+        ai=AISettings(
+            enabled=ai_enabled,
+            provider="xai",
+            model="grok-4-1-fast-reasoning",
+            polling_interval=60.0,
+            max_history=10,
+            allowed_chat_ids=[],
+            api_key="test-key",
+        ),
+        use_websocket=True,
+    )
+
+
+def test_resolve_overseer_launch_skips_overseer_when_telegram_disabled() -> None:
+    settings = _make_settings(telegram_enabled=False)
+
+    enabled, warning = _resolve_overseer_launch(settings)
+
+    assert enabled is False
+    assert warning is None
+
+
+def test_resolve_overseer_launch_warns_when_telegram_enabled_but_missing_token() -> None:
+    settings = _make_settings(telegram_enabled=True, bot_token="")
+
+    enabled, warning = _resolve_overseer_launch(settings)
+
+    assert enabled is False
+    assert warning == "AI overseer enabled but TELEGRAM_BOT_TOKEN missing; overseer disabled"
+
+
+def test_resolve_overseer_launch_enables_with_telegram_and_token() -> None:
+    settings = _make_settings(telegram_enabled=True, bot_token="token")
+
+    enabled, warning = _resolve_overseer_launch(settings)
+
+    assert enabled is True
+    assert warning is None


### PR DESCRIPTION
## Summary
- stop warning when strategy-side xAI is enabled without Telegram chat overseer
- add SimpleMACrossoverStrategy to paper strategy registration for the AVAX sidecar
- add regression coverage for overseer launch decisions and paper registration

## Validation
- .venv/bin/pytest
- .venv/bin/python -m ruff check src/main.py scripts/register_paper_strategies.py tests/test_main.py tests/test_lifecycle.py
- .venv/bin/python -m black --check --diff src/main.py scripts/register_paper_strategies.py tests/test_main.py tests/test_lifecycle.py

Task: T025