### PR TITLE
Clarify paper validation report risk snapshots

### DIFF
--- a/src/utils/paper_validation_report.py
+++ b/src/utils/paper_validation_report.py
@@ -33,11 +33,12 @@ class EventSummary:
 @dataclass(frozen=True)
 class RiskStateSummary:
     kill_switch_triggered: bool
-    daily_pnl: float
+    snapshot_daily_pnl: float
     peak_balance: float
     open_position_keys: int
     active_breakers: list[str]
     updated_at: str | None
+    updated_day: str | None
 
 
 @dataclass(frozen=True)
@@ -49,6 +50,7 @@ class PaperAgentReport:
     daily_realized_pnl: float
     daily_closed_trades: int
     daily_win_rate: float
+    risk_state_matches_report_day: bool
     portfolio: PortfolioSummary
 
 
@@ -177,11 +179,12 @@ def load_risk_state(path: Path) -> RiskStateSummary:
     if not path.exists():
         return RiskStateSummary(
             kill_switch_triggered=False,
-            daily_pnl=0.0,
+            snapshot_daily_pnl=0.0,
             peak_balance=0.0,
             open_position_keys=0,
             active_breakers=[],
             updated_at=None,
+            updated_day=None,
         )
 
     with path.open(encoding="utf-8") as handle:
@@ -189,14 +192,17 @@ def load_risk_state(path: Path) -> RiskStateSummary:
 
     breakers = payload.get("circuit_breakers") or {}
     active_breakers = sorted(name for name, active in breakers.items() if active)
+    updated_at = payload.get("updated_at")
+    updated_timestamp = parse_iso_timestamp(updated_at)
 
     return RiskStateSummary(
         kill_switch_triggered=bool(payload.get("kill_switch_triggered", False)),
-        daily_pnl=float(payload.get("daily_pnl", 0.0) or 0.0),
+        snapshot_daily_pnl=float(payload.get("daily_pnl", 0.0) or 0.0),
         peak_balance=float(payload.get("peak_balance", 0.0) or 0.0),
         open_position_keys=len(payload.get("positions") or {}),
         active_breakers=active_breakers,
-        updated_at=payload.get("updated_at"),
+        updated_at=updated_at,
+        updated_day=updated_timestamp.date().isoformat() if updated_timestamp else None,
     )
 
 
@@ -216,6 +222,8 @@ async def collect_agent_report(
         daily_realized_pnl, daily_closed_trades, daily_win_rate = await manager.get_daily_stats(day)
         portfolio = await manager.get_portfolio_summary()
 
+    risk_state_matches_report_day = risk.updated_day == day.isoformat()
+
     return PaperAgentReport(
         agent=spec,
         day=day.isoformat(),
@@ -224,6 +232,7 @@ async def collect_agent_report(
         daily_realized_pnl=daily_realized_pnl,
         daily_closed_trades=daily_closed_trades,
         daily_win_rate=daily_win_rate,
+        risk_state_matches_report_day=risk_state_matches_report_day,
         portfolio=portfolio,
     )
 
@@ -310,9 +319,12 @@ def render_markdown(report: PaperValidationReport) -> str:
         lines.append(
             f"- Active breakers: `{', '.join(agent.risk.active_breakers) if agent.risk.active_breakers else 'none'}`"
         )
-        lines.append(f"- Risk-state daily PnL: `{agent.risk.daily_pnl:.2f} USDT`")
+        lines.append(
+            f"- Current risk-state PnL snapshot: `{agent.risk.snapshot_daily_pnl:.2f} USDT`"
+        )
         lines.append(f"- Peak balance anchor: `{agent.risk.peak_balance:.2f} USDT`")
         lines.append(f"- Risk-state updated: `{agent.risk.updated_at or 'none'}`")
+        lines.append(f"- Risk-state matches report day: `{agent.risk_state_matches_report_day}`")
         if agent.events.signals_by_symbol:
             lines.append(f"- Signals by symbol: `{agent.events.signals_by_symbol}`")
         if agent.events.orders_by_symbol:

--- a/tests/test_paper_validation_report.py
+++ b/tests/test_paper_validation_report.py
@@ -102,6 +102,7 @@ def test_load_risk_state_returns_defaults_when_missing(tmp_path: Path) -> None:
     assert summary.kill_switch_triggered is False
     assert summary.active_breakers == []
     assert summary.updated_at is None
+    assert summary.updated_day is None
 
 
 def test_load_risk_state_extracts_active_breakers(tmp_path: Path) -> None:
@@ -129,6 +130,7 @@ def test_load_risk_state_extracts_active_breakers(tmp_path: Path) -> None:
     assert summary.kill_switch_triggered is True
     assert summary.open_position_keys == 1
     assert summary.active_breakers == ["api_errors", "drawdown"]
+    assert summary.updated_day == "2026-03-19"
 
 
 @pytest.mark.asyncio
@@ -201,9 +203,60 @@ async def test_collect_agent_report_aggregates_db_and_files(tmp_path: Path) -> N
 
     assert report.agent.agent_id == spec.agent_id
     assert report.events.signal_count == 1
-    assert report.risk.daily_pnl == 7.25
+    assert report.risk.snapshot_daily_pnl == 7.25
     assert report.daily_closed_trades == 3
+    assert report.risk_state_matches_report_day is True
     assert report.portfolio.total_realized_pnl == 25.0
+
+
+@pytest.mark.asyncio
+async def test_collect_agent_report_flags_risk_state_day_mismatch(tmp_path: Path) -> None:
+    spec = DEFAULT_PAPER_AGENTS[1]
+    data_dir = tmp_path
+    default_risk_state_path(spec.agent_id, data_dir).write_text(
+        json.dumps(
+            {
+                "positions": {},
+                "daily_pnl": 88.93,
+                "peak_balance": 10050.0,
+                "kill_switch_triggered": False,
+                "circuit_breakers": {"drawdown": False},
+                "updated_at": "2026-03-19T21:00:00+00:00",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    async def _enter(self):  # type: ignore[no-untyped-def]
+        return self
+
+    async def _exit(self, exc_type, exc, tb):  # type: ignore[no-untyped-def]
+        return None
+
+    with (
+        patch("src.utils.paper_validation_report.init_pool", AsyncMock()),
+        patch("src.utils.paper_validation_report.close_pool", AsyncMock()),
+        patch("src.utils.paper_validation_report.PortfolioManager.__aenter__", _enter),
+        patch("src.utils.paper_validation_report.PortfolioManager.__aexit__", _exit),
+        patch(
+            "src.utils.paper_validation_report.PortfolioManager.get_daily_stats",
+            AsyncMock(return_value=(0.0, 0, 0.0)),
+        ),
+        patch(
+            "src.utils.paper_validation_report.PortfolioManager.get_portfolio_summary",
+            AsyncMock(return_value=PortfolioSummary()),
+        ),
+    ):
+        report = await collect_agent_report(
+            spec,
+            date(2026, 3, 18),
+            db_config={"host": "timescaledb"},
+            data_dir=data_dir,
+        )
+
+    assert report.risk.snapshot_daily_pnl == 88.93
+    assert report.risk.updated_day == "2026-03-19"
+    assert report.risk_state_matches_report_day is False
 
 
 def test_render_markdown_contains_key_sections() -> None:
@@ -221,15 +274,17 @@ def test_render_markdown_contains_key_sections() -> None:
         ),
         risk=RiskStateSummary(
             kill_switch_triggered=False,
-            daily_pnl=0.0,
+            snapshot_daily_pnl=0.0,
             peak_balance=10000.0,
             open_position_keys=0,
             active_breakers=[],
             updated_at="2026-03-19T13:05:00+00:00",
+            updated_day="2026-03-19",
         ),
         daily_realized_pnl=4.5,
         daily_closed_trades=1,
         daily_win_rate=100.0,
+        risk_state_matches_report_day=True,
         portfolio=PortfolioSummary(
             total_positions=1,
             open_positions=0,
@@ -253,6 +308,8 @@ def test_render_markdown_contains_key_sections() -> None:
     assert "agent_avax" in markdown
     assert "AVAXUSDT" in markdown
     assert "Daily realized PnL" in markdown
+    assert "Current risk-state PnL snapshot" in markdown
+    assert "Risk-state matches report day" in markdown
 
 
 def test_report_to_json_serializes_datetime_fields() -> None:
@@ -268,15 +325,17 @@ def test_report_to_json_serializes_datetime_fields() -> None:
         ),
         risk=RiskStateSummary(
             kill_switch_triggered=False,
-            daily_pnl=0.0,
+            snapshot_daily_pnl=0.0,
             peak_balance=10000.0,
             open_position_keys=0,
             active_breakers=[],
             updated_at="2026-03-19T00:00:00+00:00",
+            updated_day="2026-03-19",
         ),
         daily_realized_pnl=0.0,
         daily_closed_trades=0,
         daily_win_rate=0.0,
+        risk_state_matches_report_day=True,
         portfolio=PortfolioSummary(
             total_positions=1,
             open_positions=0,


### PR DESCRIPTION
## Summary\n- stop presenting rolling risk-state daily PnL as if it were historical same-day report output\n- expose whether the saved risk-state snapshot actually matches the requested report day\n- add regression coverage for the day-mismatch case\n\n## Testing\n- .venv/bin/pytest\n- .venv/bin/python -m ruff check src/utils/paper_validation_report.py tests/test_paper_validation_report.py\n- .venv/bin/python -m black --check --diff src/utils/paper_validation_report.py tests/test_paper_validation_report.py