### PR TITLE
Automate daily paper validation reports

### DIFF
--- a/docs/PAPER_VALIDATION_REPORT.md
+++ b/docs/PAPER_VALIDATION_REPORT.md
@@ -1,0 +1,59 @@
+# Paper Validation Report
+
+`paper_validation_report` summarizes the paper trading agents for one UTC day.
+
+It combines:
+- event-log activity
+- daily closed-trade stats from the database
+- cumulative portfolio stats
+- risk-state flags
+
+Current monitored paper agents:
+- `agent_sol_sparse`
+- `agent_sentiment_macro`
+- `agent_avax`
+
+## Manual Run
+
+From the repo root:
+
+```bash
+scripts/run_paper_validation_report.sh
+```
+
+By default the wrapper reports on the previous UTC day and writes:
+
+- `data/reports/paper-validation-report-YYYY-MM-DD.md`
+- `data/reports/paper-validation-report-YYYY-MM-DD.json`
+
+Override the day:
+
+```bash
+scripts/run_paper_validation_report.sh 2026-03-19
+```
+
+## Production Timer
+
+Tracked systemd unit templates live in:
+
+- `ops/systemd/crypto-agent-paper-validation-report.service`
+- `ops/systemd/crypto-agent-paper-validation-report.timer`
+
+Install on Hetzner:
+
+```bash
+sudo install -m 0644 ops/systemd/crypto-agent-paper-validation-report.service /etc/systemd/system/
+sudo install -m 0644 ops/systemd/crypto-agent-paper-validation-report.timer /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now crypto-agent-paper-validation-report.timer
+```
+
+The timer runs daily at `00:15 UTC` and generates the report for the prior UTC day.
+
+Check status:
+
+```bash
+systemctl status crypto-agent-paper-validation-report.timer
+systemctl list-timers crypto-agent-paper-validation-report.timer
+journalctl -u crypto-agent-paper-validation-report.service --no-pager -n 100
+```

--- a/ops/systemd/crypto-agent-paper-validation-report.service
+++ b/ops/systemd/crypto-agent-paper-validation-report.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Generate daily paper validation report for crypto-agent
+After=docker.service
+Requires=docker.service
+
+[Service]
+Type=oneshot
+WorkingDirectory=/opt/crypto-agent
+ExecStart=/opt/crypto-agent/scripts/run_paper_validation_report.sh
+
+[Install]
+WantedBy=multi-user.target

--- a/ops/systemd/crypto-agent-paper-validation-report.timer
+++ b/ops/systemd/crypto-agent-paper-validation-report.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Run crypto-agent paper validation report daily
+
+[Timer]
+OnCalendar=*-*-* 00:15:00 UTC
+Persistent=true
+Unit=crypto-agent-paper-validation-report.service
+
+[Install]
+WantedBy=timers.target

--- a/scripts/run_paper_validation_report.sh
+++ b/scripts/run_paper_validation_report.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Generate the daily paper validation report from a running paper agent container.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+REPORT_OUTPUT_DIR="${REPORT_OUTPUT_DIR:-data/reports}"
+REPORT_DAY="${1:-$(date -u -d 'yesterday' +%F)}"
+REPORT_PREFIX="${REPORT_OUTPUT_DIR%/}/paper-validation-report-${REPORT_DAY}"
+
+cd "$PROJECT_DIR"
+
+if [[ -f ".env" ]]; then
+    set -a
+    # shellcheck disable=SC1091
+    source ".env"
+    set +a
+fi
+
+required_vars=(POSTGRES_DB POSTGRES_USER POSTGRES_PASSWORD)
+for name in "${required_vars[@]}"; do
+    if [[ -z "${!name:-}" ]]; then
+        echo "ERROR: required environment variable ${name} is not set" >&2
+        exit 1
+    fi
+done
+
+mkdir -p "$REPORT_OUTPUT_DIR"
+
+if ! docker compose ps --status running --services | grep -qx "agent_avax"; then
+    echo "ERROR: agent_avax service is not running" >&2
+    exit 1
+fi
+
+echo "[$(date -Iseconds)] Generating paper validation report for ${REPORT_DAY}"
+
+docker compose exec -T \
+    -e POSTGRES_HOST=timescaledb \
+    -e POSTGRES_PORT=5432 \
+    -e POSTGRES_DB="$POSTGRES_DB" \
+    -e POSTGRES_USER="$POSTGRES_USER" \
+    -e POSTGRES_PASSWORD="$POSTGRES_PASSWORD" \
+    agent_avax \
+    python scripts/paper_validation_report.py \
+    --day "$REPORT_DAY" \
+    --output-prefix "$REPORT_PREFIX"
+
+echo "[$(date -Iseconds)] Report written:"
+echo "  ${PROJECT_DIR}/${REPORT_PREFIX}.md"
+echo "  ${PROJECT_DIR}/${REPORT_PREFIX}.json"


### PR DESCRIPTION
## Summary\n- add a host wrapper to generate daily paper validation reports into ignored data/reports artifacts\n- add tracked systemd service/timer templates for Hetzner\n- document installation and operations for the new daily report timer\n\n## Testing\n- bash -n scripts/run_paper_validation_report.sh\n- .venv/bin/pytest