### PR TITLE
feat(config): add daily paper validation report

### DIFF
--- a/scripts/paper_validation_report.py
+++ b/scripts/paper_validation_report.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Generate a daily validation report for paper trading agents."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+from datetime import UTC, date, datetime
+from pathlib import Path
+
+from src.utils.paper_validation_report import (
+    collect_report,
+    render_markdown,
+    report_to_json,
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Daily paper validation report")
+    parser.add_argument(
+        "--day",
+        help="UTC day in YYYY-MM-DD format (default: today UTC)",
+    )
+    parser.add_argument(
+        "--output-prefix",
+        default="docs/reports/paper-validation-report",
+        help="Output path prefix for markdown/json artifacts",
+    )
+    return parser.parse_args()
+
+
+def _parse_day(raw: str | None) -> date:
+    if not raw:
+        return datetime.now(UTC).date()
+    return date.fromisoformat(raw)
+
+
+def _db_config() -> dict[str, object]:
+    from os import getenv
+
+    return {
+        "host": getenv("POSTGRES_HOST", "timescaledb"),
+        "port": int(getenv("POSTGRES_PORT", "5432")),
+        "name": getenv("POSTGRES_DB", "marketdata"),
+        "user": getenv("POSTGRES_USER", "trading"),
+        "password": getenv("POSTGRES_PASSWORD", ""),
+    }
+
+
+async def main() -> int:
+    args = parse_args()
+    day = _parse_day(args.day)
+    report = await collect_report(db_config=_db_config(), day=day)
+
+    output_prefix = Path(args.output_prefix)
+    output_prefix.parent.mkdir(parents=True, exist_ok=True)
+    markdown_path = output_prefix.with_suffix(".md")
+    json_path = output_prefix.with_suffix(".json")
+
+    markdown_path.write_text(render_markdown(report), encoding="utf-8")
+    json_path.write_text(report_to_json(report), encoding="utf-8")
+
+    print(f"Markdown: {markdown_path}")
+    print(f"JSON: {json_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/src/utils/paper_validation_report.py
+++ b/src/utils/paper_validation_report.py
@@ -1,0 +1,314 @@
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass, field
+from datetime import UTC, date, datetime, time, timedelta
+from pathlib import Path
+
+from src.db import close_pool, init_pool
+from src.portfolio.manager import PortfolioManager
+from src.portfolio.models import PortfolioSummary
+
+
+@dataclass(frozen=True)
+class PaperAgentSpec:
+    agent_id: str
+    service: str
+    config_path: str
+    symbols: tuple[str, ...]
+    timeframe: str
+
+
+@dataclass(frozen=True)
+class EventSummary:
+    signal_count: int
+    order_filled_count: int
+    risk_check_failed_count: int
+    last_signal_at: str | None
+    last_order_at: str | None
+    signals_by_symbol: dict[str, int] = field(default_factory=dict)
+    orders_by_symbol: dict[str, int] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class RiskStateSummary:
+    kill_switch_triggered: bool
+    daily_pnl: float
+    peak_balance: float
+    open_position_keys: int
+    active_breakers: list[str]
+    updated_at: str | None
+
+
+@dataclass(frozen=True)
+class PaperAgentReport:
+    agent: PaperAgentSpec
+    day: str
+    events: EventSummary
+    risk: RiskStateSummary
+    daily_realized_pnl: float
+    daily_closed_trades: int
+    daily_win_rate: float
+    portfolio: PortfolioSummary
+
+
+@dataclass(frozen=True)
+class PaperValidationReport:
+    generated_at: str
+    day: str
+    agents: list[PaperAgentReport]
+
+
+DEFAULT_PAPER_AGENTS: tuple[PaperAgentSpec, ...] = (
+    PaperAgentSpec(
+        agent_id="sol-trend-pullback-sparse",
+        service="agent_sol_sparse",
+        config_path="config/settings.sol_trend_pullback_sparse.yaml",
+        symbols=("SOLUSDT",),
+        timeframe="4h",
+    ),
+    PaperAgentSpec(
+        agent_id="sentiment-macro-bot",
+        service="agent_sentiment_macro",
+        config_path="config/settings.sentiment_macro.yaml",
+        symbols=("BTCUSDT", "ETHUSDT", "SOLUSDT"),
+        timeframe="1h",
+    ),
+    PaperAgentSpec(
+        agent_id="avax-4h-ma",
+        service="agent_avax",
+        config_path="config/settings.avax_4h_ma.yaml",
+        symbols=("AVAXUSDT",),
+        timeframe="4h",
+    ),
+)
+
+
+def default_risk_state_path(agent_id: str, data_dir: Path = Path("data")) -> Path:
+    if agent_id == "default":
+        return data_dir / "risk_state.json"
+    return data_dir / f"risk_state_{agent_id}.json"
+
+
+def default_event_log_path(agent_id: str, data_dir: Path = Path("data")) -> Path:
+    return data_dir / f"event_log_{agent_id}.jsonl"
+
+
+def parse_iso_timestamp(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    normalized = value.strip()
+    if normalized.endswith("Z"):
+        normalized = normalized[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)
+
+
+def _day_start(day: date) -> datetime:
+    return datetime.combine(day, time.min, tzinfo=UTC)
+
+
+def summarize_event_log(path: Path, day: date) -> EventSummary:
+    signal_count = 0
+    order_filled_count = 0
+    risk_check_failed_count = 0
+    last_signal_at: str | None = None
+    last_order_at: str | None = None
+    signals_by_symbol: dict[str, int] = {}
+    orders_by_symbol: dict[str, int] = {}
+    start = _day_start(day)
+    end = _day_start(day) + timedelta(days=1)
+
+    if not path.exists():
+        return EventSummary(
+            signal_count=0,
+            order_filled_count=0,
+            risk_check_failed_count=0,
+            last_signal_at=None,
+            last_order_at=None,
+        )
+
+    with path.open(encoding="utf-8") as handle:
+        for raw_line in handle:
+            line = raw_line.strip()
+            if not line:
+                continue
+            try:
+                payload = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+
+            event_ts = parse_iso_timestamp(payload.get("ts"))
+            if event_ts is None or event_ts < start or event_ts >= end:
+                continue
+
+            event_type = payload.get("type")
+            event_payload = payload.get("payload") or {}
+            symbol = str(event_payload.get("symbol", "unknown"))
+
+            if event_type == "signal_received":
+                signal_count += 1
+                last_signal_at = event_ts.isoformat()
+                signals_by_symbol[symbol] = signals_by_symbol.get(symbol, 0) + 1
+            elif event_type == "order_filled":
+                order_filled_count += 1
+                last_order_at = event_ts.isoformat()
+                orders_by_symbol[symbol] = orders_by_symbol.get(symbol, 0) + 1
+            elif event_type == "risk_check_failed":
+                risk_check_failed_count += 1
+
+    return EventSummary(
+        signal_count=signal_count,
+        order_filled_count=order_filled_count,
+        risk_check_failed_count=risk_check_failed_count,
+        last_signal_at=last_signal_at,
+        last_order_at=last_order_at,
+        signals_by_symbol=signals_by_symbol,
+        orders_by_symbol=orders_by_symbol,
+    )
+
+
+def load_risk_state(path: Path) -> RiskStateSummary:
+    if not path.exists():
+        return RiskStateSummary(
+            kill_switch_triggered=False,
+            daily_pnl=0.0,
+            peak_balance=0.0,
+            open_position_keys=0,
+            active_breakers=[],
+            updated_at=None,
+        )
+
+    with path.open(encoding="utf-8") as handle:
+        payload = json.load(handle)
+
+    breakers = payload.get("circuit_breakers") or {}
+    active_breakers = sorted(name for name, active in breakers.items() if active)
+
+    return RiskStateSummary(
+        kill_switch_triggered=bool(payload.get("kill_switch_triggered", False)),
+        daily_pnl=float(payload.get("daily_pnl", 0.0) or 0.0),
+        peak_balance=float(payload.get("peak_balance", 0.0) or 0.0),
+        open_position_keys=len(payload.get("positions") or {}),
+        active_breakers=active_breakers,
+        updated_at=payload.get("updated_at"),
+    )
+
+
+async def collect_agent_report(
+    spec: PaperAgentSpec,
+    day: date,
+    *,
+    db_config: dict[str, object],
+    data_dir: Path = Path("data"),
+) -> PaperAgentReport:
+    events = summarize_event_log(default_event_log_path(spec.agent_id, data_dir), day)
+    risk = load_risk_state(default_risk_state_path(spec.agent_id, data_dir))
+
+    await init_pool(db_config)
+    manager = PortfolioManager(db_config, agent_id=spec.agent_id)
+    async with manager:
+        daily_realized_pnl, daily_closed_trades, daily_win_rate = await manager.get_daily_stats(day)
+        portfolio = await manager.get_portfolio_summary()
+
+    return PaperAgentReport(
+        agent=spec,
+        day=day.isoformat(),
+        events=events,
+        risk=risk,
+        daily_realized_pnl=daily_realized_pnl,
+        daily_closed_trades=daily_closed_trades,
+        daily_win_rate=daily_win_rate,
+        portfolio=portfolio,
+    )
+
+
+async def collect_report(
+    *,
+    db_config: dict[str, object],
+    day: date,
+    agents: tuple[PaperAgentSpec, ...] = DEFAULT_PAPER_AGENTS,
+    data_dir: Path = Path("data"),
+) -> PaperValidationReport:
+    try:
+        reports: list[PaperAgentReport] = []
+        for spec in agents:
+            reports.append(
+                await collect_agent_report(
+                    spec,
+                    day,
+                    db_config=db_config,
+                    data_dir=data_dir,
+                )
+            )
+        return PaperValidationReport(
+            generated_at=datetime.now(UTC).isoformat(),
+            day=day.isoformat(),
+            agents=reports,
+        )
+    finally:
+        await close_pool()
+
+
+def report_to_json(report: PaperValidationReport) -> str:
+    return json.dumps(asdict(report), indent=2)
+
+
+def render_markdown(report: PaperValidationReport) -> str:
+    lines: list[str] = []
+    lines.append("# Daily Paper Validation Report")
+    lines.append("")
+    lines.append(f"- Generated: {report.generated_at}")
+    lines.append(f"- Day: `{report.day}`")
+    lines.append("")
+
+    total_daily_pnl = sum(agent.daily_realized_pnl for agent in report.agents)
+    total_daily_trades = sum(agent.daily_closed_trades for agent in report.agents)
+    total_signals = sum(agent.events.signal_count for agent in report.agents)
+    total_orders = sum(agent.events.order_filled_count for agent in report.agents)
+    lines.append("## Totals")
+    lines.append("")
+    lines.append(f"- Daily realized PnL: `{total_daily_pnl:.2f} USDT`")
+    lines.append(f"- Daily closed trades: `{total_daily_trades}`")
+    lines.append(f"- Daily signals: `{total_signals}`")
+    lines.append(f"- Daily order fills: `{total_orders}`")
+    lines.append("")
+
+    for agent in report.agents:
+        lines.append(f"## {agent.agent.service}")
+        lines.append("")
+        lines.append(f"- Agent ID: `{agent.agent.agent_id}`")
+        lines.append(f"- Config: `{agent.agent.config_path}`")
+        lines.append(
+            f"- Symbols/Timeframe: `{', '.join(agent.agent.symbols)}` / `{agent.agent.timeframe}`"
+        )
+        lines.append(f"- Daily realized PnL: `{agent.daily_realized_pnl:.2f} USDT`")
+        lines.append(f"- Daily closed trades: `{agent.daily_closed_trades}`")
+        lines.append(f"- Daily win rate: `{agent.daily_win_rate:.2f}%`")
+        lines.append(f"- Daily signals: `{agent.events.signal_count}`")
+        lines.append(f"- Daily order fills: `{agent.events.order_filled_count}`")
+        lines.append(f"- Daily risk check failures: `{agent.events.risk_check_failed_count}`")
+        lines.append(f"- Last signal: `{agent.events.last_signal_at or 'none'}`")
+        lines.append(f"- Last order fill: `{agent.events.last_order_at or 'none'}`")
+        lines.append(f"- Open positions: `{agent.portfolio.open_positions}`")
+        lines.append(f"- Total realized PnL: `{agent.portfolio.total_realized_pnl:.2f} USDT`")
+        lines.append(f"- Total win rate: `{agent.portfolio.win_rate:.2f}%`")
+        lines.append(f"- Kill switch: `{agent.risk.kill_switch_triggered}`")
+        lines.append(
+            f"- Active breakers: `{', '.join(agent.risk.active_breakers) if agent.risk.active_breakers else 'none'}`"
+        )
+        lines.append(f"- Risk-state daily PnL: `{agent.risk.daily_pnl:.2f} USDT`")
+        lines.append(f"- Peak balance anchor: `{agent.risk.peak_balance:.2f} USDT`")
+        lines.append(f"- Risk-state updated: `{agent.risk.updated_at or 'none'}`")
+        if agent.events.signals_by_symbol:
+            lines.append(f"- Signals by symbol: `{agent.events.signals_by_symbol}`")
+        if agent.events.orders_by_symbol:
+            lines.append(f"- Orders by symbol: `{agent.events.orders_by_symbol}`")
+        lines.append("")
+
+    return "\n".join(lines)

--- a/tests/test_paper_validation_report.py
+++ b/tests/test_paper_validation_report.py
@@ -1,0 +1,251 @@
+from __future__ import annotations
+
+import json
+from datetime import date
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from src.portfolio.models import PortfolioSummary
+from src.utils.paper_validation_report import (
+    DEFAULT_PAPER_AGENTS,
+    EventSummary,
+    PaperAgentReport,
+    PaperValidationReport,
+    RiskStateSummary,
+    collect_agent_report,
+    default_event_log_path,
+    default_risk_state_path,
+    load_risk_state,
+    parse_iso_timestamp,
+    render_markdown,
+    summarize_event_log,
+)
+
+
+def test_default_paths_handle_default_and_named_agents() -> None:
+    assert default_risk_state_path("default") == Path("data/risk_state.json")
+    assert default_risk_state_path("agent-x") == Path("data/risk_state_agent-x.json")
+    assert default_event_log_path("agent-x") == Path("data/event_log_agent-x.jsonl")
+
+
+def test_parse_iso_timestamp_handles_z_suffix() -> None:
+    parsed = parse_iso_timestamp("2026-03-19T21:00:00Z")
+
+    assert parsed is not None
+    assert parsed.isoformat() == "2026-03-19T21:00:00+00:00"
+
+
+def test_summarize_event_log_counts_only_requested_day(tmp_path: Path) -> None:
+    path = tmp_path / "event_log_agent.jsonl"
+    path.write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "seq": 1,
+                        "ts": "2026-03-18T23:59:59+00:00",
+                        "type": "signal_received",
+                        "agent_id": "agent",
+                        "payload": {"symbol": "BTCUSDT"},
+                    }
+                ),
+                json.dumps(
+                    {
+                        "seq": 2,
+                        "ts": "2026-03-19T00:00:01+00:00",
+                        "type": "signal_received",
+                        "agent_id": "agent",
+                        "payload": {"symbol": "BTCUSDT"},
+                    }
+                ),
+                json.dumps(
+                    {
+                        "seq": 3,
+                        "ts": "2026-03-19T00:10:00+00:00",
+                        "type": "order_filled",
+                        "agent_id": "agent",
+                        "payload": {"symbol": "ETHUSDT"},
+                    }
+                ),
+                json.dumps(
+                    {
+                        "seq": 4,
+                        "ts": "2026-03-19T01:00:00+00:00",
+                        "type": "risk_check_failed",
+                        "agent_id": "agent",
+                        "payload": {"symbol": "ETHUSDT"},
+                    }
+                ),
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    summary = summarize_event_log(path, date(2026, 3, 19))
+
+    assert summary.signal_count == 1
+    assert summary.order_filled_count == 1
+    assert summary.risk_check_failed_count == 1
+    assert summary.signals_by_symbol == {"BTCUSDT": 1}
+    assert summary.orders_by_symbol == {"ETHUSDT": 1}
+
+
+def test_load_risk_state_returns_defaults_when_missing(tmp_path: Path) -> None:
+    summary = load_risk_state(tmp_path / "missing.json")
+
+    assert summary.kill_switch_triggered is False
+    assert summary.active_breakers == []
+    assert summary.updated_at is None
+
+
+def test_load_risk_state_extracts_active_breakers(tmp_path: Path) -> None:
+    state_path = tmp_path / "risk.json"
+    state_path.write_text(
+        json.dumps(
+            {
+                "positions": {"BTCUSDT:spot": {}},
+                "daily_pnl": 12.5,
+                "peak_balance": 10123.0,
+                "kill_switch_triggered": True,
+                "circuit_breakers": {
+                    "drawdown": True,
+                    "daily_loss": False,
+                    "api_errors": True,
+                },
+                "updated_at": "2026-03-19T21:00:00+00:00",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    summary = load_risk_state(state_path)
+
+    assert summary.kill_switch_triggered is True
+    assert summary.open_position_keys == 1
+    assert summary.active_breakers == ["api_errors", "drawdown"]
+
+
+@pytest.mark.asyncio
+async def test_collect_agent_report_aggregates_db_and_files(tmp_path: Path) -> None:
+    spec = DEFAULT_PAPER_AGENTS[0]
+    data_dir = tmp_path
+    default_event_log_path(spec.agent_id, data_dir).write_text(
+        json.dumps(
+            {
+                "seq": 1,
+                "ts": "2026-03-19T05:00:00+00:00",
+                "type": "signal_received",
+                "agent_id": spec.agent_id,
+                "payload": {"symbol": "SOLUSDT"},
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    default_risk_state_path(spec.agent_id, data_dir).write_text(
+        json.dumps(
+            {
+                "positions": {},
+                "daily_pnl": 7.25,
+                "peak_balance": 10050.0,
+                "kill_switch_triggered": False,
+                "circuit_breakers": {"drawdown": False},
+                "updated_at": "2026-03-19T21:00:00+00:00",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    async def _enter(self):  # type: ignore[no-untyped-def]
+        return self
+
+    async def _exit(self, exc_type, exc, tb):  # type: ignore[no-untyped-def]
+        return None
+
+    with (
+        patch("src.utils.paper_validation_report.init_pool", AsyncMock()),
+        patch("src.utils.paper_validation_report.close_pool", AsyncMock()),
+        patch("src.utils.paper_validation_report.PortfolioManager.__aenter__", _enter),
+        patch("src.utils.paper_validation_report.PortfolioManager.__aexit__", _exit),
+        patch(
+            "src.utils.paper_validation_report.PortfolioManager.get_daily_stats",
+            AsyncMock(return_value=(12.5, 3, 66.67)),
+        ),
+        patch(
+            "src.utils.paper_validation_report.PortfolioManager.get_portfolio_summary",
+            AsyncMock(
+                return_value=PortfolioSummary(
+                    total_positions=4,
+                    open_positions=1,
+                    closed_positions=3,
+                    total_trades=3,
+                    total_realized_pnl=25.0,
+                    win_count=2,
+                    loss_count=1,
+                )
+            ),
+        ),
+    ):
+        report = await collect_agent_report(
+            spec,
+            date(2026, 3, 19),
+            db_config={"host": "timescaledb"},
+            data_dir=data_dir,
+        )
+
+    assert report.agent.agent_id == spec.agent_id
+    assert report.events.signal_count == 1
+    assert report.risk.daily_pnl == 7.25
+    assert report.daily_closed_trades == 3
+    assert report.portfolio.total_realized_pnl == 25.0
+
+
+def test_render_markdown_contains_key_sections() -> None:
+    report = PaperAgentReport(
+        agent=DEFAULT_PAPER_AGENTS[2],
+        day="2026-03-19",
+        events=EventSummary(
+            signal_count=2,
+            order_filled_count=1,
+            risk_check_failed_count=0,
+            last_signal_at="2026-03-19T12:00:00+00:00",
+            last_order_at="2026-03-19T13:00:00+00:00",
+            signals_by_symbol={"AVAXUSDT": 2},
+            orders_by_symbol={"AVAXUSDT": 1},
+        ),
+        risk=RiskStateSummary(
+            kill_switch_triggered=False,
+            daily_pnl=0.0,
+            peak_balance=10000.0,
+            open_position_keys=0,
+            active_breakers=[],
+            updated_at="2026-03-19T13:05:00+00:00",
+        ),
+        daily_realized_pnl=4.5,
+        daily_closed_trades=1,
+        daily_win_rate=100.0,
+        portfolio=PortfolioSummary(
+            total_positions=1,
+            open_positions=0,
+            closed_positions=1,
+            total_trades=1,
+            total_realized_pnl=4.5,
+            win_count=1,
+            loss_count=0,
+        ),
+    )
+
+    markdown = render_markdown(
+        PaperValidationReport(
+            generated_at="2026-03-19T21:00:00+00:00",
+            day="2026-03-19",
+            agents=[report],
+        )
+    )
+
+    assert "Daily Paper Validation Report" in markdown
+    assert "agent_avax" in markdown
+    assert "AVAXUSDT" in markdown
+    assert "Daily realized PnL" in markdown


### PR DESCRIPTION
## Summary
- add a daily paper validation report utility and CLI
- summarize event-log signals and order fills for paper agents over a UTC day
- join that with portfolio trade stats and persisted risk-state snapshots

## Validation
- .venv/bin/pytest
- .venv/bin/python -m ruff check src/utils/paper_validation_report.py scripts/paper_validation_report.py tests/test_paper_validation_report.py
- .venv/bin/python -m black --check --diff src/utils/paper_validation_report.py scripts/paper_validation_report.py tests/test_paper_validation_report.py

Task: T026