### PR TITLE
Fix paper validation report runtime failures

### DIFF
--- a/scripts/paper_validation_report.py
+++ b/scripts/paper_validation_report.py
@@ -5,14 +5,13 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import sys
 from datetime import UTC, date, datetime
 from pathlib import Path
 
-from src.utils.paper_validation_report import (
-    collect_report,
-    render_markdown,
-    report_to_json,
-)
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
 
 
 def parse_args() -> argparse.Namespace:
@@ -48,6 +47,12 @@ def _db_config() -> dict[str, object]:
 
 
 async def main() -> int:
+    from src.utils.paper_validation_report import (
+        collect_report,
+        render_markdown,
+        report_to_json,
+    )
+
     args = parse_args()
     day = _parse_day(args.day)
     report = await collect_report(db_config=_db_config(), day=day)

--- a/src/utils/paper_validation_report.py
+++ b/src/utils/paper_validation_report.py
@@ -256,7 +256,15 @@ async def collect_report(
 
 
 def report_to_json(report: PaperValidationReport) -> str:
-    return json.dumps(asdict(report), indent=2)
+    return json.dumps(asdict(report), indent=2, default=_json_default)
+
+
+def _json_default(value: object) -> str:
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, date):
+        return value.isoformat()
+    raise TypeError(f"Object of type {value.__class__.__name__} is not JSON serializable")
 
 
 def render_markdown(report: PaperValidationReport) -> str:

--- a/tests/test_paper_validation_report.py
+++ b/tests/test_paper_validation_report.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
 import json
+import os
+import subprocess
+import sys
 from datetime import date
 from pathlib import Path
 from unittest.mock import AsyncMock, patch
@@ -20,6 +23,7 @@ from src.utils.paper_validation_report import (
     load_risk_state,
     parse_iso_timestamp,
     render_markdown,
+    report_to_json,
     summarize_event_log,
 )
 
@@ -249,3 +253,65 @@ def test_render_markdown_contains_key_sections() -> None:
     assert "agent_avax" in markdown
     assert "AVAXUSDT" in markdown
     assert "Daily realized PnL" in markdown
+
+
+def test_report_to_json_serializes_datetime_fields() -> None:
+    report = PaperAgentReport(
+        agent=DEFAULT_PAPER_AGENTS[0],
+        day="2026-03-19",
+        events=EventSummary(
+            signal_count=0,
+            order_filled_count=0,
+            risk_check_failed_count=0,
+            last_signal_at=None,
+            last_order_at=None,
+        ),
+        risk=RiskStateSummary(
+            kill_switch_triggered=False,
+            daily_pnl=0.0,
+            peak_balance=10000.0,
+            open_position_keys=0,
+            active_breakers=[],
+            updated_at="2026-03-19T00:00:00+00:00",
+        ),
+        daily_realized_pnl=0.0,
+        daily_closed_trades=0,
+        daily_win_rate=0.0,
+        portfolio=PortfolioSummary(
+            total_positions=1,
+            open_positions=0,
+            closed_positions=1,
+            total_trades=1,
+            last_trade_time=parse_iso_timestamp("2026-03-19T12:34:56Z"),
+            total_realized_pnl=1.25,
+            win_count=1,
+            loss_count=0,
+        ),
+    )
+
+    payload = report_to_json(
+        PaperValidationReport(
+            generated_at="2026-03-19T21:00:00+00:00",
+            day="2026-03-19",
+            agents=[report],
+        )
+    )
+
+    assert "2026-03-19T12:34:56+00:00" in payload
+
+
+def test_script_runs_directly_without_pythonpath() -> None:
+    env = os.environ.copy()
+    env.pop("PYTHONPATH", None)
+
+    result = subprocess.run(
+        [sys.executable, "scripts/paper_validation_report.py", "--help"],
+        cwd=Path(__file__).resolve().parents[1],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert "Daily paper validation report" in result.stdout


### PR DESCRIPTION
## Summary\n- allow direct container execution of the paper validation report script\n- serialize datetime fields in report JSON output\n- add regression tests for both runtime failures\n\n## Testing\n- .venv/bin/pytest\n- .venv/bin/python -m ruff check scripts/paper_validation_report.py src/utils/paper_validation_report.py tests/test_paper_validation_report.py\n- .venv/bin/python -m black --check --diff scripts/paper_validation_report.py src/utils/paper_validation_report.py tests/test_paper_validation_report.py