### PR TITLE
docs(research): RS probe record, Phase 0 ops, funding normalization surface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ ENV/
 .copilot/
 .cleo/
 .sisyphus/
+.grok/
 claudedocs/
 
 # OS

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,8 +38,8 @@ ssh crypto-agent "cd /opt/crypto-agent && docker compose -f docker-compose.prod.
 ssh crypto-agent "cd /opt/crypto-agent && docker compose -f docker-compose.prod.yml up -d <service>"
 
 # Active strategy services in prod right now:
-# - agent_avax
 # - agent_sol_sparse
+# - agent_sol_panic_block_paper
 # - agent_sentiment_macro
 
 # WRONG — this is the dev command, NOT production:
@@ -57,7 +57,8 @@ ssh crypto-agent "cd /opt/crypto-agent && docker compose -f docker-compose.prod.
 - Config is selected via `SETTINGS_PATH` env var (e.g., `config/settings.btc-4h.yaml`)
 - All agents share one TimescaleDB instance, isolated by `agent_id` columns (see `migrations/005_add_agent_isolation.sql`)
 
-Disabled strategy services are kept in `docker-compose.prod.yml` as commented blocks with WFO rationale (`agent`, `agent_2`, `agent_btc`, `agent_eth`).
+Disabled strategy services are kept in `docker-compose.prod.yml` as commented blocks with WFO
+or operational rationale (`agent`, `agent_2`, `agent_btc`, `agent_eth`, `agent_avax`).
 
 ### Futures execution gotchas
 - **Notional sizing is symbol-step constrained**: quantity is computed as `order_size_usdt / price`, then truncated to exchange LOT_SIZE `stepSize`. Final exposure can be slightly lower than requested because of truncation.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -460,9 +460,10 @@ The system supports running multiple isolated trading agents simultaneously. In 
 | ~~`agent_2`~~ | ~~`config/settings.agent2.yaml`~~ | DISABLED — WFO: no edge on BNBUSDT 4h |
 | ~~`agent_btc`~~ | ~~`config/settings.btc-4h.yaml`~~ | DISABLED — WFO: no edge on BTCUSDT 4h |
 | ~~`agent_eth`~~ | ~~`config/settings.eth_4h.yaml`~~ | DISABLED — WFO: 12% win rate on ETHUSDT 4h simple_ma |
+| ~~`agent_avax`~~ | ~~`config/settings.avax_4h_ma.yaml`~~ | DISABLED — live performance: 2W/11L, no current edge |
 | `agent_sol_sparse` | `config/settings.sol_trend_pullback_sparse.yaml` | SOL trend pullback |
-| `agent_sentiment_macro` | `config/settings.sentiment_macro.yaml` | Sentiment mean reversion, live futures routing |
-| `agent_avax` | `config/settings.avax_4h_ma.yaml` | AVAX 4h CCI breakout (WFO-validated) |
+| `agent_sol_panic_block_paper` | `config/settings.sol_4h_panic_block_paper.yaml` | SOL panic-block paper validation |
+| `agent_sentiment_macro` | `config/settings.sentiment_macro.yaml` | SOL-only sentiment mean reversion, live futures routing |
 
 **Disabled agent rationale:**
 
@@ -472,6 +473,7 @@ The system supports running multiple isolated trading agents simultaneously. In 
 | `agent_2` (BNBUSDT 4h) | All 5 strategies negative OOS, best -7.7%. | commit `5be9a0d` |
 | `agent_btc` (BTCUSDT 4h) | 50+ param combos (simple_ma, CCI, MTF regime) all deeply negative OOS. Post-fix P&L: -$25 across 4 trades. | commit `21419d3` |
 | `agent_eth` (ETHUSDT 4h) | 12% win rate on simple_ma, no edge across any strategy. WFO sweep: all candidates failed quality gates. | commit `5be9a0d`, `docs/reports/mtf-ethusdt-sweep-analysis.md` |
+| `agent_avax` (AVAXUSDT 4h) | Live performance degraded to 2W/11L and `-$9.58`; prior WFO edge did not persist. | `docker-compose.prod.yml` |
 
 Agents are isolated via `AGENT_ID` environment variable. Database tables use `agent_id` columns for state separation (see `migrations/005_add_agent_isolation.sql`).
 

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -2,7 +2,7 @@
 # Multi-stage build for smaller image size
 
 # Stage 1: Build dependencies
-FROM python:3.11-slim as builder
+FROM python:3.11-slim AS builder
 
 WORKDIR /build
 
@@ -23,7 +23,7 @@ RUN pip install --no-cache-dir --upgrade pip && \
 
 
 # Stage 2: Production image
-FROM python:3.11-slim as production
+FROM python:3.11-slim AS production
 
 # Create non-root user for security
 RUN groupadd -r crypto && useradd -r -g crypto crypto

--- a/config/autoresearch/overlap_manifest_sol_1h.yaml
+++ b/config/autoresearch/overlap_manifest_sol_1h.yaml
@@ -1,0 +1,16 @@
+# Entry-overlap study: SOLUSDT 1h agents (WFO OOS windows + optional live DB).
+symbol: SOLUSDT
+timeframe: 1h
+train_months: 3
+test_months: 2
+tolerance_hours: 1
+agents:
+  - label: sol_1h_trend_pullback_overlay_live
+    config: config/settings.sol_1h_trend_pullback_overlay_live.yaml
+  - label: sentiment_macro
+    config: config/settings.sentiment_macro.yaml
+    replay_sentiment_log: data/event_log_sentiment-macro-bot.jsonl
+    replay_sentiment_max_age_hours: 24
+  - label: sol_1h_trend_pullback_overlay_paper
+    config: config/settings.sol_1h_trend_pullback_overlay_paper.yaml
+    note: Second SOL 1h config variant (same signal stack as live)

--- a/config/autoresearch/overlays/tracked-avaxusdt-1h-regime-gated-pullback.yaml
+++ b/config/autoresearch/overlays/tracked-avaxusdt-1h-regime-gated-pullback.yaml
@@ -1,0 +1,63 @@
+# Best Wave 2 AVAX candidate (run 0004, bootstrap=100).
+# WFO: +6.55% OOS, 18 trades, P(loss) 41%, concentration 38.6%.
+trading_execution:
+  sl_atr_multiplier: 2.49
+  tp_atr_multiplier: 3.82
+  trailing_activate_atr: 2.1
+  trailing_offset_atr: 0.98
+strategy:
+  global_trend_filter_buffer_pct: 0.0097
+  strategies:
+    - name: rsi_reversal
+      config:
+        rsi_period: 7
+        oversold_threshold: 35
+        overbought_threshold: 65
+    - name: macd_histogram
+      config:
+        min_histogram_threshold: 0.00004
+        use_atr_filter: true
+        atr_min_pct: 0.0086
+    - name: bollinger_bounce
+      config:
+        band_distance_threshold: 0.0053
+        rsi_oversold: 30
+        rsi_overbought: 70
+    - name: cci_breakout
+      config:
+        cci_buy_threshold: 100
+        cci_sell_threshold: -100
+        atr_min_pct: 0.0127
+    - name: vwap_reversion
+      config:
+        vwap_atr_multiplier: 1.85
+        rsi_oversold: 40
+        rsi_overbought: 60
+    - name: trend_pullback
+      config:
+        rsi_reclaim_level: 48
+        min_trend_strength_pct: 0.0117
+        max_pullback_distance_pct: 0.0177
+        vwap_pullback_distance_pct: 0.0249
+        min_atr_pct: 0.0131
+        min_macd_hist: -0.0094
+        strong_trend_strength_pct: 0.0188
+        continuation_rsi_level: 52
+        continuation_max_vwap_distance_pct: 0.0423
+        continuation_max_ema50_extension_pct: 0.0332
+        continuation_min_macd_hist: -0.0069
+  aggregator:
+    buy_threshold: 1.26
+    buy_threshold_uptrend: 1.13
+    sell_threshold: -0.8
+    min_confidence: 0.34
+    btc_regime_filter_enabled: true
+    btc_dump_threshold_pct: -1.11
+    btc_dump_require_below_ema200: true
+  per_symbol_aggregator_config:
+    AVAXUSDT:
+      min_agreement: 1
+      buy_threshold: 1.26
+      buy_threshold_uptrend: 1.13
+      sell_threshold: -0.8
+      sell_min_agreement: 2

--- a/config/autoresearch/overlays/tracked-ethusdt-1h-breakout-retest.yaml
+++ b/config/autoresearch/overlays/tracked-ethusdt-1h-breakout-retest.yaml
@@ -1,0 +1,60 @@
+# Best Wave 2 ETH candidate (run 0004, bootstrap=100).
+# WFO: +0.67% OOS, 19 trades — near-miss on Sharpe/bootstrap; validate at 1000.
+trading_execution:
+  sl_atr_multiplier: 2.19
+  tp_atr_multiplier: 4.37
+  trailing_activate_atr: 1.63
+  trailing_offset_atr: 1.07
+strategy:
+  strategies:
+    - name: rsi_reversal
+      config:
+        rsi_period: 7
+        oversold_threshold: 35
+        overbought_threshold: 65
+    - name: macd_histogram
+      config:
+        min_histogram_threshold: 0.00004
+        use_atr_filter: true
+        atr_min_pct: 0.008
+    - name: bollinger_bounce
+      config:
+        band_distance_threshold: 0.0053
+        rsi_oversold: 30
+        rsi_overbought: 70
+    - name: cci_breakout
+      config:
+        cci_buy_threshold: 100
+        cci_sell_threshold: -100
+        atr_min_pct: 0.0115
+    - name: vwap_reversion
+      config:
+        vwap_atr_multiplier: 1.85
+        rsi_oversold: 40
+        rsi_overbought: 60
+    - name: breakout_retest
+      config:
+        min_trend_strength_pct: 0.0061
+        min_atr_pct: 0.0094
+        breakout_rsi_level: 56.1
+        breakout_min_macd_hist: 0.0008
+        breakout_band_distance_threshold: 0.0111
+        breakout_min_vwap_extension_pct: 0.0118
+        retest_window_bars: 5
+        retest_vwap_distance_pct: 0.0124
+        retest_ema50_distance_pct: 0.0168
+        reclaim_rsi_level: 48
+        retest_min_macd_hist: -0.0016
+        max_extension_after_retest_pct: 0.0289
+  aggregator:
+    buy_threshold: 1.23
+    buy_threshold_uptrend: 1.11
+    sell_threshold: -0.8
+    min_confidence: 0.2
+  per_symbol_aggregator_config:
+    ETHUSDT:
+      min_agreement: 1
+      buy_threshold: 1.23
+      buy_threshold_uptrend: 1.11
+      sell_threshold: -0.8
+      sell_min_agreement: 1

--- a/config/grafana/provisioning/alerting/alerts.yml
+++ b/config/grafana/provisioning/alerting/alerts.yml
@@ -62,7 +62,7 @@ groups:
               to: 0
             datasourceUid: prometheus
             model:
-              expr: count(up{job="trading-agent"})
+              expr: min(up{job="trading-agent"})
               refId: A
           - refId: B
             relativeTimeRange:
@@ -87,13 +87,13 @@ groups:
                 - evaluator:
                     type: lt
                     params:
-                      - 7
+                      - 1
         noDataState: Alerting
         execErrState: Error
         for: 2m
         annotations:
           summary: "Crypto trading agent not reporting"
-          description: "Expected 7 agents, found: {{ $value }}"
+          description: "At least one configured trading agent is not reporting: {{ $value }}"
         labels:
           severity: critical
           alert_type: agent_down

--- a/config/grafana/provisioning/plugins/plugins.yml
+++ b/config/grafana/provisioning/plugins/plugins.yml
@@ -1,0 +1,3 @@
+apiVersion: 1
+
+apps: []

--- a/config/prometheus/agents.json
+++ b/config/prometheus/agents.json
@@ -19,5 +19,12 @@
 			"agent_id": "sol-4h-panic-block-paper"
 		},
 		"targets": ["agent_sol_panic_block_paper:8000"]
+	},
+	{
+		"labels": {
+			"service": "agent_sol_1h_trend_pullback_overlay_live",
+			"agent_id": "sol-1h-trend-pullback-overlay-live"
+		},
+		"targets": ["agent_sol_1h_trend_pullback_overlay_live:8000"]
 	}
 ]

--- a/config/prometheus/agents.json
+++ b/config/prometheus/agents.json
@@ -15,9 +15,9 @@
 	},
 	{
 		"labels": {
-			"service": "agent_avax",
-			"agent_id": "avax-4h-ma"
+			"service": "agent_sol_panic_block_paper",
+			"agent_id": "sol-4h-panic-block-paper"
 		},
-		"targets": ["agent_avax:8000"]
+		"targets": ["agent_sol_panic_block_paper:8000"]
 	}
 ]

--- a/config/risk.sol-1h-probe-paper.yaml
+++ b/config/risk.sol-1h-probe-paper.yaml
@@ -1,0 +1,26 @@
+position_limits:
+  max_position_pct: 0.10
+  max_open_positions: 1
+
+loss_limits:
+  max_daily_loss_pct: 0.03
+  max_drawdown_pct: 0.10
+  max_single_loss_pct: 0.015
+
+circuit_breakers:
+  consecutive_losses: 3
+  api_errors: 3
+  latency_spike_ms: 5000
+
+kill_switch:
+  enabled: true
+  telegram_confirm: true
+  auto_reset_minutes: 60
+
+futures_limits:
+  max_leverage: 3
+  liquidation_buffer_pct: 5.0
+  max_daily_loss_pct: 3.0
+  max_margin_usage_pct: 20.0
+  margin_mode: isolated
+  position_mode: one-way

--- a/config/risk.sol-1h-trend-pullback-overlay-live.yaml
+++ b/config/risk.sol-1h-trend-pullback-overlay-live.yaml
@@ -1,0 +1,26 @@
+position_limits:
+  max_position_pct: 0.10
+  max_open_positions: 1
+
+loss_limits:
+  max_daily_loss_pct: 0.03
+  max_drawdown_pct: 0.10
+  max_single_loss_pct: 0.015
+
+circuit_breakers:
+  consecutive_losses: 3
+  api_errors: 3
+  latency_spike_ms: 5000
+
+kill_switch:
+  enabled: true
+  telegram_confirm: true
+  auto_reset_minutes: 60
+
+futures_limits:
+  max_leverage: 3
+  liquidation_buffer_pct: 5.0
+  max_daily_loss_pct: 3.0
+  max_margin_usage_pct: 20.0
+  margin_mode: isolated
+  position_mode: one-way

--- a/config/risk.sol-1h-trend-pullback-overlay-paper.yaml
+++ b/config/risk.sol-1h-trend-pullback-overlay-paper.yaml
@@ -1,0 +1,26 @@
+position_limits:
+  max_position_pct: 0.10
+  max_open_positions: 1
+
+loss_limits:
+  max_daily_loss_pct: 0.03
+  max_drawdown_pct: 0.10
+  max_single_loss_pct: 0.015
+
+circuit_breakers:
+  consecutive_losses: 3
+  api_errors: 3
+  latency_spike_ms: 5000
+
+kill_switch:
+  enabled: true
+  telegram_confirm: true
+  auto_reset_minutes: 60
+
+futures_limits:
+  max_leverage: 3
+  liquidation_buffer_pct: 5.0
+  max_daily_loss_pct: 3.0
+  max_margin_usage_pct: 20.0
+  margin_mode: isolated
+  position_mode: one-way

--- a/config/settings.sentiment_macro.yaml
+++ b/config/settings.sentiment_macro.yaml
@@ -14,7 +14,6 @@ mode: live
 
 trading:
   pairs:
-    - BTCUSDT
     - ETHUSDT
     - SOLUSDT
   timeframe: 1h
@@ -53,7 +52,6 @@ futures:
   # Wait longer after SL before re-entry on the same symbol.
   sl_cooldown_minutes: 240
   symbols:
-    - BTCUSDT
     - ETHUSDT
     - SOLUSDT
 

--- a/config/settings.sentiment_macro.yaml
+++ b/config/settings.sentiment_macro.yaml
@@ -71,9 +71,9 @@ strategy:
         # Threshold based on actual ATR% data: BTC avg ~0.004-0.005, ETH avg ~0.005-0.007
         # 0.005 catches elevated-vol regimes where MR gets chopped
         atr_pct_threshold: 0.005
-  # Mean-reversion buys dips by design, so allow entries up to 5% below EMA200.
-  # Strict 0.0 blocked every BUY when BTC/ETH dipped below EMA200 (Apr 18-20 bear).
-  global_trend_filter_buffer_pct: 0.05
+  # Keep dip buys above EMA200. Historical testing found that the prior 5% buffer
+  # materially worsened BTC drawdown by allowing entries during sustained downtrends.
+  global_trend_filter_buffer_pct: 0.0
   aggregator:
     buy_threshold: 0.6
     sell_threshold: -0.6

--- a/config/settings.sentiment_macro.yaml
+++ b/config/settings.sentiment_macro.yaml
@@ -14,7 +14,6 @@ mode: live
 
 trading:
   pairs:
-    - ETHUSDT
     - SOLUSDT
   timeframe: 1h
 
@@ -52,7 +51,6 @@ futures:
   # Wait longer after SL before re-entry on the same symbol.
   sl_cooldown_minutes: 240
   symbols:
-    - ETHUSDT
     - SOLUSDT
 
 strategy:

--- a/config/settings.sentiment_macro.yaml
+++ b/config/settings.sentiment_macro.yaml
@@ -37,6 +37,8 @@ trading_execution:
   tp_atr_multiplier: 3.5
   exit_rules:
     time_stop_minutes: 1440
+    # Keep replay validation aligned with futures ATR SL/TP behavior.
+    backtest_use_executor_exit_model: true
 
 futures:
   enabled: true

--- a/config/settings.sol_1h_probe_paper.yaml
+++ b/config/settings.sol_1h_probe_paper.yaml
@@ -1,0 +1,84 @@
+agent_id: sol-1h-probe-paper
+display_name: sol-1h-probe-paper
+mode: paper
+
+trading:
+  pairs:
+    - SOLUSDT
+  timeframe: 1h
+
+ingest:
+  use_websocket: false
+
+telegram:
+  enabled: false
+  daily_summary_enabled: true
+
+trading_execution:
+  # Paper/probe default. Do not enable live execution from this file without a
+  # separate promotion review.
+  enabled: false
+  test_mode: true
+  use_atr_sizing: false
+  order_size_usdt: 22.0
+  sl_atr_multiplier: 2.3
+  tp_atr_multiplier: 3.98
+  trailing_activate_atr: 1.91
+  trailing_offset_atr: 0.92
+
+futures:
+  enabled: false
+  test_mode: true
+  default_leverage: 1
+  max_leverage: 3
+  margin_mode: isolated
+  position_mode: one-way
+  liquidation_buffer_pct: 5.0
+  max_concurrent_longs: 1
+  sl_cooldown_minutes: 240
+  symbols:
+    - SOLUSDT
+
+strategy:
+  default_trading_mode: spot
+  evaluation_interval_seconds: 3600
+  strategies:
+    - name: rsi_reversal
+      config:
+        rsi_period: 7
+        oversold_threshold: 35
+        overbought_threshold: 65
+    - name: macd_histogram
+      config:
+        min_histogram_threshold: 0.00018
+        use_atr_filter: true
+        atr_min_pct: 0.0088
+    - name: bollinger_bounce
+      config:
+        band_distance_threshold: 0.005
+        rsi_oversold: 30
+        rsi_overbought: 70
+    - name: cci_breakout
+      config:
+        cci_buy_threshold: 100
+        cci_sell_threshold: -100
+        atr_min_pct: 0.0117
+    - name: vwap_reversion
+      config:
+        vwap_atr_multiplier: 2.02
+        rsi_oversold: 40
+        rsi_overbought: 60
+  aggregator:
+    buy_threshold: 1.08
+    buy_threshold_uptrend: 1.06
+    sell_threshold: -0.77
+    btc_regime_filter_enabled: true
+    btc_reference_symbol: BTCUSDT
+    btc_dump_threshold_pct: -1.0
+    btc_dump_require_below_ema200: true
+  per_symbol_aggregator_config:
+    SOLUSDT:
+      min_agreement: 1
+      buy_threshold: 1.08
+      sell_threshold: -0.77
+      sell_min_agreement: 1

--- a/config/settings.sol_1h_trend_pullback_overlay_live.yaml
+++ b/config/settings.sol_1h_trend_pullback_overlay_live.yaml
@@ -1,0 +1,98 @@
+agent_id: sol-1h-trend-pullback-overlay-live
+display_name: sol-1h-trend-pullback-overlay-live
+mode: live
+
+trading:
+  pairs:
+    - SOLUSDT
+  timeframe: 1h
+
+ingest:
+  use_websocket: false
+
+telegram:
+  daily_summary_enabled: true
+
+trading_execution:
+  enabled: true
+  test_mode: false
+  use_atr_sizing: false
+  order_size_usdt: 22.0
+  sl_atr_multiplier: 2.38
+  tp_atr_multiplier: 4.23
+  trailing_activate_atr: 1.82
+  trailing_offset_atr: 1.07
+  exit_rules:
+    backtest_use_executor_exit_model: true
+
+futures:
+  enabled: true
+  test_mode: false
+  default_leverage: 3
+  max_leverage: 3
+  margin_mode: isolated
+  position_mode: one-way
+  liquidation_buffer_pct: 5.0
+  max_concurrent_longs: 1
+  sl_cooldown_minutes: 240
+  symbols:
+    - SOLUSDT
+
+strategy:
+  default_trading_mode: futures
+  evaluation_interval_seconds: 3600
+  strategies:
+    - name: rsi_reversal
+      config:
+        rsi_period: 7
+        oversold_threshold: 35
+        overbought_threshold: 65
+    - name: macd_histogram
+      config:
+        min_histogram_threshold: 0.0
+        use_atr_filter: true
+        atr_min_pct: 0.0078
+    - name: bollinger_bounce
+      config:
+        band_distance_threshold: 0.0049
+        rsi_oversold: 35
+        rsi_overbought: 70
+    - name: cci_breakout
+      config:
+        cci_buy_threshold: 100
+        cci_sell_threshold: -100
+        atr_min_pct: 0.0114
+    - name: vwap_reversion
+      config:
+        vwap_atr_multiplier: 2.02
+        rsi_oversold: 40
+        rsi_overbought: 60
+    - name: trend_pullback
+      config:
+        rsi_reclaim_level: 50
+        min_trend_strength_pct: 0.0089
+        max_pullback_distance_pct: 0.0291
+        vwap_pullback_distance_pct: 0.0151
+        min_atr_pct: 0.0064
+        min_macd_hist: -0.0084
+        strong_trend_strength_pct: 0.0153
+        continuation_rsi_level: 52
+        continuation_max_vwap_distance_pct: 0.0434
+        continuation_max_ema50_extension_pct: 0.0361
+        continuation_min_macd_hist: -0.0054
+  aggregator:
+    buy_threshold: 1.27
+    buy_threshold_uptrend: 1.07
+    sell_threshold: -0.79
+    btc_regime_filter_enabled: true
+    btc_reference_symbol: BTCUSDT
+    btc_dump_threshold_pct: -1.0
+    btc_dump_require_below_ema200: true
+    min_confidence: 0.04
+  per_symbol_aggregator_config:
+    SOLUSDT:
+      min_agreement: 1
+      buy_threshold: 1.27
+      buy_threshold_uptrend: 1.07
+      sell_threshold: -0.79
+      sell_min_agreement: 1

--- a/config/settings.sol_1h_trend_pullback_overlay_live.yaml
+++ b/config/settings.sol_1h_trend_pullback_overlay_live.yaml
@@ -41,6 +41,7 @@ futures:
 strategy:
   default_trading_mode: futures
   evaluation_interval_seconds: 3600
+  global_trend_filter_buffer_pct: 0.0
   strategies:
     - name: rsi_reversal
       config:

--- a/config/settings.sol_1h_trend_pullback_overlay_paper.yaml
+++ b/config/settings.sol_1h_trend_pullback_overlay_paper.yaml
@@ -1,0 +1,99 @@
+agent_id: sol-1h-trend-pullback-overlay-paper
+display_name: sol-1h-trend-pullback-overlay-paper
+mode: paper
+
+trading:
+  pairs:
+    - SOLUSDT
+  timeframe: 1h
+
+ingest:
+  use_websocket: false
+
+telegram:
+  enabled: false
+  daily_summary_enabled: true
+
+trading_execution:
+  # Paper/probe default. Do not enable live execution from this file without a
+  # separate promotion review.
+  enabled: false
+  test_mode: true
+  use_atr_sizing: false
+  order_size_usdt: 22.0
+  sl_atr_multiplier: 2.38
+  tp_atr_multiplier: 4.23
+  trailing_activate_atr: 1.82
+  trailing_offset_atr: 1.07
+
+futures:
+  enabled: false
+  test_mode: true
+  default_leverage: 1
+  max_leverage: 3
+  margin_mode: isolated
+  position_mode: one-way
+  liquidation_buffer_pct: 5.0
+  max_concurrent_longs: 1
+  sl_cooldown_minutes: 240
+  symbols:
+    - SOLUSDT
+
+strategy:
+  default_trading_mode: spot
+  evaluation_interval_seconds: 3600
+  strategies:
+    - name: rsi_reversal
+      config:
+        rsi_period: 7
+        oversold_threshold: 35
+        overbought_threshold: 65
+    - name: macd_histogram
+      config:
+        min_histogram_threshold: 0.0
+        use_atr_filter: true
+        atr_min_pct: 0.0078
+    - name: bollinger_bounce
+      config:
+        band_distance_threshold: 0.0049
+        rsi_oversold: 35
+        rsi_overbought: 70
+    - name: cci_breakout
+      config:
+        cci_buy_threshold: 100
+        cci_sell_threshold: -100
+        atr_min_pct: 0.0114
+    - name: vwap_reversion
+      config:
+        vwap_atr_multiplier: 2.02
+        rsi_oversold: 40
+        rsi_overbought: 60
+    - name: trend_pullback
+      config:
+        rsi_reclaim_level: 50
+        min_trend_strength_pct: 0.0089
+        max_pullback_distance_pct: 0.0291
+        vwap_pullback_distance_pct: 0.0151
+        min_atr_pct: 0.0064
+        min_macd_hist: -0.0084
+        strong_trend_strength_pct: 0.0153
+        continuation_rsi_level: 52
+        continuation_max_vwap_distance_pct: 0.0434
+        continuation_max_ema50_extension_pct: 0.0361
+        continuation_min_macd_hist: -0.0054
+  aggregator:
+    buy_threshold: 1.27
+    buy_threshold_uptrend: 1.07
+    sell_threshold: -0.79
+    btc_regime_filter_enabled: true
+    btc_reference_symbol: BTCUSDT
+    btc_dump_threshold_pct: -1.0
+    btc_dump_require_below_ema200: true
+    min_confidence: 0.04
+  per_symbol_aggregator_config:
+    SOLUSDT:
+      min_agreement: 1
+      buy_threshold: 1.27
+      buy_threshold_uptrend: 1.07
+      sell_threshold: -0.79
+      sell_min_agreement: 1

--- a/config/settings.sol_1h_trend_pullback_overlay_paper.yaml
+++ b/config/settings.sol_1h_trend_pullback_overlay_paper.yaml
@@ -42,6 +42,7 @@ futures:
 strategy:
   default_trading_mode: spot
   evaluation_interval_seconds: 3600
+  global_trend_filter_buffer_pct: 0.0
   strategies:
     - name: rsi_reversal
       config:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -117,7 +117,7 @@ services:
       GF_AUTH_DISABLE_LOGIN_FORM: "false"
       GF_AUTH_ANONYMOUS_ENABLED: "false"
       GF_SERVER_ROOT_URL: ${GRAFANA_ROOT_URL:-http://localhost:3000}
-      GF_INSTALL_PLUGINS: grafana-clock-panel,grafana-simple-json-datasource
+      GF_INSTALL_PLUGINS: grafana-clock-panel
       POSTGRES_DB: ${POSTGRES_DB}
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -226,6 +226,39 @@ services:
       AGENT_ID: sol-4h-panic-block-paper
       SETTINGS_PATH: config/settings.sol_4h_panic_block_paper.yaml
 
+  # agent_sol_1h_probe_paper: DISABLED 2026-06-03 — autoresearch probe only.
+  # Passed probe_1h but missed the standard gate on sample count: 17/20 WFO trades.
+  # Uncomment only for paper/shadow validation, then add a matching Prometheus target.
+  # agent_sol_1h_probe_paper:
+  #   <<: *agent-common
+  #   environment:
+  #     POSTGRES_HOST: timescaledb
+  #     POSTGRES_PORT: "5432"
+  #     PROMETHEUS_PORT: "8000"
+  #     AGENT_ID: sol-1h-probe-paper
+  #     SETTINGS_PATH: config/settings.sol_1h_probe_paper.yaml
+
+  # agent_sol_1h_trend_pullback_overlay_paper: DISABLED 2026-06-03 — standard-gate pass.
+  # Passed SOLUSDT 1h WFO/bootstrap standard gate with trend_pullback overlay.
+  # Uncomment only for paper/shadow validation, then add a matching Prometheus target.
+  # agent_sol_1h_trend_pullback_overlay_paper:
+  #   <<: *agent-common
+  #   environment:
+  #     POSTGRES_HOST: timescaledb
+  #     POSTGRES_PORT: "5432"
+  #     PROMETHEUS_PORT: "8000"
+  #     AGENT_ID: sol-1h-trend-pullback-overlay-paper
+  #     SETTINGS_PATH: config/settings.sol_1h_trend_pullback_overlay_paper.yaml
+
+  agent_sol_1h_trend_pullback_overlay_live:
+    <<: *agent-common
+    environment:
+      POSTGRES_HOST: timescaledb
+      POSTGRES_PORT: "5432"
+      PROMETHEUS_PORT: "8000"
+      AGENT_ID: sol-1h-trend-pullback-overlay-live
+      SETTINGS_PATH: config/settings.sol_1h_trend_pullback_overlay_live.yaml
+
   agent_sentiment_macro:
     <<: *agent-common
     environment:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -235,26 +235,27 @@ services:
       AGENT_ID: sentiment-macro-bot
       SETTINGS_PATH: config/settings.sentiment_macro.yaml
 
-  # Nginx reverse proxy
-  nginx:
-    image: nginx:alpine
-    restart: always
-    ports:
-      - "80:80"
-      - "443:443"
-    volumes:
-      - ./config/nginx/nginx.conf:/etc/nginx/nginx.conf:ro
-      - ./config/nginx/ssl:/etc/nginx/ssl:ro
-    depends_on:
-      - grafana
-      - prometheus
-    networks:
-      - crypto-net
-    logging:
-      driver: "json-file"
-      options:
-        max-size: "50m"
-        max-file: "3"
+  # nginx: DISABLED 2026-06-01 — tailscaled owns the host HTTPS listener on port 443.
+  # Keep Grafana internal-only until ingress is intentionally consolidated.
+  # nginx:
+  #   image: nginx:alpine
+  #   restart: always
+  #   ports:
+  #     - "80:80"
+  #     - "443:443"
+  #   volumes:
+  #     - ./config/nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+  #     - ./config/nginx/ssl:/etc/nginx/ssl:ro
+  #   depends_on:
+  #     - grafana
+  #     - prometheus
+  #   networks:
+  #     - crypto-net
+  #   logging:
+  #     driver: "json-file"
+  #     options:
+  #       max-size: "50m"
+  #       max-file: "3"
 
 volumes:
   timescaledb-data:

--- a/docs/EXPERIMENT_AUTOPILOT.md
+++ b/docs/EXPERIMENT_AUTOPILOT.md
@@ -51,3 +51,169 @@ Reports are written under `docs/reports/` by default:
 - `experiment-autopilot-<timestamp>.json`
 
 Use `--output-prefix` to change path/prefix.
+
+## Autoresearch Loop
+
+`scripts/run_autoresearch.py` runs one fixed evaluation and appends the result to
+`research/results.tsv`. `scripts/autoresearch_loop.py` adds the Karpathy-style
+control loop on top: it generates bounded YAML overlays under
+`research/candidates/`, evaluates each candidate through the fixed runner, and
+lets the runner mark each result as `keep`, `discard`, `crash`, or `timeout`.
+Child command output is captured in `research/autoresearch_loop.log`; the fixed
+runner still writes the latest child result to `research/last_result.json`.
+
+Dry-run candidate generation:
+
+```bash
+python scripts/autoresearch_loop.py \
+  --config config/settings.autoresearch.yaml \
+  --symbol SOLUSDT \
+  --timeframe 4h \
+  --gate-profile sparse_trend_3_2 \
+  --max-runs 5 \
+  --dry-run
+```
+
+Bounded research campaign:
+
+```bash
+python scripts/autoresearch_loop.py \
+  --config config/settings.autoresearch.yaml \
+  --symbol SOLUSDT \
+  --timeframe 4h \
+  --train-months 3 \
+  --test-months 2 \
+  --gate-profile sparse_trend_3_2 \
+  --include-baseline \
+  --max-runs 10
+```
+
+Focused follow-up after a broad campaign identifies a promising family:
+
+```bash
+python scripts/autoresearch_loop.py \
+  --config config/settings.autoresearch.yaml \
+  --symbol SOLUSDT \
+  --timeframe 4h \
+  --train-months 3 \
+  --test-months 2 \
+  --gate-profile sparse_trend_3_2 \
+  --families aggregator_thresholds \
+  --aggregator-focus \
+  --max-runs 30
+```
+
+Combined follow-up when a single-family sweep improves score but still fails
+robustness gates:
+
+```bash
+python scripts/autoresearch_loop.py \
+  --config config/settings.autoresearch.yaml \
+  --symbol SOLUSDT \
+  --timeframe 4h \
+  --train-months 3 \
+  --test-months 2 \
+  --gate-profile sparse_trend_3_2 \
+  --families combined_focus \
+  --max-runs 50
+```
+
+Standard-gate bridge search after a candidate passes risk/profit gates but is
+short on aggregate WFO trades:
+
+```bash
+set -a && source .env && set +a
+export POSTGRES_HOST=127.0.0.1 POSTGRES_PORT=15432
+
+python scripts/autoresearch_loop.py \
+  --config config/settings.autoresearch.yaml \
+  --symbol SOLUSDT \
+  --timeframe 1h \
+  --train-months 3 \
+  --test-months 2 \
+  --gate-profile standard \
+  --families standard_gate_bridge \
+  --max-runs 50
+```
+
+This family intentionally samples between the best SOLUSDT 1h near miss and the
+lowest-damage 20+ WFO-trade failures. Its purpose is to add a few trades without
+moving into the high-frequency, high-drawdown region that prior near-pass
+expansion sweeps exposed.
+
+If the bridge campaign still fails by moving into poor-bootstrap variants, run a
+narrower trade-lift search around the original 17-WFO near miss:
+
+```bash
+python scripts/autoresearch_loop.py \
+  --config config/settings.autoresearch.yaml \
+  --symbol SOLUSDT \
+  --timeframe 1h \
+  --train-months 3 \
+  --test-months 2 \
+  --gate-profile standard \
+  --families near_miss_trade_lift \
+  --max-runs 30
+```
+
+If the same surface remains capped below 20 robust WFO trades, test a
+complementary trend-consistent signal instead of loosening mean-reversion
+thresholds:
+
+```bash
+python scripts/autoresearch_loop.py \
+  --config config/settings.autoresearch.yaml \
+  --symbol SOLUSDT \
+  --timeframe 1h \
+  --train-months 3 \
+  --test-months 2 \
+  --gate-profile standard \
+  --families trend_pullback_overlay \
+  --max-runs 30
+```
+
+If the local DB is only reachable through Hetzner, run the same bridge search
+through the SSH tunnel wrapper:
+
+```bash
+scripts/run_autoresearch_tunnel.sh \
+  --mode loop \
+  --config config/settings.autoresearch.yaml \
+  --symbol SOLUSDT \
+  --timeframe 1h \
+  --train-months 3 \
+  --test-months 2 \
+  --bootstrap 100 \
+  --seed 314 \
+  --gate-profile standard \
+  --families standard_gate_bridge \
+  --max-runs 50 \
+  --timeout-seconds 900 \
+  --output-dir /tmp/crypto-agent-autoresearch-sol-1h-standard-bridge-50
+```
+
+Near-pass expansion when the best candidate has acceptable drawdown and return
+but fails because OOS trade count is too low:
+
+```bash
+python scripts/autoresearch_loop.py \
+  --config config/settings.autoresearch.yaml \
+  --symbol SOLUSDT \
+  --timeframe 4h \
+  --train-months 3 \
+  --test-months 2 \
+  --gate-profile sparse_trend_3_2 \
+  --families near_pass_expansion \
+  --max-runs 50
+```
+
+Use `--gate-profile probe_1h` only for limited 1h research probes where the
+candidate already passes return, Sharpe, drawdown, bootstrap loss, and profit
+concentration gates but narrowly misses the standard `min_wfo_trades: 20`
+requirement. It keeps the standard risk gates and lowers only the aggregate WFO
+trade-count requirement to 15. This is not a full production-promotion gate.
+
+The loop is intentionally config-only. It does not edit production settings,
+restart services, or mutate strategy/execution code. A candidate should only be
+promoted manually after reviewing `research/results.tsv`,
+`research/last_result.json`, and the archived autopilot report.

--- a/docs/PAPER_VALIDATION_REPORT.md
+++ b/docs/PAPER_VALIDATION_REPORT.md
@@ -3,15 +3,19 @@
 `paper_validation_report` summarizes the paper trading agents for one UTC day.
 
 It combines:
+
 - event-log activity
 - daily closed-trade stats from the database
 - cumulative portfolio stats
 - risk-state flags
 
 Current monitored paper agents:
+
 - `agent_sol_sparse`
-- `agent_sentiment_macro`
-- `agent_avax`
+- `agent_sol_panic_block_paper`
+
+`agent_sentiment_macro` is intentionally excluded because it routes live SOL futures orders.
+`agent_avax` is disabled because its prior walk-forward edge did not persist in live trading.
 
 ## Manual Run
 

--- a/docs/PAPER_VALIDATION_REPORT.md
+++ b/docs/PAPER_VALIDATION_REPORT.md
@@ -23,6 +23,12 @@ Current monitored paper agents:
 - `agent_sol_sparse`
 - `agent_sol_panic_block_paper`
 
+Optional probe agents are not included until their compose services are explicitly
+enabled and added to `config/prometheus/agents.json`. As of 2026-06-03,
+`agent_sol_1h_probe_paper` is tracked as a disabled SOLUSDT 1h autoresearch
+probe because it passed the `probe_1h` gate but missed the standard WFO trade
+count gate.
+
 `agent_sentiment_macro` is intentionally excluded because it routes live SOL futures orders.
 `agent_avax` is disabled because its prior walk-forward edge did not persist in live trading.
 

--- a/docs/PAPER_VALIDATION_REPORT.md
+++ b/docs/PAPER_VALIDATION_REPORT.md
@@ -8,6 +8,10 @@ It combines:
 - daily closed-trade stats from the database
 - cumulative portfolio stats
 - risk-state flags
+- campaign metrics scoped to each validator's explicit rollout timestamp
+
+Promotion decisions must use campaign metrics. Lifetime database metrics are retained only for
+audit context because they can include rows from older strategy settings.
 
 Current monitored paper agents:
 

--- a/docs/PAPER_VALIDATION_REPORT.md
+++ b/docs/PAPER_VALIDATION_REPORT.md
@@ -9,9 +9,14 @@ It combines:
 - cumulative portfolio stats
 - risk-state flags
 - campaign metrics scoped to each validator's explicit rollout timestamp
+- conservative paper-to-live review readiness based on campaign age and closed-trade count
 
 Promotion decisions must use campaign metrics. Lifetime database metrics are retained only for
 audit context because they can include rows from older strategy settings.
+
+`ready_for_review` is not automatic promotion. A validator reaches that state only after at
+least `28` days and `10` campaign closed trades. Promotion still requires human review of
+PnL, win rate, drawdown, trade quality, and operational logs.
 
 Current monitored paper agents:
 

--- a/docs/PRODUCTION_DRIFT_SENTINEL.md
+++ b/docs/PRODUCTION_DRIFT_SENTINEL.md
@@ -8,7 +8,7 @@ It detects drift in:
 - Dirty worktree state
 - deploy-relevant `config/settings*.yaml` file hashes
 - Docker Compose service runtime status
-- Required systemd timer status
+- Required systemd timer status, oneshot result, and report artifact freshness
 - Recent signal activity (consensus signal drought/staleness)
 
 Service discovery is dynamic. The sentinel reads

--- a/docs/PRODUCTION_DRIFT_SENTINEL.md
+++ b/docs/PRODUCTION_DRIFT_SENTINEL.md
@@ -10,7 +10,9 @@ It detects drift in:
 - Docker Compose service runtime status
 - Recent signal activity (consensus signal drought/staleness)
 
-Service discovery is dynamic. The sentinel reads `docker compose config --services` on the remote host, so newly added services such as `agent_sol_sparse` are included automatically without code changes.
+Service discovery is dynamic. The sentinel reads
+`docker compose -f docker-compose.prod.yml config --services` on the remote host, so newly
+added services such as `agent_sol_sparse` are included automatically without code changes.
 Research-only configs such as `config/settings.autoresearch.yaml` are excluded from deploy parity checks.
 
 ## One Command
@@ -38,6 +40,7 @@ For the SOL sparse paper rollout, use watched-service mode so the report include
 
 ```bash
 python scripts/production_drift_sentinel.py \
+  --ssh-config ~/.ssh/config \
   --expected-branch main \
   --remote-host crypto-agent \
   --remote-dir /opt/crypto-agent \

--- a/docs/PRODUCTION_DRIFT_SENTINEL.md
+++ b/docs/PRODUCTION_DRIFT_SENTINEL.md
@@ -57,6 +57,18 @@ Local-only mode (no SSH):
 python scripts/production_drift_sentinel.py --local-only
 ```
 
+Production-local mode runs the full inspection directly on the server without nested SSH:
+
+```bash
+python scripts/production_drift_sentinel.py \
+  --production-local \
+  --remote-dir /opt/crypto-agent \
+  --watch-service agent_sol_sparse \
+  --signal-stale-hours 72 \
+  --fail-on error \
+  --output-prefix data/reports/production-drift-sentinel
+```
+
 JSON output:
 
 ```bash
@@ -71,3 +83,30 @@ By default it writes report files to `docs/reports/`:
 - `production-drift-sentinel-<timestamp>.json`
 
 Override path/prefix with `--output-prefix`.
+
+## Hourly Production Audit
+
+Install and enable the systemd timer on the production host:
+
+```bash
+sudo install -m 0644 ops/systemd/crypto-agent-production-drift-sentinel.service /etc/systemd/system/
+sudo install -m 0644 ops/systemd/crypto-agent-production-drift-sentinel.timer /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now crypto-agent-production-drift-sentinel.timer
+```
+
+The service expects production to deploy from `main`. During an intentional feature-branch
+rollout, set an explicit override before starting the service:
+
+```bash
+printf 'EXPECTED_DEPLOY_BRANCH=%s\n' fix/example-rollout |
+  sudo tee /etc/default/crypto-agent-production-drift-sentinel
+```
+
+Inspect the timer and its latest report:
+
+```bash
+systemctl status crypto-agent-production-drift-sentinel.timer
+journalctl -u crypto-agent-production-drift-sentinel.service --no-pager -n 100
+ls -1t data/reports/production-drift-sentinel-*.json | head
+```

--- a/docs/PRODUCTION_DRIFT_SENTINEL.md
+++ b/docs/PRODUCTION_DRIFT_SENTINEL.md
@@ -8,7 +8,7 @@ It detects drift in:
 - Dirty worktree state
 - deploy-relevant `config/settings*.yaml` file hashes
 - Docker Compose service runtime status
-- Required systemd timer status, oneshot result, and report artifact freshness
+- Required systemd timer status, oneshot result, and per-timer report artifact freshness
 - Recent signal activity (consensus signal drought/staleness)
 
 Service discovery is dynamic. The sentinel reads
@@ -110,3 +110,7 @@ systemctl status crypto-agent-production-drift-sentinel.timer
 journalctl -u crypto-agent-production-drift-sentinel.service --no-pager -n 100
 ls -1t data/reports/production-drift-sentinel-*.json | head
 ```
+
+Each hourly audit also verifies its own timer and latest artifact. A missing artifact or an
+artifact older than two hours fails the audit. Daily paper-validation artifacts retain a
+36-hour freshness window.

--- a/docs/PRODUCTION_DRIFT_SENTINEL.md
+++ b/docs/PRODUCTION_DRIFT_SENTINEL.md
@@ -8,6 +8,7 @@ It detects drift in:
 - Dirty worktree state
 - deploy-relevant `config/settings*.yaml` file hashes
 - Docker Compose service runtime status
+- Required systemd timer status
 - Recent signal activity (consensus signal drought/staleness)
 
 Service discovery is dynamic. The sentinel reads

--- a/docs/PRODUCTION_DRIFT_SENTINEL.md
+++ b/docs/PRODUCTION_DRIFT_SENTINEL.md
@@ -91,6 +91,7 @@ Install and enable the systemd timer on the production host:
 ```bash
 sudo install -m 0644 ops/systemd/crypto-agent-production-drift-sentinel.service /etc/systemd/system/
 sudo install -m 0644 ops/systemd/crypto-agent-production-drift-sentinel.timer /etc/systemd/system/
+sudo install -m 0644 ops/systemd/crypto-agent-telegram-failure@.service /etc/systemd/system/
 sudo systemctl daemon-reload
 sudo systemctl enable --now crypto-agent-production-drift-sentinel.timer
 ```
@@ -113,4 +114,5 @@ ls -1t data/reports/production-drift-sentinel-*.json | head
 
 Each hourly audit also verifies its own timer and latest artifact. A missing artifact or an
 artifact older than two hours fails the audit. Daily paper-validation artifacts retain a
-36-hour freshness window.
+36-hour freshness window. A failed audit starts `crypto-agent-telegram-failure@.service`,
+which sends a critical Telegram notification using the existing `.env` credentials.

--- a/docs/PRODUCTION_DRIFT_SENTINEL.md
+++ b/docs/PRODUCTION_DRIFT_SENTINEL.md
@@ -23,6 +23,7 @@ Research-only configs such as `config/settings.autoresearch.yaml` are excluded f
 
 ```bash
 python scripts/production_drift_sentinel.py \
+  --ssh-config ~/.ssh/config \
   --expected-branch main \
   --remote-host crypto-agent \
   --remote-dir /opt/crypto-agent \

--- a/docs/SOL_TREND_PULLBACK_SPARSE.md
+++ b/docs/SOL_TREND_PULLBACK_SPARSE.md
@@ -41,25 +41,29 @@ export DB_HOST=127.0.0.1 DB_PORT=15432 DB_PASSWORD="$POSTGRES_PASSWORD"
 
 ## Paper Rollout
 
-The dedicated paper service is `agent_sol_sparse` in [docker-compose.yml](/home/yderf/TRADING/crypto-agent/docker-compose.yml).
+The dedicated paper service is `agent_sol_sparse` in
+[`docker-compose.prod.yml`](../docker-compose.prod.yml).
 
 Deploy on the server after syncing the repo:
 
 ```bash
-ssh crypto-agent "cd /opt/crypto-agent && git pull && docker compose up -d agent_sol_sparse"
+ssh crypto-agent "cd /opt/crypto-agent && git pull"
+ssh crypto-agent "cd /opt/crypto-agent && docker compose -f docker-compose.prod.yml build agent_sol_sparse"
+ssh crypto-agent "cd /opt/crypto-agent && docker compose -f docker-compose.prod.yml up -d agent_sol_sparse"
 ```
 
 Verify:
 
 ```bash
-ssh crypto-agent "cd /opt/crypto-agent && docker compose ps agent_sol_sparse"
-ssh crypto-agent "cd /opt/crypto-agent && docker compose logs agent_sol_sparse --tail=100 --no-log-prefix"
+ssh crypto-agent "cd /opt/crypto-agent && docker compose -f docker-compose.prod.yml ps agent_sol_sparse"
+ssh crypto-agent "cd /opt/crypto-agent && docker compose -f docker-compose.prod.yml logs agent_sol_sparse --tail=100 --no-log-prefix"
 ```
 
 Drift and activity check:
 
 ```bash
 python scripts/production_drift_sentinel.py \
+  --ssh-config ~/.ssh/config \
   --expected-branch main \
   --remote-host crypto-agent \
   --remote-dir /opt/crypto-agent \
@@ -72,8 +76,8 @@ python scripts/production_drift_sentinel.py \
 Stop or remove the paper validation service:
 
 ```bash
-ssh crypto-agent "cd /opt/crypto-agent && docker compose stop agent_sol_sparse"
-ssh crypto-agent "cd /opt/crypto-agent && docker compose rm -f agent_sol_sparse"
+ssh crypto-agent "cd /opt/crypto-agent && docker compose -f docker-compose.prod.yml stop agent_sol_sparse"
+ssh crypto-agent "cd /opt/crypto-agent && docker compose -f docker-compose.prod.yml rm -f agent_sol_sparse"
 ```
 
 ## Guardrails

--- a/docs/reports/autoresearch-candidate-ledger.md
+++ b/docs/reports/autoresearch-candidate-ledger.md
@@ -88,15 +88,13 @@ FAMILIES=breakout_retest_overlay MAX_RUNS=50 ./scripts/run_autoresearch_campaign
 ## Priority Queue (remaining)
 
 **Cumulative search: ~1040+ runs**, **1** deployable (`agent_sol_1h_trend_pullback_overlay_live`).
+**Post-mortem:** [autoresearch-postmortem-2026-06-04.md](./autoresearch-postmortem-2026-06-04.md) — sweeps **paused** until live forward data or new surface brief.
 
 | Priority | Action | Status |
 |----------|--------|--------|
-| 1 | Monitor live SOL 1h + sentiment-macro forward | ongoing |
-| 2 | Wave 6 BTC 1h overlay (`w6-overlay`) | **closed — REJECT** |
-| 3 | BNB 1h standalone / overlay | **closed** |
-| 4 | AVAX/ETH W2 #0004 | **closed** (b=1000 reject) |
-
-After Wave 6: if no `promotion_candidate`, pivot to longer-history BTC/ETH regimes or new high-density bounded families — not threshold tweaks.
+| 1 | Forward validation: SOL overlay live + sentiment-macro | **active** |
+| 2 | New autoresearch sweeps | **paused** |
+| 3 | BTC/BNB 1h, AVAX/ETH W2 #0004 | **closed** |
 
 ## Wave 4 — Bootstrap 1000 + specialist-only (2026-06-04)
 

--- a/docs/reports/autoresearch-candidate-ledger.md
+++ b/docs/reports/autoresearch-candidate-ledger.md
@@ -105,6 +105,27 @@ Tracked overlays: `config/autoresearch/overlays/`
 
 **Takeaway:** Do not promote AVAX/ETH from Wave-2 near-misses; bootstrap=1000 collapses edge. SOL 4h without the five-vote stack does not beat prior overlay lanes. **Still 1 deployable agent** (SOL 1h trend_pullback overlay live). Combined target 8–20 trades/month requires more lanes or lower bar only after paper-forward evidence—not gate shopping.
 
+## Entry overlap — SOLUSDT 1h (2026-06-04)
+
+Report: `docs/reports/entry-overlap-sol-1h.md` (WFO OOS, train=3mo test=2mo, ±1h tolerance).
+
+| Pair | OOS entries A | OOS entries B | Shared | Jaccard | %A also in B |
+|------|---------------|---------------|--------|---------|--------------|
+| overlay_live vs sentiment_macro | 32 | 2 | 0 | 0% | 0% |
+| overlay_live vs overlay_paper | 32 | 36 | 31 | 84% | 97% |
+| sentiment_macro vs overlay_paper | 2 | 36 | 0 | 0% | 0% |
+
+**Read:** Live SOL 1h overlay and sentiment-macro are **independent on OOS entry timing** (0 shared bars). Paper/live configs are the same signal stack (expected ~97% overlap). Live DB `positions` rows lack `agent_id` tagging for these services yet — use forward paper/live logs for realized overlap.
+
+## Wave 5 — BNB/BTC 1h standalone (in progress)
+
+| Symbol | Output dir | Families | Gate |
+|--------|------------|----------|------|
+| BNBUSDT | `research/bnbusdt-1h-w5b-standalone` | 3 standalone | sparse_trend_3_2 |
+| BTCUSDT | `research/btcusdt-1h-w5b-standalone` | 3 standalone | sparse_trend_3_2 |
+
+(w5-standalone failed: `run_autoresearch` import path; fixed in `60702e3`.)
+
 ## Wave 3 — Bridge + funding
 
 | Date | Symbol | TF | Families | Runs | Passes | Near-miss | Output dir | Decision |

--- a/docs/reports/autoresearch-candidate-ledger.md
+++ b/docs/reports/autoresearch-candidate-ledger.md
@@ -95,7 +95,7 @@ FAMILIES=breakout_retest_overlay MAX_RUNS=50 ./scripts/run_autoresearch_campaign
 | Priority | Action | Status |
 |----------|--------|--------|
 | 1 | Forward validation: SOL overlay live + sentiment-macro | **active** |
-| 2 | New autoresearch sweeps | **paused** |
+| 2 | Phase 7: ETH/BTC 4h regime + bounded + funding-primary | **in progress** |
 | 3 | BTC/BNB 1h, AVAX/ETH W2 #0004 | **closed** |
 
 ## Wave 4 — Bootstrap 1000 + specialist-only (2026-06-04)
@@ -153,6 +153,20 @@ Families: `trend_pullback_overlay`, `combined_focus`, `standard_gate_bridge`. Ga
 **Decision: REJECT / CLOSED.** Overlay stack **worse** than BTC standalone near-miss. Stop conditions met (Sharpe ≈ 0, P(loss) ≫ 20%, concentration high). **Do not schedule bootstrap=1000** on any Wave 6 config. BTC 1h overlay lane closed; pivot to new surfaces (longer history, bounded-density families), not more BTC 1h threshold work.
 
 Output: `research/btcusdt-1h-w6-overlay`
+
+## Wave 7 — New surfaces (2026-06-04, in progress)
+
+Per [autoresearch-next-candidate-path-2026-06-04.md](./autoresearch-next-candidate-path-2026-06-04.md). Gate: `standard`, bootstrap=100, `promotion_candidate` pre-filter required before b=1000.
+
+| Lane | Output dir | Families | Runs |
+|------|------------|----------|------|
+| ETHUSDT 4h regime | `research/ethusdt-4h-w7-eth-4h-regime` | regime_gated_pullback_overlay, breakout_retest_overlay | 80 |
+| BTCUSDT 4h regime | `research/btcusdt-4h-w7-btc-4h-regime` | same | 80 |
+| ETHUSDT 4h bounded | `research/ethusdt-4h-w8-eth-4h-bounded` | range_reversion_bounded | 50 |
+| BTCUSDT 4h bounded | `research/btcusdt-4h-w8-btc-4h-bounded` | range_reversion_bounded | 50 |
+| BTCUSDT 4h funding | `research/btcusdt-4h-w8-btc-4h-funding-primary` | funding_primary_standalone | 50 |
+
+Launcher: `scripts/run_phase7_4h_campaigns.sh`
 
 ## Wave 3 — Bridge + funding
 

--- a/docs/reports/autoresearch-candidate-ledger.md
+++ b/docs/reports/autoresearch-candidate-ledger.md
@@ -1,0 +1,79 @@
+# Autoresearch Candidate Ledger
+
+Tracks bounded autoresearch campaigns and promotion decisions. Gate profile `standard`:
+WFO trades ≥ 20, mean OOS Sharpe ≥ 0.5, OOS return > 0, max DD ≤ 10%, bootstrap P(loss) ≤ 25%,
+profit concentration ≤ 50%. Final promotion requires bootstrap=1000 revalidation.
+
+## Deployed / Tracked Candidates
+
+| Date | Symbol | TF | Family | Runs | Passes | Best artifact | WFO trades | WFO Sharpe | OOS return | Max DD | P(loss) | Concentration | Decision |
+|------|--------|-----|--------|------|--------|---------------|------------|------------|------------|--------|---------|---------------|----------|
+| 2026-06-03 | SOLUSDT | 1h | trend_pullback_overlay | 30 | 2 | `/tmp/crypto-agent-autoresearch-tracked-sol-1h-trend-pullback-overlay/archive/experiment-autopilot-20260603-205536-773725-2bdb15-20260603-155544.json` | 26 | 1.72 | 19.13% | 7.39% | 14.10% | 28.65% | DEPLOY_LIVE |
+
+Live service: `agent_sol_1h_trend_pullback_overlay_live` (`AGENT_ID=sol-1h-trend-pullback-overlay-live`).
+
+## Campaign Log
+
+| Date | Symbol | TF | Families | Runs | Passes | Near-miss | Output dir | Decision |
+|------|--------|-----|----------|------|--------|-----------|------------|----------|
+| 2026-06-03 | ETHUSDT | 1h | trend_pullback_overlay,combined_focus | 50 | 0 | 2 | `crypto-agent:/opt/crypto-agent/research/ethusdt-1h-pass1` | NEAR_MISS |
+| 2026-06-03 | ETHUSDT | 1h | near_pass_expansion,standard_gate_bridge | 50 | 0 | 1 | `crypto-agent:/opt/crypto-agent/research/ethusdt-1h-bridge` | REJECT |
+| 2026-06-03 | BNBUSDT | 1h | trend_pullback_overlay,combined_focus | 50 | 0 | 0 | `crypto-agent:/opt/crypto-agent/research/bnbusdt-1h-pass1` | REJECT |
+| 2026-06-03 | BTCUSDT | 1h | trend_pullback_overlay,combined_focus | 50 | 0 | 0 | `crypto-agent:/opt/crypto-agent/research/btcusdt-1h-pass1` | REJECT |
+| 2026-06-03 | AVAXUSDT | 1h | trend_pullback_overlay,combined_focus | 50 | 0 | 0 | `crypto-agent:/opt/crypto-agent/research/avaxusdt-1h-pass1` | REJECT |
+| 2026-06-03 | SOLUSDT | 4h | trend_pullback_overlay,combined_focus | 50 | 0 | 0 | `crypto-agent:/opt/crypto-agent/research/solusdt-4h-pass1` | REJECT |
+
+ETH pass1 best: OOS +4.05%, WFO trades 19, Sharpe 0.31 — failed DD/bootstrap/WFO count gates.
+ETH bridge best: OOS +5.09%, WFO trades 15, Sharpe 0.55 — failed WFO count / DD / bootstrap.
+BNB pass1 best: OOS +6.70%, WFO trades 26, Sharpe -0.36, conc 72% — failed Sharpe/concentration.
+BTC pass1 best: OOS -2.23%, WFO trades 16, Sharpe -0.37 — no viable near-miss.
+AVAX pass1 best: OOS +3.09%, WFO trades 60, Sharpe 0.38, **DD 23.7%**, P(loss) 84% — over-traded, risk gates fail.
+SOL 4h pass1 best: OOS +3.21%, WFO trades **6**, Sharpe 0.14 — too sparse for standard gate.
+
+Monitor: `ssh crypto-agent 'tail -f /opt/crypto-agent/research/<lane>/campaign.log'`
+
+## Decision Labels
+
+- `REJECT` — failed gates, no follow-up
+- `NEAR_MISS` — promising; bridge or probe_1h follow-up
+- `REVALIDATE_1000` — pass at bootstrap=100; schedule bootstrap=1000
+- `TRACK_CONFIG` — bootstrap=1000 pass; add tracked paper config
+- `DEPLOY_LIVE` — paper validated; live compose + Prometheus target
+
+## Independence Notes
+
+| Agent | Symbol | TF | Notes |
+|-------|--------|-----|-------|
+| agent_sol_1h_trend_pullback_overlay_live | SOLUSDT | 1h | Standard-gate technical stack + trend_pullback |
+| agent_sentiment_macro | SOLUSDT | 1h | Sentiment/macro — overlap risk for second SOL 1h technical |
+| agent_sol_sparse | SOLUSDT | 4h | trend_pullback sparse paper |
+| agent_sol_panic_block_paper | SOLUSDT | 4h | panic block paper |
+
+## Wave 2 — New signal families (code landed 2026-06-03)
+
+Families in `scripts/autoresearch_loop.py`:
+
+- `breakout_retest_overlay` — impulse breakout + retest reclaim
+- `volatility_squeeze_overlay` — BB compression → expansion breakout
+- `funding_extreme_overlay` — crowded funding mean-reversion vote
+- `regime_gated_pullback_overlay` — trend_pullback + stricter ATR + BTC regime filter
+
+| Date | Symbol | TF | Families | Runs | Passes | Output dir | Decision |
+|------|--------|-----|----------|------|--------|------------|----------|
+| 2026-06-03 | ETHUSDT | 1h | breakout_retest_overlay | 50 | — | `research/ethusdt-1h-w2a-breakout` | IN_PROGRESS |
+| 2026-06-03 | BNBUSDT | 1h | breakout_retest_overlay | 50 | — | `research/bnbusdt-1h-w2a-breakout` | IN_PROGRESS |
+| 2026-06-03 | BTCUSDT | 1h | breakout_retest_overlay | 50 | — | `research/btcusdt-1h-w2a-breakout` | IN_PROGRESS |
+| 2026-06-03 | SOLUSDT | 4h | volatility_squeeze_overlay | 50 | — | `research/solusdt-4h-w2b-squeeze` | IN_PROGRESS |
+| 2026-06-03 | AVAXUSDT | 1h | regime_gated_pullback_overlay | 50 | — | `research/avaxusdt-1h-w2b-regime` | IN_PROGRESS |
+
+Launch:
+
+```bash
+FAMILIES=breakout_retest_overlay MAX_RUNS=50 ./scripts/run_autoresearch_campaign_remote.sh ETHUSDT 1h w2a-breakout
+```
+
+## Priority Queue (remaining)
+
+**Phase 1 pass1 complete (6 lanes, 300 runs): 0 new standard passes.**
+
+After Wave 2: bootstrap=1000 on any `REVALIDATE_1000` lane; `funding_extreme_overlay` on BNB/ETH if breakout near-miss.

--- a/docs/reports/autoresearch-candidate-ledger.md
+++ b/docs/reports/autoresearch-candidate-ledger.md
@@ -81,16 +81,18 @@ FAMILIES=breakout_retest_overlay MAX_RUNS=50 ./scripts/run_autoresearch_campaign
 **Wave 2 complete (250 runs): 0 standard passes.**
 **Wave 3 complete (200 runs): 0 standard passes.** Cumulative search: **750+ runs**, **1** deployable (SOL 1h trend_pullback overlay live).
 
-## Wave 4 — Bootstrap 1000 + specialist-only (in progress)
+## Wave 4 — Bootstrap 1000 + specialist-only (2026-06-04)
 
 Tracked overlays: `config/autoresearch/overlays/`
 
-| Lane | Type | Output dir | Decision |
-|------|------|------------|----------|
-| AVAXUSDT 1h regime (W2 best) | bootstrap=1000 | `research/avaxusdt-1h-validation-b1000` | IN_PROGRESS |
-| ETHUSDT 1h breakout (W2 best) | bootstrap=1000 | `research/ethusdt-1h-validation-b1000` | IN_PROGRESS |
-| SOLUSDT 4h | `trend_pullback_standalone,volatility_squeeze_standalone,breakout_retest_standalone` | `research/solusdt-4h-w4-standalone` | IN_PROGRESS |
-| SOLUSDT 1h | `mtf_breakout_standalone` | `research/solusdt-1h-w4-mtf-breakout` | IN_PROGRESS |
+| Lane | Type | Output dir | WFO trades | OOS | Sharpe | P(loss) | Decision |
+|------|------|------------|------------|-----|--------|---------|----------|
+| AVAXUSDT 1h regime (W2 #0004) | bootstrap=1000 | `research/avaxusdt-1h-validation-b1000-b1000` | 17 | −0.72% | −0.47 | 81.1% | **REJECT** (was +6.55% @ b=100) |
+| ETHUSDT 1h breakout (W2 #0004) | bootstrap=1000 | `research/ethusdt-1h-validation-b1000-b1000` | 9 | −2.35% | −0.31 | 87.8% | **REJECT** |
+| SOLUSDT 4h standalone (50) | sparse_trend_3_2 | `research/solusdt-4h-w4-standalone` | 16 | +7.08% | 0.08 | 57.0% | **REJECT** (DD 12%, Sharpe/P(loss) fail) |
+| SOLUSDT 1h mtf_breakout (30) | standard | `research/solusdt-1h-w4-mtf-breakout` | 151 | −48.5% | −3.74 | 100% | **REJECT** (over-trades, independence risk vs live SOL) |
+
+**Takeaway:** Do not promote AVAX/ETH from Wave-2 near-misses; bootstrap=1000 collapses edge. SOL 4h without the five-vote stack does not beat prior overlay lanes. **Still 1 deployable agent** (SOL 1h trend_pullback overlay live). Combined target 8–20 trades/month requires more lanes or lower bar only after paper-forward evidence—not gate shopping.
 
 ## Wave 3 — Bridge + funding
 

--- a/docs/reports/autoresearch-candidate-ledger.md
+++ b/docs/reports/autoresearch-candidate-ledger.md
@@ -81,6 +81,17 @@ FAMILIES=breakout_retest_overlay MAX_RUNS=50 ./scripts/run_autoresearch_campaign
 **Wave 2 complete (250 runs): 0 standard passes.**
 **Wave 3 complete (200 runs): 0 standard passes.** Cumulative search: **750+ runs**, **1** deployable (SOL 1h trend_pullback overlay live).
 
+## Wave 4 — Bootstrap 1000 + specialist-only (in progress)
+
+Tracked overlays: `config/autoresearch/overlays/`
+
+| Lane | Type | Output dir | Decision |
+|------|------|------------|----------|
+| AVAXUSDT 1h regime (W2 best) | bootstrap=1000 | `research/avaxusdt-1h-validation-b1000` | IN_PROGRESS |
+| ETHUSDT 1h breakout (W2 best) | bootstrap=1000 | `research/ethusdt-1h-validation-b1000` | IN_PROGRESS |
+| SOLUSDT 4h | `trend_pullback_standalone,volatility_squeeze_standalone,breakout_retest_standalone` | `research/solusdt-4h-w4-standalone` | IN_PROGRESS |
+| SOLUSDT 1h | `mtf_breakout_standalone` | `research/solusdt-1h-w4-mtf-breakout` | IN_PROGRESS |
+
 ## Wave 3 — Bridge + funding
 
 | Date | Symbol | TF | Families | Runs | Passes | Near-miss | Output dir | Decision |

--- a/docs/reports/autoresearch-candidate-ledger.md
+++ b/docs/reports/autoresearch-candidate-ledger.md
@@ -87,7 +87,7 @@ FAMILIES=breakout_retest_overlay MAX_RUNS=50 ./scripts/run_autoresearch_campaign
 
 ## Priority Queue (remaining)
 
-**Cumulative search: ~1040+ runs**, **1** deployable (`agent_sol_1h_trend_pullback_overlay_live`).
+**Cumulative search: ~1440+ runs** (incl. Wave 7 ~400), **1** deployable (`agent_sol_1h_trend_pullback_overlay_live`).
 **Post-mortem:** [autoresearch-postmortem-2026-06-04.md](./autoresearch-postmortem-2026-06-04.md) — sweeps **paused** until live forward data or new surface brief.
 **Next candidate path:** [autoresearch-next-candidate-path-2026-06-04.md](./autoresearch-next-candidate-path-2026-06-04.md).
 **Plan overview / index:** [autoresearch-plan-overview.md](./autoresearch-plan-overview.md) — start here.

--- a/docs/reports/autoresearch-candidate-ledger.md
+++ b/docs/reports/autoresearch-candidate-ledger.md
@@ -87,12 +87,12 @@ FAMILIES=breakout_retest_overlay MAX_RUNS=50 ./scripts/run_autoresearch_campaign
 
 ## Priority Queue (remaining)
 
-**Cumulative search: ~980+ runs**, **1** deployable (`agent_sol_1h_trend_pullback_overlay_live`).
+**Cumulative search: ~1040+ runs**, **1** deployable (`agent_sol_1h_trend_pullback_overlay_live`).
 
 | Priority | Action | Status |
 |----------|--------|--------|
 | 1 | Monitor live SOL 1h + sentiment-macro forward | ongoing |
-| 2 | Wave 6 BTC 1h overlay (`w6-overlay`) | in progress |
+| 2 | Wave 6 BTC 1h overlay (`w6-overlay`) | **closed — REJECT** |
 | 3 | BNB 1h standalone / overlay | **closed** |
 | 4 | AVAX/ETH W2 #0004 | **closed** (b=1000 reject) |
 
@@ -136,21 +136,23 @@ Families: `trend_pullback_standalone`, `breakout_retest_standalone`, `volatility
 
 **Read:** BNB 1h standalone is closed (0-trade best = wrong surface, not tuning). BTC 1h standalone found a small low-risk pocket but fails trade count / Sharpe for promotion. **Still 1 deployable agent** (SOL 1h overlay live).
 
-## Wave 6 — BTCUSDT 1h overlay (in progress)
+## Wave 6 — BTCUSDT 1h overlay (2026-06-04, complete)
 
-Denser signal stack after Wave 5 BTC standalone near-miss. **BNB not continued.**
+Families: `trend_pullback_overlay`, `combined_focus`, `standard_gate_bridge`. Gate: `standard`, bootstrap=100, 60 runs.
 
-| Symbol | Output dir | Families | Runs | Gate | bootstrap |
-|--------|------------|----------|------|------|-----------|
-| BTCUSDT | `research/btcusdt-1h-w6-overlay` | `trend_pullback_overlay`, `combined_focus`, `standard_gate_bridge` | 60 | `standard` | 100 |
+| Metric | Wave 5 standalone best | Wave 6 overlay best |
+|--------|------------------------|---------------------|
+| OOS return | **+2.83%** | **−2.23%** |
+| WFO trades | 10 | 16 |
+| Sharpe | 0.58 | −0.37 |
+| Max DD | 5.5% | 10.8% |
+| P(loss) | 38% | 94% |
+| Concentration | 50.4% | 75.1% |
+| Standard passes | 0 | **0** |
 
-Stop without promotion if: best WFO trades < 15, Sharpe ≈ 0, P(loss) > 20%, or edge is concentration-only. Promote only if `eligible_for_bootstrap_1000` → bootstrap=1000 pass → low entry overlap vs SOL overlay + sentiment-macro.
+**Decision: REJECT / CLOSED.** Overlay stack **worse** than BTC standalone near-miss. Stop conditions met (Sharpe ≈ 0, P(loss) ≫ 20%, concentration high). **Do not schedule bootstrap=1000** on any Wave 6 config. BTC 1h overlay lane closed; pivot to new surfaces (longer history, bounded-density families), not more BTC 1h threshold work.
 
-```bash
-FAMILIES=trend_pullback_overlay,combined_focus,standard_gate_bridge \
-MAX_RUNS=60 GATE_PROFILE=standard BOOTSTRAP=100 \
-./scripts/run_autoresearch_campaign_remote.sh BTCUSDT 1h w6-overlay
-```
+Output: `research/btcusdt-1h-w6-overlay`
 
 ## Wave 3 — Bridge + funding
 

--- a/docs/reports/autoresearch-candidate-ledger.md
+++ b/docs/reports/autoresearch-candidate-ledger.md
@@ -121,7 +121,7 @@ Report: `docs/reports/entry-overlap-sol-1h.md` (WFO OOS, train=3mo test=2mo, ±1
 | overlay_live vs overlay_paper | 32 | 36 | 31 | 84% | 97% |
 | sentiment_macro vs overlay_paper | 2 | 36 | 0 | 0% | 0% |
 
-**Read:** Live SOL 1h overlay and sentiment-macro are **independent on OOS entry timing** (0 shared bars). Paper/live configs are the same signal stack (expected ~97% overlap). Live DB `positions` rows lack `agent_id` tagging for these services yet — use forward paper/live logs for realized overlap.
+**Read:** Live SOL 1h overlay and sentiment-macro are **independent on OOS entry timing** (0 shared bars). Paper/live configs are the same signal stack (expected ~97% overlap). Live DB `positions`/`trades` now carry real per-agent `agent_id` (`bc309ae`, deployed 2026-06-04) — realized overlap is measurable from post-deploy fills onward; pre-deploy rows are bucketed as `'default'`.
 
 ## Wave 5 — BNB/BTC 1h standalone (2026-06-04, complete)
 

--- a/docs/reports/autoresearch-candidate-ledger.md
+++ b/docs/reports/autoresearch-candidate-ledger.md
@@ -79,12 +79,15 @@ FAMILIES=breakout_retest_overlay MAX_RUNS=50 ./scripts/run_autoresearch_campaign
 **Phase 1 pass1 complete (6 lanes, 300 runs): 0 new standard passes.**
 
 **Wave 2 complete (250 runs): 0 standard passes.**
+**Wave 3 complete (200 runs): 0 standard passes.** Cumulative search: **750+ runs**, **1** deployable (SOL 1h trend_pullback overlay live).
 
-## Wave 3 — Bridge + funding (in progress)
+## Wave 3 — Bridge + funding
 
-| Date | Symbol | TF | Families | Runs | Output dir | Decision |
-|------|--------|-----|----------|------|------------|----------|
-| 2026-06-03 | ETHUSDT | 1h | breakout_retest_bridge,near_miss_trade_lift | 50 | `research/ethusdt-1h-w3-breakout-bridge` | IN_PROGRESS |
-| 2026-06-03 | AVAXUSDT | 1h | regime_gated_pullback_bridge,standard_gate_bridge | 50 | `research/avaxusdt-1h-w3-regime-bridge` | IN_PROGRESS |
-| 2026-06-03 | ETHUSDT | 1h | funding_extreme_overlay | 50 | `research/ethusdt-1h-w3-funding` | IN_PROGRESS |
-| 2026-06-03 | BNBUSDT | 1h | funding_extreme_overlay | 50 | `research/bnbusdt-1h-w3-funding` | IN_PROGRESS |
+| Date | Symbol | TF | Families | Runs | Passes | Near-miss | Output dir | Decision |
+|------|--------|-----|----------|------|--------|-----------|------------|----------|
+| 2026-06-03 | ETHUSDT | 1h | breakout_retest_bridge,near_miss_trade_lift | 50 | 0 | 3 | `research/ethusdt-1h-w3-breakout-bridge` | NEAR_MISS |
+| 2026-06-03 | AVAXUSDT | 1h | regime_gated_pullback_bridge,standard_gate_bridge | 50 | 0 | 3 | `research/avaxusdt-1h-w3-regime-bridge` | NEAR_MISS |
+| 2026-06-03 | ETHUSDT | 1h | funding_extreme_overlay | 50 | 0 | 0 | `research/ethusdt-1h-w3-funding` | REJECT |
+| 2026-06-03 | BNBUSDT | 1h | funding_extreme_overlay | 50 | 0 | 0 | `research/bnbusdt-1h-w3-funding` | REJECT |
+
+Wave 3 best: ETH breakout-bridge +3.96% OOS, 16 WFO trades, Sharpe 0.44 (still under 20 WFO trades). AVAX regime-bridge 19 trades, Sharpe -0.35. BNB funding 28 trades but Sharpe -0.16, DD 13.9%.

--- a/docs/reports/autoresearch-candidate-ledger.md
+++ b/docs/reports/autoresearch-candidate-ledger.md
@@ -1,8 +1,19 @@
 # Autoresearch Candidate Ledger
 
-Tracks bounded autoresearch campaigns and promotion decisions. Gate profile `standard`:
-WFO trades ≥ 20, mean OOS Sharpe ≥ 0.5, OOS return > 0, max DD ≤ 10%, bootstrap P(loss) ≤ 25%,
-profit concentration ≤ 50%. Final promotion requires bootstrap=1000 revalidation.
+Tracks bounded autoresearch campaigns and promotion decisions.
+
+**Goal:** find up to 10 agents, but only if each survives bootstrap=1000 **and** adds independence.
+Count is secondary to gates.
+
+| Profile | Purpose |
+|---------|---------|
+| `standard` | Discovery / campaign pass |
+| `promotion_candidate` | Pre-filter before scheduling bootstrap=1000 (stricter) |
+| bootstrap=1000 | Final promotion gate (same thresholds as `standard`) |
+
+`standard`: WFO trades ≥ 20, mean OOS Sharpe ≥ 0.5, OOS return > 0, max DD ≤ 10%, bootstrap P(loss) ≤ 25%, concentration ≤ 50%.
+
+`promotion_candidate` (required before b=1000): WFO trades ≥ 20, OOS return ≥ 1%, max DD ≤ 8%, bootstrap P(loss) ≤ 20% at b=100, concentration ≤ 40%, Sharpe ≥ 0.5. Recorded in `last_result.json` as `eligible_for_bootstrap_1000`.
 
 ## Deployed / Tracked Candidates
 

--- a/docs/reports/autoresearch-candidate-ledger.md
+++ b/docs/reports/autoresearch-candidate-ledger.md
@@ -95,7 +95,7 @@ FAMILIES=breakout_retest_overlay MAX_RUNS=50 ./scripts/run_autoresearch_campaign
 | Priority | Action | Status |
 |----------|--------|--------|
 | 1 | Forward validation: SOL overlay live + sentiment-macro | **active** |
-| 2 | Phase 7: ETH/BTC 4h regime + bounded + funding-primary | **in progress** |
+| 2 | Phase 7: ETH/BTC 4h (complete) | **0 passes** — ETH bounded near-miss only |
 | 3 | BTC/BNB 1h, AVAX/ETH W2 #0004 | **closed** |
 
 ## Wave 4 — Bootstrap 1000 + specialist-only (2026-06-04)
@@ -154,17 +154,19 @@ Families: `trend_pullback_overlay`, `combined_focus`, `standard_gate_bridge`. Ga
 
 Output: `research/btcusdt-1h-w6-overlay`
 
-## Wave 7 — New surfaces (2026-06-04, in progress)
+## Wave 7 — New surfaces (2026-06-04, complete)
 
-Per [autoresearch-next-candidate-path-2026-06-04.md](./autoresearch-next-candidate-path-2026-06-04.md). Gate: `standard`, bootstrap=100, `promotion_candidate` pre-filter required before b=1000.
+Per [autoresearch-next-candidate-path-2026-06-04.md](./autoresearch-next-candidate-path-2026-06-04.md). Gate: `standard`, bootstrap=100. **0 standard passes. 0 `promotion_candidate` eligibles.**
 
-| Lane | Output dir | Families | Runs |
-|------|------------|----------|------|
-| ETHUSDT 4h regime | `research/ethusdt-4h-w7-eth-4h-regime` | regime_gated_pullback_overlay, breakout_retest_overlay | 80 |
-| BTCUSDT 4h regime | `research/btcusdt-4h-w7-btc-4h-regime` | same | 80 |
-| ETHUSDT 4h bounded | `research/ethusdt-4h-w8-eth-4h-bounded` | range_reversion_bounded | 50 |
-| BTCUSDT 4h bounded | `research/btcusdt-4h-w8-btc-4h-bounded` | range_reversion_bounded | 50 |
-| BTCUSDT 4h funding | `research/btcusdt-4h-w8-btc-4h-funding-primary` | funding_primary_standalone | 50 |
+| Lane | Runs | Best OOS | WFO tr | Sharpe | DD | P(loss) | Decision |
+|------|------|----------|--------|--------|-----|---------|----------|
+| ETH 4h regime | 80 | −2.53% | 5 | −0.63 | 6.2% | 64% | **CLOSED** (too sparse) |
+| BTC 4h regime | 80 | −1.30% | 1 | −0.36 | 1.3% | 100% | **CLOSED** (too sparse) |
+| ETH 4h bounded | 50 | **+13.55%** | **24** | 0.48 | 20.3% | 56% | **NEAR_MISS** — DD/P(loss)/Sharpe fail |
+| BTC 4h bounded | ~78 | −15.89% | 23 | −1.05 | 26.4% | 94% | **CLOSED** |
+| BTC 4h funding-primary | 50 | 0% | **0** | — | — | 100% | **CLOSED** (no signals) |
+
+**Read:** 4h regime overlays did not improve on ETH/BTC vs 1h closed lanes. Only **ETH 4h `range_reversion_bounded`** shows positive OOS with adequate trades but fails promotion pre-filter (DD 20.3%, P(loss) 56%). Optional: one b=1000 stress-test on ETH bounded best overlay — expect reject like AVAX. **No new deployable agent.**
 
 Launcher: `scripts/run_phase7_4h_campaigns.sh`
 

--- a/docs/reports/autoresearch-candidate-ledger.md
+++ b/docs/reports/autoresearch-candidate-ledger.md
@@ -90,6 +90,7 @@ FAMILIES=breakout_retest_overlay MAX_RUNS=50 ./scripts/run_autoresearch_campaign
 **Cumulative search: ~1040+ runs**, **1** deployable (`agent_sol_1h_trend_pullback_overlay_live`).
 **Post-mortem:** [autoresearch-postmortem-2026-06-04.md](./autoresearch-postmortem-2026-06-04.md) — sweeps **paused** until live forward data or new surface brief.
 **Next candidate path:** [autoresearch-next-candidate-path-2026-06-04.md](./autoresearch-next-candidate-path-2026-06-04.md).
+**Plan overview / index:** [autoresearch-plan-overview.md](./autoresearch-plan-overview.md) — start here.
 
 | Priority | Action | Status |
 |----------|--------|--------|

--- a/docs/reports/autoresearch-candidate-ledger.md
+++ b/docs/reports/autoresearch-candidate-ledger.md
@@ -89,6 +89,7 @@ FAMILIES=breakout_retest_overlay MAX_RUNS=50 ./scripts/run_autoresearch_campaign
 
 **Cumulative search: ~1040+ runs**, **1** deployable (`agent_sol_1h_trend_pullback_overlay_live`).
 **Post-mortem:** [autoresearch-postmortem-2026-06-04.md](./autoresearch-postmortem-2026-06-04.md) — sweeps **paused** until live forward data or new surface brief.
+**Next candidate path:** [autoresearch-next-candidate-path-2026-06-04.md](./autoresearch-next-candidate-path-2026-06-04.md).
 
 | Priority | Action | Status |
 |----------|--------|--------|

--- a/docs/reports/autoresearch-candidate-ledger.md
+++ b/docs/reports/autoresearch-candidate-ledger.md
@@ -78,4 +78,13 @@ FAMILIES=breakout_retest_overlay MAX_RUNS=50 ./scripts/run_autoresearch_campaign
 
 **Phase 1 pass1 complete (6 lanes, 300 runs): 0 new standard passes.**
 
-**Wave 2 complete (250 runs): 0 standard passes.** Next: `funding_extreme_overlay` on ETH/BNB; bootstrap=1000 on AVAX/ETH best configs if bridge lifts WFO trades to 20+.
+**Wave 2 complete (250 runs): 0 standard passes.**
+
+## Wave 3 — Bridge + funding (in progress)
+
+| Date | Symbol | TF | Families | Runs | Output dir | Decision |
+|------|--------|-----|----------|------|------------|----------|
+| 2026-06-03 | ETHUSDT | 1h | breakout_retest_bridge,near_miss_trade_lift | 50 | `research/ethusdt-1h-w3-breakout-bridge` | IN_PROGRESS |
+| 2026-06-03 | AVAXUSDT | 1h | regime_gated_pullback_bridge,standard_gate_bridge | 50 | `research/avaxusdt-1h-w3-regime-bridge` | IN_PROGRESS |
+| 2026-06-03 | ETHUSDT | 1h | funding_extreme_overlay | 50 | `research/ethusdt-1h-w3-funding` | IN_PROGRESS |
+| 2026-06-03 | BNBUSDT | 1h | funding_extreme_overlay | 50 | `research/bnbusdt-1h-w3-funding` | IN_PROGRESS |

--- a/docs/reports/autoresearch-candidate-ledger.md
+++ b/docs/reports/autoresearch-candidate-ledger.md
@@ -87,10 +87,16 @@ FAMILIES=breakout_retest_overlay MAX_RUNS=50 ./scripts/run_autoresearch_campaign
 
 ## Priority Queue (remaining)
 
-**Phase 1 pass1 complete (6 lanes, 300 runs): 0 new standard passes.**
+**Cumulative search: ~980+ runs**, **1** deployable (`agent_sol_1h_trend_pullback_overlay_live`).
 
-**Wave 2 complete (250 runs): 0 standard passes.**
-**Wave 3 complete (200 runs): 0 standard passes.** Cumulative search: **750+ runs**, **1** deployable (SOL 1h trend_pullback overlay live).
+| Priority | Action | Status |
+|----------|--------|--------|
+| 1 | Monitor live SOL 1h + sentiment-macro forward | ongoing |
+| 2 | Wave 6 BTC 1h overlay (`w6-overlay`) | in progress |
+| 3 | BNB 1h standalone / overlay | **closed** |
+| 4 | AVAX/ETH W2 #0004 | **closed** (b=1000 reject) |
+
+After Wave 6: if no `promotion_candidate`, pivot to longer-history BTC/ETH regimes or new high-density bounded families — not threshold tweaks.
 
 ## Wave 4 — Bootstrap 1000 + specialist-only (2026-06-04)
 
@@ -117,14 +123,34 @@ Report: `docs/reports/entry-overlap-sol-1h.md` (WFO OOS, train=3mo test=2mo, ±1
 
 **Read:** Live SOL 1h overlay and sentiment-macro are **independent on OOS entry timing** (0 shared bars). Paper/live configs are the same signal stack (expected ~97% overlap). Live DB `positions` rows lack `agent_id` tagging for these services yet — use forward paper/live logs for realized overlap.
 
-## Wave 5 — BNB/BTC 1h standalone (in progress)
+## Wave 5 — BNB/BTC 1h standalone (2026-06-04, complete)
 
-| Symbol | Output dir | Families | Gate |
-|--------|------------|----------|------|
-| BNBUSDT | `research/bnbusdt-1h-w5b-standalone` | 3 standalone | sparse_trend_3_2 |
-| BTCUSDT | `research/btcusdt-1h-w5b-standalone` | 3 standalone | sparse_trend_3_2 |
+Families: `trend_pullback_standalone`, `breakout_retest_standalone`, `volatility_squeeze_standalone`. Gate: `sparse_trend_3_2`, bootstrap=100. Promotion pre-filter: `eligible_for_bootstrap_1000` in `last_result.json`.
 
-(w5-standalone failed: `run_autoresearch` import path; fixed in `60702e3`.)
+| Symbol | Output dir | Runs | Passes | Best OOS | WFO tr | Sharpe | Max DD | P(loss) | Conc | Decision |
+|--------|------------|------|--------|----------|--------|--------|--------|---------|------|----------|
+| BNBUSDT | `research/bnbusdt-1h-w5b-standalone` | 50 | 0 | 0% | **0** | — | — | — | — | **CLOSED** — search surface silent |
+| BTCUSDT | `research/btcusdt-1h-w5b-standalone` | 50 | 0 | +2.83% | 10 | 0.58 | 5.5% | 38% | 50.4% | **NEAR_MISS** — sparse, P(loss)/conc fail |
+
+`w5-standalone` lanes (BNB/BTC) aborted: `run_autoresearch` import path (fixed `60702e3`); no usable archive.
+
+**Read:** BNB 1h standalone is closed (0-trade best = wrong surface, not tuning). BTC 1h standalone found a small low-risk pocket but fails trade count / Sharpe for promotion. **Still 1 deployable agent** (SOL 1h overlay live).
+
+## Wave 6 — BTCUSDT 1h overlay (in progress)
+
+Denser signal stack after Wave 5 BTC standalone near-miss. **BNB not continued.**
+
+| Symbol | Output dir | Families | Runs | Gate | bootstrap |
+|--------|------------|----------|------|------|-----------|
+| BTCUSDT | `research/btcusdt-1h-w6-overlay` | `trend_pullback_overlay`, `combined_focus`, `standard_gate_bridge` | 60 | `standard` | 100 |
+
+Stop without promotion if: best WFO trades < 15, Sharpe ≈ 0, P(loss) > 20%, or edge is concentration-only. Promote only if `eligible_for_bootstrap_1000` → bootstrap=1000 pass → low entry overlap vs SOL overlay + sentiment-macro.
+
+```bash
+FAMILIES=trend_pullback_overlay,combined_focus,standard_gate_bridge \
+MAX_RUNS=60 GATE_PROFILE=standard BOOTSTRAP=100 \
+./scripts/run_autoresearch_campaign_remote.sh BTCUSDT 1h w6-overlay
+```
 
 ## Wave 3 — Bridge + funding
 

--- a/docs/reports/autoresearch-candidate-ledger.md
+++ b/docs/reports/autoresearch-candidate-ledger.md
@@ -58,13 +58,15 @@ Families in `scripts/autoresearch_loop.py`:
 - `funding_extreme_overlay` — crowded funding mean-reversion vote
 - `regime_gated_pullback_overlay` — trend_pullback + stricter ATR + BTC regime filter
 
-| Date | Symbol | TF | Families | Runs | Passes | Output dir | Decision |
-|------|--------|-----|----------|------|--------|------------|----------|
-| 2026-06-03 | ETHUSDT | 1h | breakout_retest_overlay | 50 | — | `research/ethusdt-1h-w2a-breakout` | IN_PROGRESS |
-| 2026-06-03 | BNBUSDT | 1h | breakout_retest_overlay | 50 | — | `research/bnbusdt-1h-w2a-breakout` | IN_PROGRESS |
-| 2026-06-03 | BTCUSDT | 1h | breakout_retest_overlay | 50 | — | `research/btcusdt-1h-w2a-breakout` | IN_PROGRESS |
-| 2026-06-03 | SOLUSDT | 4h | volatility_squeeze_overlay | 50 | — | `research/solusdt-4h-w2b-squeeze` | IN_PROGRESS |
-| 2026-06-03 | AVAXUSDT | 1h | regime_gated_pullback_overlay | 50 | — | `research/avaxusdt-1h-w2b-regime` | IN_PROGRESS |
+| Date | Symbol | TF | Families | Runs | Passes | Near-miss | Output dir | Decision |
+|------|--------|-----|----------|------|--------|-----------|------------|----------|
+| 2026-06-03 | ETHUSDT | 1h | breakout_retest_overlay | 50 | 0 | 3 | `research/ethusdt-1h-w2a-breakout` | NEAR_MISS |
+| 2026-06-03 | BNBUSDT | 1h | breakout_retest_overlay | 50 | 0 | 1 | `research/bnbusdt-1h-w2a-breakout` | REJECT |
+| 2026-06-03 | BTCUSDT | 1h | breakout_retest_overlay | 50 | 0 | 0 | `research/btcusdt-1h-w2a-breakout` | REJECT |
+| 2026-06-03 | SOLUSDT | 4h | volatility_squeeze_overlay | 50 | 0 | 2 | `research/solusdt-4h-w2b-squeeze` | NEAR_MISS |
+| 2026-06-03 | AVAXUSDT | 1h | regime_gated_pullback_overlay | 50 | 0 | 5 | `research/avaxusdt-1h-w2b-regime` | NEAR_MISS |
+
+Wave 2 best: AVAX regime +6.55% OOS, 18 WFO trades, P(loss) 41%; ETH breakout 19 trades but Sharpe −0.22 / P(loss) 88%.
 
 Launch:
 
@@ -76,4 +78,4 @@ FAMILIES=breakout_retest_overlay MAX_RUNS=50 ./scripts/run_autoresearch_campaign
 
 **Phase 1 pass1 complete (6 lanes, 300 runs): 0 new standard passes.**
 
-After Wave 2: bootstrap=1000 on any `REVALIDATE_1000` lane; `funding_extreme_overlay` on BNB/ETH if breakout near-miss.
+**Wave 2 complete (250 runs): 0 standard passes.** Next: `funding_extreme_overlay` on ETH/BNB; bootstrap=1000 on AVAX/ETH best configs if bridge lifts WFO trades to 20+.

--- a/docs/reports/autoresearch-next-candidate-path-2026-06-04.md
+++ b/docs/reports/autoresearch-next-candidate-path-2026-06-04.md
@@ -293,8 +293,8 @@ Decision rule:
 | 2 | Relative-strength probe | **done** — paused; do not implement RS v0 |
 | 3 | Merge `docs/relative-strength-rotation` → `main` | **open PR** |
 | 4 | Funding/crowding surface brief | **done** — `funding-crowding-primary-surface-v0.md` |
-| 5 | Cheap funding-normalization probe (BTC/ETH/SOL) | **in progress** — `probe_funding_normalization.py` |
-| 6 | Full impl + autoresearch only if probe HAS_PULSE | **blocked** until step 5 passes |
+| 5 | Cheap funding-normalization probe (BTC/ETH/SOL) | **done** — see [funding-normalization-probe-2026-06-04.md](./funding-normalization-probe-2026-06-04.md) |
+| 6 | Full impl + autoresearch only if probe HAS_PULSE | **blocked** — default thresholds failed |
 | 7 | Funding DB coverage | **done** — BTC/ETH/SOL backfilled |
 | 8 | Short-side feasibility review | **queued** |
 

--- a/docs/reports/autoresearch-next-candidate-path-2026-06-04.md
+++ b/docs/reports/autoresearch-next-candidate-path-2026-06-04.md
@@ -290,15 +290,17 @@ Decision rule:
 | Step | Action | Expected Outcome |
 |------|--------|------------------|
 | 1 | Continue forward monitoring SOL overlay + sentiment-macro | real execution/frequency evidence |
-| 2 | Implement `relative_strength_rotation_standalone` from the spec | first-principles cross-asset surface |
-| 3 | Run ETHUSDT 1h relative-strength campaign | candidate #2 search with BTC anchor |
-| 4 | Review failure mode before any second lane | prevent blind sweeps |
-| 5 | Run ETHUSDT 4h only if 1h is readable but noisy | lower-noise follow-up |
-| 6 | Funding/crowding data audit | future different primitive, not current priority |
-| 7 | Short-side feasibility review | only if execution/risk parity is proven |
+| 2 | Run `scripts/probe_relative_strength_rotation.py` on ETH/BTC 1h | frequency + crude forward-edge kill/go read |
+| 3 | Implement `relative_strength_rotation_standalone` only if the probe has a pulse | first-principles cross-asset surface justified by evidence |
+| 4 | Run ETHUSDT 1h relative-strength campaign | candidate #2 search with BTC anchor |
+| 5 | Review failure mode before any second lane | prevent blind sweeps |
+| 6 | Run ETHUSDT 4h only if 1h is readable but noisy | lower-noise follow-up |
+| 7 | Funding/crowding data audit | future different primitive, not current priority |
+| 8 | Short-side feasibility review | only if execution/risk parity is proven |
 
-Stop after each phase if no candidate reaches `promotion_candidate=true`. Do not
-chain campaigns just because compute is available.
+Stop after each phase if no candidate reaches `promotion_candidate=true`. For the
+probe step, stop before implementation if events are silent or crude forward
+excess is non-positive. Do not chain campaigns just because compute is available.
 
 ---
 

--- a/docs/reports/autoresearch-next-candidate-path-2026-06-04.md
+++ b/docs/reports/autoresearch-next-candidate-path-2026-06-04.md
@@ -287,16 +287,16 @@ Decision rule:
 
 ## Recommended Execution Order
 
-| Step | Action | Expected Outcome |
-|------|--------|------------------|
-| 1 | Continue forward monitoring SOL overlay + sentiment-macro | real execution/frequency evidence |
-| 2 | Review the failed ETH/BTC 1h relative-strength probe | 14 events / 20,508 rows, negative forward excess |
-| 3 | Reshape the probe or choose a different surface before implementation | avoid building a sparse, negative-edge surface |
-| 4 | Run ETHUSDT 1h relative-strength campaign | candidate #2 search with BTC anchor |
-| 5 | Review failure mode before any second lane | prevent blind sweeps |
-| 6 | Run ETHUSDT 4h only if 1h is readable but noisy | lower-noise follow-up |
-| 7 | Funding/crowding data audit | future different primitive, not current priority |
-| 8 | Short-side feasibility review | only if execution/risk parity is proven |
+| Step | Action | Status (2026-06-04) |
+|------|--------|---------------------|
+| 1 | Forward-monitor SOL overlay + sentiment-macro | **active** — live agents healthy; 0 post-deploy attributed fills yet |
+| 2 | Review failed ETH/BTC 1h relative-strength probe | **done** — 14 events, −0.66% mean excess vs BTC |
+| 3 | Reshape probe or choose different surface | **required** before RS full implementation |
+| 4 | ETHUSDT 1h relative-strength campaign | **blocked** (step 2 stop condition) |
+| 5 | Second RS lane | **blocked** |
+| 6 | ETHUSDT 4h RS follow-up | **blocked** |
+| 7 | Funding/crowding data audit | **done** — DB has **AVAXUSDT only**; backfill BTC/ETH/SOL before Phase 3 |
+| 8 | Short-side feasibility review | **queued** |
 
 Stop after each phase if no candidate reaches `promotion_candidate=true`. The
 initial relative-strength probe already hit the stop condition: sparse events and

--- a/docs/reports/autoresearch-next-candidate-path-2026-06-04.md
+++ b/docs/reports/autoresearch-next-candidate-path-2026-06-04.md
@@ -1,0 +1,341 @@
+# Next Candidate Search Path (June 2026)
+
+**Objective:** find 4-9 additional independent deployable agents without lowering
+promotion standards.
+
+**Current state:** one deployable technical candidate exists:
+`agent_sol_1h_trend_pullback_overlay_live`. `agent_sentiment_macro` remains live
+and historically independent from the SOL overlay on OOS entry timing.
+
+The original 5-10 agent goal is still open. The search is paused because the
+tested 1h pullback/overlay surfaces are exhausted, not because the goal is
+abandoned.
+
+---
+
+## Operating Principle
+
+Do not continue by tuning the same surface harder. The failed lanes are already
+informative:
+
+- BTC/BNB 1h standalone/overlay: closed.
+- AVAX/ETH Wave-2 near-misses: failed bootstrap=1000.
+- SOL 4h standalone and SOL 1h MTF breakout: rejected.
+- Repeated threshold/aggregator sweeps on the same stack: exhausted.
+
+The next campaign must introduce a materially different source of edge:
+
+- different timeframe,
+- different market regime,
+- different signal primitive,
+- different holding-period logic,
+- or different market microstructure input.
+
+Agent count is secondary. A second weak agent increases risk faster than it
+improves validation speed.
+
+---
+
+## Promotion Rules
+
+Every candidate still follows the same promotion path:
+
+1. Discovery run at bootstrap=100.
+2. `promotion_candidate=true` (`eligible_for_bootstrap_1000` in `last_result.json`)
+   before any bootstrap=1000 validation.
+3. Revalidation at bootstrap=1000 — **same `standard` gate profile, only
+   `--bootstrap 1000`**. There is no separate `bootstrap_1000` profile; the higher
+   iteration count is the only change.
+4. Entry-overlap analysis versus live agents.
+5. Tracked paper config, live config, risk file, compose service, and monitoring.
+
+Gate thresholds (`standard` and `promotion_candidate`) are defined once in
+[`autoresearch-candidate-ledger.md`](./autoresearch-candidate-ledger.md) and
+implemented in `GATE_PROFILES` in `scripts/run_autoresearch.py`. Do not restate
+the numbers here — they would drift. The pre-filter (`promotion_candidate`) is
+strictly tighter than `standard` on return, drawdown, P(loss), and concentration.
+
+Do not use `probe_1h` for promotion. Its `min_wfo_trades` is 15 (below the
+`standard` floor of 20), so it can tag research near-misses only.
+
+---
+
+## Phase 0 — Forward Evidence Before More Tuning
+
+Keep these live:
+
+- `agent_sol_1h_trend_pullback_overlay_live`
+- `agent_sentiment_macro`
+
+Track weekly:
+
+- entries/month,
+- closed trades,
+- realized PnL,
+- fill quality and slippage,
+- exchange-side SL/TP placement reliability,
+- max adverse excursion per trade,
+- whether both live agents lose in the same market regime.
+
+Review thresholds:
+
+| Milestone | Use |
+|-----------|-----|
+| 5 closed SOL overlay trades | sanity check execution and frequency |
+| 10 closed SOL overlay trades | first weak forward-quality read |
+| 20 closed SOL overlay trades | stronger forward validation read |
+
+This phase does not block all research, but it should block scaling notional and
+prevent more SOL 1h clones unless their entry overlap is low.
+
+**Prerequisite (blocking for realized-overlap measurement):** live DB `positions`
+rows are not yet tagged with `agent_id` for these services (see ledger,
+"Entry overlap — SOLUSDT 1h"). Until `agent_id` is written on position rows,
+"do both live agents lose in the same regime?" and the acceptance-checklist
+"entry overlap vs live agents" can only be answered from WFO/paper logs, not
+realized live fills. Add `agent_id` tagging to the live position write path
+before relying on any live-overlap number.
+
+---
+
+## Phase 1 — Longer-History 4h Regime Candidates
+
+**Why:** 1h surfaces produced too many noisy near-misses. The 4h timeframe may
+produce fewer but cleaner regime-conditioned entries and lower execution noise.
+
+Priority lanes:
+
+| Priority | Symbol | TF | Surface |
+|----------|--------|----|---------|
+| 1 | ETHUSDT | 4h | regime-conditioned trend/reversal |
+| 2 | BTCUSDT | 4h | regime-conditioned trend/reversal |
+| 3 | SOLUSDT | 4h | only if materially different from live SOL 1h |
+| 4 | AVAXUSDT | 4h | only with strict drawdown controls |
+
+Avoid BNB first; recent BNB 1h evidence was too silent or concentration-heavy.
+
+Design requirements:
+
+- explicit BTC/market regime gate,
+- no entry if ATR regime is extreme unless strategy is specifically volatility
+  breakout,
+- bounded WFO trade target: 20-60 trades,
+- avoid single-window profit concentration,
+- force long-only first unless short-side execution is separately reviewed.
+
+**Gate profile:** run discovery under `standard` (the script default), which
+requires ≥ 20 WFO trades. Do **not** drop to `sparse_trend_3_2` for 4h here — a
+4h candidate that cannot reach 20 trains/test trades is too sparse to validate at
+bootstrap=1000 and contradicts the 20-60 trade design target. If 4h proves
+structurally too sparse on every lane, that is a reason to abandon the 4h surface,
+not to lower the gate.
+
+Suggested first lane (explicit profile for clarity):
+
+```bash
+FAMILIES=regime_gated_pullback_overlay,breakout_retest_overlay \
+MAX_RUNS=80 \
+GATE_PROFILE=standard \
+./scripts/run_autoresearch_campaign_remote.sh ETHUSDT 4h w7-eth-4h-regime
+```
+
+Stop this phase if best candidates across the campaign repeatedly show any of:
+
+- WFO trades < 20 (cannot clear the `standard` gate the run is scored against),
+- Sharpe < 0.5,
+- DD > 10%,
+- P(loss) > 25%,
+- or profit concentration > 50%.
+
+These match the live `standard` gate — a "near-miss" that still fails one of
+them is not promotable, so do not keep retuning the same lane past it.
+
+---
+
+## Phase 2 — Bounded High-Density Families
+
+**Why:** The portfolio needs more than 1-2 trades/month per agent, but Wave 6
+showed that simply densifying overlays can destroy robustness. Density must be a
+design constraint, not a side effect of loosening thresholds.
+
+Define new family behavior before running broad campaigns:
+
+- target 20-80 WFO trades,
+- max one entry per symbol per N bars,
+- time-stop exits included in backtest and live parity,
+- no repeated buys in the same volatility impulse,
+- optional cooldown after stop loss,
+- reject candidates whose added trades reduce Sharpe below 0.5.
+
+Candidate family ideas:
+
+| Family | Hypothesis |
+|--------|------------|
+| `range_reversion_bounded` | Mean reversion only inside low-volatility ranges |
+| `trend_continuation_bounded` | Enter after trend confirmation and shallow pullback, capped by cooldown |
+| `volatility_breakout_bounded` | Trade squeeze expansion only with ATR and volume confirmation |
+| `regime_router_bounded` | Route between range and trend sub-strategies instead of stacking all votes |
+
+First implementation should be one family, not four at once. Start with
+`range_reversion_bounded` because it is most different from the live SOL
+trend-pullback overlay.
+
+Promotion note: high-density candidates need extra overlap analysis. A strategy
+with many trades can appear independent by symbol but still lose in the same
+market shock windows.
+
+---
+
+## Phase 3 — Funding / Carry / Crowding Surface
+
+**Why:** Funding logic is a different primitive from candle-pattern technical
+signals. Earlier funding overlays were light sweeps, not a full surface design.
+
+**Do not re-run the prior sweep.** `funding_extreme_overlay` already ran in Wave 2
+and Wave 3 on ETHUSDT and BNBUSDT (ledger "Wave 3 — Bridge + funding"): ETH/BNB
+funding 1h returned 0 near-misses and REJECT; the one BNB funding lane that traded
+(28 WFO trades) was Sharpe −0.16, DD 13.9%. That family is a single crowded-funding
+mean-reversion vote stacked onto the existing aggregator. A new attempt must change
+the surface, not the symbol — the two deltas versus that prior sweep are:
+
+- treat funding/crowding as the **primary** entry trigger, not one overlay vote;
+- condition on funding *normalization* (reversal of the extreme), not the extreme
+  level alone, to avoid entering mid-cascade.
+
+The cost-netting and cooldown requirements below were already nominal in the old
+sweep; they are necessary but not the differentiator. If the new brief reduces to
+"the same overlay vote on a new pair," skip it.
+
+Research brief:
+
+- futures only,
+- long when funding/crowding is extreme but price structure confirms reversal,
+- avoid entries directly into liquidation cascades,
+- include funding costs in expected return if available,
+- require cooldown after funding normalization.
+
+Best target symbols:
+
+- BTCUSDT,
+- ETHUSDT,
+- SOLUSDT.
+
+Avoid broad alt baskets until slippage and funding-data quality are verified.
+
+Gate additions for this surface:
+
+- positive return after funding-cost adjustment,
+- no single funding event contributes > 25-30% of profit,
+- no entry if exchange-side SL/TP placement is not supported.
+
+Run this only after confirming funding data coverage in production DB.
+
+---
+
+## Phase 4 — Short-Side / Two-Sided Candidates
+
+**Why:** Current live technical edge is long-biased. Additional agents may remain
+correlated during broad selloffs unless a controlled short-side surface exists.
+
+Precondition:
+
+- futures execution supports the exact short lifecycle safely,
+- risk manager blocks liquidation proximity for shorts,
+- notifications clearly distinguish long and short entries,
+- backtest exit model matches live futures short SL/TP behavior.
+
+Do not launch short-side live from research alone. First create a dedicated
+paper/shadow candidate and run an execution parity review.
+
+Candidate surfaces:
+
+- failed-breakdown retest short,
+- trend-continuation short in confirmed downtrend,
+- funding/crowding short when long funding is extreme.
+
+Promotion gate remains standard + bootstrap=1000, plus manual execution review.
+
+---
+
+## Phase 5 — Longer-History Validation
+
+**Why:** 2024-2026 WFO is useful but can still produce regime-specific winners.
+For any candidate that looks robust, rerun with a longer available history when
+the DB supports it.
+
+Use longer history for:
+
+- BTC 4h,
+- ETH 4h,
+- any funding/carry strategy,
+- any candidate with only 20-25 WFO trades.
+
+Decision rule:
+
+- If longer history flips OOS negative or doubles P(loss), reject.
+- If longer history lowers return but keeps positive OOS, acceptable DD, and
+  stable concentration, keep as lower-confidence `TRACK_CONFIG`.
+
+---
+
+## Recommended Execution Order
+
+| Step | Action | Expected Outcome |
+|------|--------|------------------|
+| 1 | Continue forward monitoring SOL overlay + sentiment-macro | real execution/frequency evidence |
+| 2 | ETHUSDT 4h regime-conditioned campaign | best next independent candidate surface |
+| 3 | BTCUSDT 4h regime-conditioned campaign | lower-noise BTC lane, not closed by BTC 1h result |
+| 4 | Design one bounded high-density family | avoid blind parameter sweeps |
+| 5 | Run bounded family on ETH/BTC/SOL 1h and 4h | seek 20-80 WFO trades without overtrading |
+| 6 | Funding/crowding research brief and data audit | different signal primitive |
+| 7 | Short-side feasibility review | only if execution/risk parity is proven |
+
+Stop after each phase if no candidate reaches `promotion_candidate=true`. Do not
+chain campaigns just because compute is available.
+
+---
+
+## Candidate Acceptance Checklist
+
+Before adding any new tracked config:
+
+- [ ] Standard gate passed at bootstrap=100.
+- [ ] `eligible_for_bootstrap_1000=true`.
+- [ ] bootstrap=1000 passed.
+- [ ] Entry overlap checked versus:
+  - `agent_sol_1h_trend_pullback_overlay_live`,
+  - `agent_sentiment_macro`,
+  - any other active promoted agent.
+- [ ] Profit concentration is not single-window dominated.
+- [ ] Runtime/backtest parity fields are explicit in config.
+- [ ] Risk file exists for the exact `agent_id`.
+- [ ] Compose service and Prometheus target are added only after promotion.
+- [ ] Live notional starts small; no scaling before forward evidence.
+
+---
+
+## What Not To Do
+
+- Do not rerun BTCUSDT 1h standalone/overlay without a new hypothesis.
+- Do not rerun BNBUSDT 1h standalone; the surface was silent.
+- Do not resurrect AVAX/ETH Wave-2 #0004; bootstrap=1000 rejected them.
+- Do not deploy from bootstrap=100.
+- Do not lower gates to reach 5-10 agents.
+- Do not add more SOL 1h technical variants without entry-overlap proof.
+
+---
+
+## Success Definition
+
+The next search cycle succeeds when it produces at least one additional candidate
+that:
+
+1. passes bootstrap=1000,
+2. adds low-overlap entries versus current live agents,
+3. has a documented runtime parity config,
+4. starts with conservative live risk,
+5. and improves expected combined portfolio trade count without increasing
+   correlated drawdown.
+
+The 5-10 agent target remains the long-term portfolio objective. The immediate
+next milestone is **candidate #2**, not filling all remaining slots at once.

--- a/docs/reports/autoresearch-next-candidate-path-2026-06-04.md
+++ b/docs/reports/autoresearch-next-candidate-path-2026-06-04.md
@@ -88,13 +88,13 @@ Review thresholds:
 This phase does not block all research, but it should block scaling notional and
 prevent more SOL 1h clones unless their entry overlap is low.
 
-**Prerequisite (blocking for realized-overlap measurement):** live DB `positions`
-rows are not yet tagged with `agent_id` for these services (see ledger,
-"Entry overlap — SOLUSDT 1h"). Until `agent_id` is written on position rows,
-"do both live agents lose in the same regime?" and the acceptance-checklist
-"entry overlap vs live agents" can only be answered from WFO/paper logs, not
-realized live fills. Add `agent_id` tagging to the live position write path
-before relying on any live-overlap number.
+**Prerequisite — RESOLVED (`bc309ae`, deployed 2026-06-04):** the live position
+write path now tags the real per-agent `agent_id` on `positions` and `trades`, and
+reads are agent-scoped. "Do both live agents lose in the same regime?" and the
+acceptance-checklist "entry overlap vs live agents" can now be answered from real
+fills — but only for fills **after this deploy** (pre-deploy rows were backfilled
+to the `'default'` bucket and cannot be split retroactively). Let the two live
+agents accumulate post-deploy fills before computing realized overlap.
 
 ---
 

--- a/docs/reports/autoresearch-next-candidate-path-2026-06-04.md
+++ b/docs/reports/autoresearch-next-candidate-path-2026-06-04.md
@@ -31,6 +31,12 @@ The next campaign must introduce a materially different source of edge:
 - different holding-period logic,
 - or different market microstructure input.
 
+The next selected surface is specified in
+[`../specs/relative-strength-rotation-surface-v0.md`](../specs/relative-strength-rotation-surface-v0.md):
+cross-asset relative strength rotation with controlled pullback entry. It trades
+capital rotation versus BTC/ETH anchors instead of another single-symbol
+technical threshold stack.
+
 Agent count is secondary. A second weak agent increases risk faster than it
 improves validation speed.
 
@@ -283,11 +289,11 @@ Decision rule:
 | Step | Action | Expected Outcome |
 |------|--------|------------------|
 | 1 | Continue forward monitoring SOL overlay + sentiment-macro | real execution/frequency evidence |
-| 2 | ETHUSDT 4h regime-conditioned campaign | best next independent candidate surface |
-| 3 | BTCUSDT 4h regime-conditioned campaign | lower-noise BTC lane, not closed by BTC 1h result |
-| 4 | Design one bounded high-density family | avoid blind parameter sweeps |
-| 5 | Run bounded family on ETH/BTC/SOL 1h and 4h | seek 20-80 WFO trades without overtrading |
-| 6 | Funding/crowding research brief and data audit | different signal primitive |
+| 2 | Implement `relative_strength_rotation_standalone` from the spec | first-principles cross-asset surface |
+| 3 | Run ETHUSDT 1h relative-strength campaign | candidate #2 search with BTC anchor |
+| 4 | Review failure mode before any second lane | prevent blind sweeps |
+| 5 | Run ETHUSDT 4h only if 1h is readable but noisy | lower-noise follow-up |
+| 6 | Funding/crowding data audit | future different primitive, not current priority |
 | 7 | Short-side feasibility review | only if execution/risk parity is proven |
 
 Stop after each phase if no candidate reaches `promotion_candidate=true`. Do not

--- a/docs/reports/autoresearch-next-candidate-path-2026-06-04.md
+++ b/docs/reports/autoresearch-next-candidate-path-2026-06-04.md
@@ -170,7 +170,8 @@ Define new family behavior before running broad campaigns:
 - max one entry per symbol per N bars,
 - time-stop exits included in backtest and live parity,
 - no repeated buys in the same volatility impulse,
-- optional cooldown after stop loss,
+- strategy-local cooldown after emitted exits/time stops; stop-loss cooldown only
+  if modeled by the executor/backtest path,
 - reject candidates whose added trades reduce Sharpe below 0.5.
 
 Candidate family ideas:

--- a/docs/reports/autoresearch-next-candidate-path-2026-06-04.md
+++ b/docs/reports/autoresearch-next-candidate-path-2026-06-04.md
@@ -31,11 +31,11 @@ The next campaign must introduce a materially different source of edge:
 - different holding-period logic,
 - or different market microstructure input.
 
-The next selected surface is specified in
-[`../specs/relative-strength-rotation-surface-v0.md`](../specs/relative-strength-rotation-surface-v0.md):
-cross-asset relative strength rotation with controlled pullback entry. It trades
-capital rotation versus BTC/ETH anchors instead of another single-symbol
-technical threshold stack.
+Relative strength rotation was probed and **paused** (sparse, negative excess).
+The active next surface is
+[`../specs/funding-crowding-primary-surface-v0.md`](../specs/funding-crowding-primary-surface-v0.md):
+funding/crowding as a **primary** trigger on normalization (not extreme level alone),
+net of funding cost, one entry per cycle, BTC/ETH/SOL only.
 
 Agent count is secondary. A second weak agent increases risk faster than it
 improves validation speed.
@@ -289,13 +289,13 @@ Decision rule:
 
 | Step | Action | Status (2026-06-04) |
 |------|--------|---------------------|
-| 1 | Forward-monitor SOL overlay + sentiment-macro | **active** — live agents healthy; 0 post-deploy attributed fills yet |
-| 2 | Review failed ETH/BTC 1h relative-strength probe | **done** — 14 events, −0.66% mean excess vs BTC |
-| 3 | Reshape probe or choose different surface | **required** before RS full implementation |
-| 4 | ETHUSDT 1h relative-strength campaign | **blocked** (step 2 stop condition) |
-| 5 | Second RS lane | **blocked** |
-| 6 | ETHUSDT 4h RS follow-up | **blocked** |
-| 7 | Funding/crowding data audit | **done** — DB has **AVAXUSDT only**; backfill BTC/ETH/SOL before Phase 3 |
+| 1 | Forward-monitor SOL overlay + sentiment-macro | **active** — weekly `run_entry_overlap_remote.sh` |
+| 2 | Relative-strength probe | **done** — paused; do not implement RS v0 |
+| 3 | Merge `docs/relative-strength-rotation` → `main` | **open PR** |
+| 4 | Funding/crowding surface brief | **done** — `funding-crowding-primary-surface-v0.md` |
+| 5 | Cheap funding-normalization probe (BTC/ETH/SOL) | **in progress** — `probe_funding_normalization.py` |
+| 6 | Full impl + autoresearch only if probe HAS_PULSE | **blocked** until step 5 passes |
+| 7 | Funding DB coverage | **done** — BTC/ETH/SOL backfilled |
 | 8 | Short-side feasibility review | **queued** |
 
 Stop after each phase if no candidate reaches `promotion_candidate=true`. The

--- a/docs/reports/autoresearch-next-candidate-path-2026-06-04.md
+++ b/docs/reports/autoresearch-next-candidate-path-2026-06-04.md
@@ -290,17 +290,18 @@ Decision rule:
 | Step | Action | Expected Outcome |
 |------|--------|------------------|
 | 1 | Continue forward monitoring SOL overlay + sentiment-macro | real execution/frequency evidence |
-| 2 | Run `scripts/probe_relative_strength_rotation.py` on ETH/BTC 1h | frequency + crude forward-edge kill/go read |
-| 3 | Implement `relative_strength_rotation_standalone` only if the probe has a pulse | first-principles cross-asset surface justified by evidence |
+| 2 | Review the failed ETH/BTC 1h relative-strength probe | 14 events / 20,508 rows, negative forward excess |
+| 3 | Reshape the probe or choose a different surface before implementation | avoid building a sparse, negative-edge surface |
 | 4 | Run ETHUSDT 1h relative-strength campaign | candidate #2 search with BTC anchor |
 | 5 | Review failure mode before any second lane | prevent blind sweeps |
 | 6 | Run ETHUSDT 4h only if 1h is readable but noisy | lower-noise follow-up |
 | 7 | Funding/crowding data audit | future different primitive, not current priority |
 | 8 | Short-side feasibility review | only if execution/risk parity is proven |
 
-Stop after each phase if no candidate reaches `promotion_candidate=true`. For the
-probe step, stop before implementation if events are silent or crude forward
-excess is non-positive. Do not chain campaigns just because compute is available.
+Stop after each phase if no candidate reaches `promotion_candidate=true`. The
+initial relative-strength probe already hit the stop condition: sparse events and
+non-positive crude forward excess. Do not chain campaigns just because compute is
+available.
 
 ---
 

--- a/docs/reports/autoresearch-plan-overview.md
+++ b/docs/reports/autoresearch-plan-overview.md
@@ -98,7 +98,7 @@ b=100 discovery (standard gate)
 Only **Phase 0 (forward monitoring)** is active operationally. The next research
 surface brief now exists as
 [`relative-strength-rotation-surface-v0.md`](../specs/relative-strength-rotation-surface-v0.md);
-implementation should start there instead of launching more generic sweeps.
+run the cheap feasibility probe before building the full surface.
 
 Phase numbers below match the phases in the
 [next-candidate-path doc](./autoresearch-next-candidate-path-2026-06-04.md). The
@@ -113,7 +113,7 @@ phases — it is listed separately as the active next research target.
 | 3 | `funding_primary_standalone` BTC 4h | **closed** (0 trades) |
 | 4 | Short-side / two-sided (paper + execution parity first) | queued |
 | 5 | Longer-history revalidation | per-candidate |
-| **New surface** | `relative_strength_rotation_standalone` (cross-asset, ETH/BTC anchor) | **designed**; implementation queued |
+| **New surface** | `relative_strength_rotation_standalone` (cross-asset, ETH/BTC anchor) | **designed**; feasibility probe ready |
 
 Full phase detail, gate-profile choices, and stop conditions are in the
 [next-candidate-path doc](./autoresearch-next-candidate-path-2026-06-04.md).

--- a/docs/reports/autoresearch-plan-overview.md
+++ b/docs/reports/autoresearch-plan-overview.md
@@ -1,0 +1,123 @@
+# Autoresearch Plan — Overview & Index
+
+**Purpose:** single entry point for the autoresearch candidate-search effort. Start
+here, then follow the links. This file is an index and current-state snapshot, not
+a data log — per-campaign numbers live in the ledger, and gate thresholds live in
+code.
+
+**Last updated:** 2026-06-04
+
+---
+
+## Goal
+
+Find 5–10 **independent** trading agents that each pass walk-forward + bootstrap=1000
+gates and together support ~8–20 trades/month for faster forward validation.
+
+**Count is subordinate to gates and independence.** A second weak or correlated
+agent adds risk faster than it adds validation speed.
+
+---
+
+## Current State
+
+| Item | Value |
+|------|-------|
+| Total search runs | ~1,040+ |
+| Deployable technical agents | **1** |
+| Live technical | `agent_sol_1h_trend_pullback_overlay_live` |
+| Independent live strategy | `agent_sentiment_macro` (0 shared OOS entry bars) |
+| New standard-gate passes beyond SOL | 0 |
+| Gates lowered to inflate count | No |
+| Autoresearch sweeps | **Paused** — forward evidence or new surface brief only |
+
+The bottleneck is **lack of independent edge**, not tooling. The infrastructure and
+gates behaved correctly; ~1,040 runs did not produce additional deployable edge on
+the BNB/BTC/AVAX/ETH 1h surfaces tested.
+
+---
+
+## Document Map
+
+| Doc | Role | When to read it |
+|-----|------|-----------------|
+| **This file** | Index + current-state snapshot | First |
+| [`autoresearch-postmortem-2026-06-04.md`](./autoresearch-postmortem-2026-06-04.md) | What ~1,040 runs produced and why sweeps paused | To understand *why* we're here |
+| [`autoresearch-candidate-ledger.md`](./autoresearch-candidate-ledger.md) | Per-campaign data (Waves 1–6), gate definitions, decision labels | For exact numbers / before any new run |
+| [`autoresearch-next-candidate-path-2026-06-04.md`](./autoresearch-next-candidate-path-2026-06-04.md) | Forward plan — phases, promotion pipeline, prerequisites | To plan the next campaign |
+| [`entry-overlap-sol-1h.md`](./entry-overlap-sol-1h.md) | Independence evidence (SOL overlay vs sentiment-macro) | When checking candidate independence |
+
+Gate thresholds are defined once in the ledger and implemented in `GATE_PROFILES`
+in `scripts/run_autoresearch.py`. Do not restate them elsewhere.
+
+---
+
+## Promotion Pipeline (fixed)
+
+```
+b=100 discovery (standard gate)
+   → promotion_candidate pre-filter (stricter; eligible_for_bootstrap_1000)
+   → bootstrap=1000 (same standard gate, only --bootstrap 1000)
+   → entry-overlap check vs live agents
+   → tracked paper config
+   → small live notional
+```
+
+- `standard` gate = discovery floor.
+- `promotion_candidate` = stricter pre-filter, run before spending b=1000 compute.
+- bootstrap=1000 = the real promotion gate. **Never paper/live from b=100 alone** —
+  it is what killed the AVAX/ETH Wave-2 near-misses.
+- `probe_1h` (min 15 WFO trades) may tag research near-misses only, never promote.
+
+---
+
+## Live Portfolio
+
+| Agent | Symbol | TF | Role |
+|-------|--------|-----|------|
+| `agent_sol_1h_trend_pullback_overlay_live` | SOLUSDT | 1h | Only deployable technical (standard + b=1000) |
+| `agent_sentiment_macro` | SOLUSDT | 1h | Independent sentiment/macro futures |
+| `agent_sol_sparse`, `agent_sol_panic_block_paper` | SOLUSDT | 4h | Paper research — not in promotion queue |
+
+---
+
+## Closed Surfaces (do not re-run without a new hypothesis)
+
+- BNBUSDT 1h standalone and overlay (standalone fired 0 trades — wrong surface)
+- BTCUSDT 1h standalone and overlay (Wave 5–6: sparse standalone, worse overlay)
+- AVAX / ETH Wave-2 #0004 tracked overlays (collapsed at bootstrap=1000)
+- SOL 1h `mtf_breakout_standalone` (catastrophic over-trading)
+- Repeated threshold / aggregator sweeps on the same 1h technical stack
+
+---
+
+## What Happens Next
+
+Only **Phase 0 (forward monitoring)** is active. Everything else is gated behind
+forward evidence or a new surface brief.
+
+| Phase | Focus | Status |
+|-------|-------|--------|
+| 0 | Forward-monitor SOL overlay + sentiment-macro | **active** |
+| 1 | ETH/BTC **4h** regime-conditioned candidates | queued |
+| 2 | Bounded high-density families (trade-count caps by design) | queued |
+| 3 | Funding / carry / crowding surface (not the old light sweep) | queued |
+| 4 | Short-side / two-sided (paper + execution parity first) | queued |
+| 5 | Longer-history revalidation | per-candidate |
+
+Full phase detail, gate-profile choices, and stop conditions are in the
+[next-candidate-path doc](./autoresearch-next-candidate-path-2026-06-04.md).
+
+### Known prerequisite (engineering)
+
+Live DB `positions` rows are **not yet tagged with `agent_id`** for these services.
+Until the live position write path tags `agent_id`, realized live entry-overlap
+(the independence check Phases 0–4 depend on) can only be measured from WFO/paper
+logs, not real fills. Fix this before relying on any live-overlap number.
+
+---
+
+## One-line takeaway
+
+One robust promoted agent exists. The next value is **forward validation and new
+signal-surface design**, not incremental 1h parameter search.

--- a/docs/reports/autoresearch-plan-overview.md
+++ b/docs/reports/autoresearch-plan-overview.md
@@ -108,12 +108,15 @@ forward evidence or a new surface brief.
 Full phase detail, gate-profile choices, and stop conditions are in the
 [next-candidate-path doc](./autoresearch-next-candidate-path-2026-06-04.md).
 
-### Known prerequisite (engineering)
+### Engineering prerequisite — RESOLVED (`bc309ae`, deployed 2026-06-04)
 
-Live DB `positions` rows are **not yet tagged with `agent_id`** for these services.
-Until the live position write path tags `agent_id`, realized live entry-overlap
-(the independence check Phases 0–4 depend on) can only be measured from WFO/paper
-logs, not real fills. Fix this before relying on any live-overlap number.
+The live position write path now tags the **real per-agent `agent_id`** on both
+`positions` and `trades`, and reads are agent-scoped (`src/portfolio/manager.py`).
+Realized live entry-overlap (the independence check Phases 0–4 depend on) can now
+be measured from real fills, **starting from this deploy forward**. Caveat:
+pre-deploy historical rows were backfilled to the literal `'default'` bucket and
+cannot be split per-agent retroactively — only post-`bc309ae` fills carry true
+attribution.
 
 ---
 

--- a/docs/reports/autoresearch-plan-overview.md
+++ b/docs/reports/autoresearch-plan-overview.md
@@ -95,10 +95,12 @@ b=100 discovery (standard gate)
 
 ## What Happens Next
 
-Only **Phase 0 (forward monitoring)** is active operationally. The next research
-surface brief now exists as
+Only **Phase 0 (forward monitoring)** is active operationally. The relative
+strength surface brief exists, but its first ETH/BTC 1h feasibility probe failed
+(14 events / 20,508 rows, negative forward excess), so do not proceed to full
+implementation without reshaping the probe or selecting a different surface.
+The surface brief is:
 [`relative-strength-rotation-surface-v0.md`](../specs/relative-strength-rotation-surface-v0.md);
-run the cheap feasibility probe before building the full surface.
 
 Phase numbers below match the phases in the
 [next-candidate-path doc](./autoresearch-next-candidate-path-2026-06-04.md). The
@@ -113,7 +115,7 @@ phases — it is listed separately as the active next research target.
 | 3 | `funding_primary_standalone` BTC 4h | **closed** (0 trades) |
 | 4 | Short-side / two-sided (paper + execution parity first) | queued |
 | 5 | Longer-history revalidation | per-candidate |
-| **New surface** | `relative_strength_rotation_standalone` (cross-asset, ETH/BTC anchor) | **designed**; feasibility probe ready |
+| **New surface** | `relative_strength_rotation_standalone` (cross-asset, ETH/BTC anchor) | **paused** after sparse/negative initial probe |
 
 Full phase detail, gate-profile choices, and stop conditions are in the
 [next-candidate-path doc](./autoresearch-next-candidate-path-2026-06-04.md).

--- a/docs/reports/autoresearch-plan-overview.md
+++ b/docs/reports/autoresearch-plan-overview.md
@@ -109,7 +109,7 @@ phases — it is listed separately as the active next research target.
 
 | Phase | Focus | Status |
 |-------|-------|--------|
-| 0 | Forward-monitor SOL overlay + sentiment-macro | **active** |
+| 0 | Forward-monitor SOL overlay + sentiment-macro | **active** — see [forward-validation-snapshot-2026-06-04.md](./forward-validation-snapshot-2026-06-04.md) |
 | 1 | ETH/BTC **4h** regime-conditioned | **closed** (≤5 WFO trades best) |
 | 2 | `range_reversion_bounded` ETH/BTC 4h | ETH **near_miss**; BTC **closed** |
 | 3 | `funding_primary_standalone` BTC 4h | **closed** (0 trades) |

--- a/docs/reports/autoresearch-plan-overview.md
+++ b/docs/reports/autoresearch-plan-overview.md
@@ -29,7 +29,7 @@ agent adds risk faster than it adds validation speed.
 | Independent live strategy | `agent_sentiment_macro` (0 shared OOS entry bars) |
 | New standard-gate passes beyond SOL | 0 |
 | Gates lowered to inflate count | No |
-| Autoresearch sweeps | **Active** — Phase 1–3 (4h / bounded / funding-primary) per next-candidate-path |
+| Autoresearch sweeps | **Paused** after Wave 7 (0 passes; ETH 4h bounded near-miss only) |
 
 The bottleneck is **lack of independent edge**, not tooling. The infrastructure and
 gates behaved correctly; ~1,040 runs did not produce additional deployable edge on
@@ -99,9 +99,9 @@ forward evidence or a new surface brief.
 | Phase | Focus | Status |
 |-------|-------|--------|
 | 0 | Forward-monitor SOL overlay + sentiment-macro | **active** |
-| 1 | ETH/BTC **4h** regime-conditioned candidates | **in progress** (`w7-*-4h-regime`) |
-| 2 | `range_reversion_bounded` on ETH/BTC 4h | **in progress** (`w8-*-4h-bounded`) |
-| 3 | `funding_primary_standalone` on BTC 4h | **in progress** (`w8-btc-4h-funding-primary`) |
+| 1 | ETH/BTC **4h** regime-conditioned | **closed** (≤5 WFO trades best) |
+| 2 | `range_reversion_bounded` ETH/BTC 4h | ETH **near_miss**; BTC **closed** |
+| 3 | `funding_primary_standalone` BTC 4h | **closed** (0 trades) |
 | 4 | Short-side / two-sided (paper + execution parity first) | queued |
 | 5 | Longer-history revalidation | per-candidate |
 

--- a/docs/reports/autoresearch-plan-overview.md
+++ b/docs/reports/autoresearch-plan-overview.md
@@ -23,7 +23,7 @@ agent adds risk faster than it adds validation speed.
 
 | Item | Value |
 |------|-------|
-| Total search runs | ~1,040+ |
+| Total search runs | ~1,440+ (incl. Wave 7 ~400) |
 | Deployable technical agents | **1** |
 | Live technical | `agent_sol_1h_trend_pullback_overlay_live` |
 | Independent live strategy | `agent_sentiment_macro` (0 shared OOS entry bars) |
@@ -32,8 +32,8 @@ agent adds risk faster than it adds validation speed.
 | Autoresearch sweeps | **Paused** after Wave 7 (0 passes; ETH 4h bounded near-miss only) |
 
 The bottleneck is **lack of independent edge**, not tooling. The infrastructure and
-gates behaved correctly; ~1,040 runs did not produce additional deployable edge on
-the BNB/BTC/AVAX/ETH 1h surfaces tested.
+gates behaved correctly; ~1,440 runs did not produce additional deployable edge on
+the BNB/BTC/AVAX/ETH 1h and ETH/BTC 4h surfaces tested.
 
 ---
 

--- a/docs/reports/autoresearch-plan-overview.md
+++ b/docs/reports/autoresearch-plan-overview.md
@@ -29,7 +29,7 @@ agent adds risk faster than it adds validation speed.
 | Independent live strategy | `agent_sentiment_macro` (0 shared OOS entry bars) |
 | New standard-gate passes beyond SOL | 0 |
 | Gates lowered to inflate count | No |
-| Autoresearch sweeps | **Paused** — forward evidence or new surface brief only |
+| Autoresearch sweeps | **Active** — Phase 1–3 (4h / bounded / funding-primary) per next-candidate-path |
 
 The bottleneck is **lack of independent edge**, not tooling. The infrastructure and
 gates behaved correctly; ~1,040 runs did not produce additional deployable edge on
@@ -99,9 +99,9 @@ forward evidence or a new surface brief.
 | Phase | Focus | Status |
 |-------|-------|--------|
 | 0 | Forward-monitor SOL overlay + sentiment-macro | **active** |
-| 1 | ETH/BTC **4h** regime-conditioned candidates | queued |
-| 2 | Bounded high-density families (trade-count caps by design) | queued |
-| 3 | Funding / carry / crowding surface (not the old light sweep) | queued |
+| 1 | ETH/BTC **4h** regime-conditioned candidates | **in progress** (`w7-*-4h-regime`) |
+| 2 | `range_reversion_bounded` on ETH/BTC 4h | **in progress** (`w8-*-4h-bounded`) |
+| 3 | `funding_primary_standalone` on BTC 4h | **in progress** (`w8-btc-4h-funding-primary`) |
 | 4 | Short-side / two-sided (paper + execution parity first) | queued |
 | 5 | Longer-history revalidation | per-candidate |
 

--- a/docs/reports/autoresearch-plan-overview.md
+++ b/docs/reports/autoresearch-plan-overview.md
@@ -42,6 +42,7 @@ the BNB/BTC/AVAX/ETH 1h and ETH/BTC 4h surfaces tested.
 | Doc | Role | When to read it |
 |-----|------|-----------------|
 | **This file** | Index + current-state snapshot | First |
+| [`candidate-search-options-2026-06-04.md`](./candidate-search-options-2026-06-04.md) | **Options A–G** — what to do next, trade-offs, commands | When choosing next surface |
 | [`autoresearch-postmortem-2026-06-04.md`](./autoresearch-postmortem-2026-06-04.md) | What ~1,040 runs produced and why sweeps paused | To understand *why* we're here |
 | [`autoresearch-candidate-ledger.md`](./autoresearch-candidate-ledger.md) | Per-campaign data (Waves 1–6), gate definitions, decision labels | For exact numbers / before any new run |
 | [`autoresearch-next-candidate-path-2026-06-04.md`](./autoresearch-next-candidate-path-2026-06-04.md) | Forward plan — phases, promotion pipeline, prerequisites | To plan the next campaign |

--- a/docs/reports/autoresearch-plan-overview.md
+++ b/docs/reports/autoresearch-plan-overview.md
@@ -45,6 +45,7 @@ the BNB/BTC/AVAX/ETH 1h and ETH/BTC 4h surfaces tested.
 | [`autoresearch-postmortem-2026-06-04.md`](./autoresearch-postmortem-2026-06-04.md) | What ~1,040 runs produced and why sweeps paused | To understand *why* we're here |
 | [`autoresearch-candidate-ledger.md`](./autoresearch-candidate-ledger.md) | Per-campaign data (Waves 1–6), gate definitions, decision labels | For exact numbers / before any new run |
 | [`autoresearch-next-candidate-path-2026-06-04.md`](./autoresearch-next-candidate-path-2026-06-04.md) | Forward plan — phases, promotion pipeline, prerequisites | To plan the next campaign |
+| [`../specs/relative-strength-rotation-surface-v0.md`](../specs/relative-strength-rotation-surface-v0.md) | First-principles surface brief: cross-asset relative strength rotation | Before implementing the next research family |
 | [`entry-overlap-sol-1h.md`](./entry-overlap-sol-1h.md) | Independence evidence (SOL overlay vs sentiment-macro) | When checking candidate independence |
 
 Gate thresholds are defined once in the ledger and implemented in `GATE_PROFILES`
@@ -93,8 +94,10 @@ b=100 discovery (standard gate)
 
 ## What Happens Next
 
-Only **Phase 0 (forward monitoring)** is active. Everything else is gated behind
-forward evidence or a new surface brief.
+Only **Phase 0 (forward monitoring)** is active operationally. The next research
+surface brief now exists as
+[`relative-strength-rotation-surface-v0.md`](../specs/relative-strength-rotation-surface-v0.md);
+implementation should start there instead of launching more generic sweeps.
 
 | Phase | Focus | Status |
 |-------|-------|--------|
@@ -102,7 +105,7 @@ forward evidence or a new surface brief.
 | 1 | ETH/BTC **4h** regime-conditioned | **closed** (≤5 WFO trades best) |
 | 2 | `range_reversion_bounded` ETH/BTC 4h | ETH **near_miss**; BTC **closed** |
 | 3 | `funding_primary_standalone` BTC 4h | **closed** (0 trades) |
-| 4 | Short-side / two-sided (paper + execution parity first) | queued |
+| 4 | `relative_strength_rotation_standalone` | **designed**; implementation queued |
 | 5 | Longer-history revalidation | per-candidate |
 
 Full phase detail, gate-profile choices, and stop conditions are in the

--- a/docs/reports/autoresearch-plan-overview.md
+++ b/docs/reports/autoresearch-plan-overview.md
@@ -99,14 +99,20 @@ surface brief now exists as
 [`relative-strength-rotation-surface-v0.md`](../specs/relative-strength-rotation-surface-v0.md);
 implementation should start there instead of launching more generic sweeps.
 
+Phase numbers below match the phases in the
+[next-candidate-path doc](./autoresearch-next-candidate-path-2026-06-04.md). The
+relative-strength surface is a **new surface brief**, not one of those legacy
+phases — it is listed separately as the active next research target.
+
 | Phase | Focus | Status |
 |-------|-------|--------|
 | 0 | Forward-monitor SOL overlay + sentiment-macro | **active** |
 | 1 | ETH/BTC **4h** regime-conditioned | **closed** (≤5 WFO trades best) |
 | 2 | `range_reversion_bounded` ETH/BTC 4h | ETH **near_miss**; BTC **closed** |
 | 3 | `funding_primary_standalone` BTC 4h | **closed** (0 trades) |
-| 4 | `relative_strength_rotation_standalone` | **designed**; implementation queued |
+| 4 | Short-side / two-sided (paper + execution parity first) | queued |
 | 5 | Longer-history revalidation | per-candidate |
+| **New surface** | `relative_strength_rotation_standalone` (cross-asset, ETH/BTC anchor) | **designed**; implementation queued |
 
 Full phase detail, gate-profile choices, and stop conditions are in the
 [next-candidate-path doc](./autoresearch-next-candidate-path-2026-06-04.md).

--- a/docs/reports/autoresearch-plan-overview.md
+++ b/docs/reports/autoresearch-plan-overview.md
@@ -45,7 +45,8 @@ the BNB/BTC/AVAX/ETH 1h and ETH/BTC 4h surfaces tested.
 | [`autoresearch-postmortem-2026-06-04.md`](./autoresearch-postmortem-2026-06-04.md) | What ~1,040 runs produced and why sweeps paused | To understand *why* we're here |
 | [`autoresearch-candidate-ledger.md`](./autoresearch-candidate-ledger.md) | Per-campaign data (Waves 1–6), gate definitions, decision labels | For exact numbers / before any new run |
 | [`autoresearch-next-candidate-path-2026-06-04.md`](./autoresearch-next-candidate-path-2026-06-04.md) | Forward plan — phases, promotion pipeline, prerequisites | To plan the next campaign |
-| [`../specs/relative-strength-rotation-surface-v0.md`](../specs/relative-strength-rotation-surface-v0.md) | First-principles surface brief: cross-asset relative strength rotation | Before implementing the next research family |
+| [`../specs/funding-crowding-primary-surface-v0.md`](../specs/funding-crowding-primary-surface-v0.md) | Active surface brief: funding normalization primary | Before funding probe / implementation |
+| [`../specs/relative-strength-rotation-surface-v0.md`](../specs/relative-strength-rotation-surface-v0.md) | Paused: cross-asset relative strength rotation | Do not implement until probe redesign passes |
 | [`relative-strength-rotation-implementation-summary-2026-06-04.md`](./relative-strength-rotation-implementation-summary-2026-06-04.md) | Implementation summary, missing code, and launch checklist for relative strength rotation | Before assigning implementation work |
 | [`entry-overlap-sol-1h.md`](./entry-overlap-sol-1h.md) | Independence evidence (SOL overlay vs sentiment-macro) | When checking candidate independence |
 
@@ -115,7 +116,7 @@ phases — it is listed separately as the active next research target.
 | 3 | `funding_primary_standalone` BTC 4h | **closed** (0 trades) |
 | 4 | Short-side / two-sided (paper + execution parity first) | queued |
 | 5 | Longer-history revalidation | per-candidate |
-| **New surface** | `relative_strength_rotation_standalone` (cross-asset, ETH/BTC anchor) | **paused** after sparse/negative initial probe |
+| **New surface** | `funding_normalization` primary (BTC/ETH/SOL) | **probe** — RS rotation **paused** |
 
 Full phase detail, gate-profile choices, and stop conditions are in the
 [next-candidate-path doc](./autoresearch-next-candidate-path-2026-06-04.md).

--- a/docs/reports/autoresearch-plan-overview.md
+++ b/docs/reports/autoresearch-plan-overview.md
@@ -116,7 +116,7 @@ phases — it is listed separately as the active next research target.
 | 3 | `funding_primary_standalone` BTC 4h | **closed** (0 trades) |
 | 4 | Short-side / two-sided (paper + execution parity first) | queued |
 | 5 | Longer-history revalidation | per-candidate |
-| **New surface** | `funding_normalization` primary (BTC/ETH/SOL) | **probe** — RS rotation **paused** |
+| **New surface** | `funding_normalization` primary (BTC/ETH/SOL) | **probe done** — default thresholds NO_PULSE/SPARSE; reshape before impl |
 
 Full phase detail, gate-profile choices, and stop conditions are in the
 [next-candidate-path doc](./autoresearch-next-candidate-path-2026-06-04.md).

--- a/docs/reports/autoresearch-plan-overview.md
+++ b/docs/reports/autoresearch-plan-overview.md
@@ -46,6 +46,7 @@ the BNB/BTC/AVAX/ETH 1h and ETH/BTC 4h surfaces tested.
 | [`autoresearch-candidate-ledger.md`](./autoresearch-candidate-ledger.md) | Per-campaign data (Waves 1–6), gate definitions, decision labels | For exact numbers / before any new run |
 | [`autoresearch-next-candidate-path-2026-06-04.md`](./autoresearch-next-candidate-path-2026-06-04.md) | Forward plan — phases, promotion pipeline, prerequisites | To plan the next campaign |
 | [`../specs/relative-strength-rotation-surface-v0.md`](../specs/relative-strength-rotation-surface-v0.md) | First-principles surface brief: cross-asset relative strength rotation | Before implementing the next research family |
+| [`relative-strength-rotation-implementation-summary-2026-06-04.md`](./relative-strength-rotation-implementation-summary-2026-06-04.md) | Implementation summary, missing code, and launch checklist for relative strength rotation | Before assigning implementation work |
 | [`entry-overlap-sol-1h.md`](./entry-overlap-sol-1h.md) | Independence evidence (SOL overlay vs sentiment-macro) | When checking candidate independence |
 
 Gate thresholds are defined once in the ledger and implemented in `GATE_PROFILES`

--- a/docs/reports/autoresearch-postmortem-2026-06-04.md
+++ b/docs/reports/autoresearch-postmortem-2026-06-04.md
@@ -159,3 +159,16 @@ Each new lane needs: hypothesis, independence plan (entry overlap vs live agents
 ## Conclusion
 
 One robust, promoted agent exists: **SOLUSDT 1h trend_pullback overlay live**. The search infrastructure and gates behaved correctly; ~1,040 runs did not produce additional deployable independent edge on BNB/BTC/AVAX/ETH 1h surfaces tested. **Next value is forward validation and new signal design—not incremental parameter search.**
+
+---
+
+## Addendum — Wave 7 (2026-06-04, after this post-mortem)
+
+This post-mortem's "new surfaces only" recommendation (longer-history BTC/ETH 4h, bounded high-density families, funding logic) was then **executed as Wave 7** — and all of it closed. ~400 additional runs (cumulative ~1,440), **0 standard passes, 0 `promotion_candidate` eligibles**:
+
+- ETH/BTC **4h regime** overlays — too sparse (best 1–5 WFO trades). CLOSED.
+- **BTC 4h `range_reversion_bounded`** — −15.89% OOS, DD 26.4%, P(loss) 94%. CLOSED.
+- **BTC 4h funding-primary** — 0 trades (same silent-surface failure as BNB 1h standalone). CLOSED.
+- **ETH 4h `range_reversion_bounded`** — +13.55% OOS, 24 trades, but DD 20.3% / P(loss) 56% / Sharpe 0.48. Near-miss only; not `promotion_candidate`.
+
+Detail in the [ledger](./autoresearch-candidate-ledger.md) Wave 7 section. **Conclusion unchanged: still 1 deployable agent; the bottleneck remains independent edge, and Wave 7 confirms 4h/bounded/funding-primary did not supply it.** The next attempt needs a genuinely new surface brief, not a retune of these lanes.

--- a/docs/reports/autoresearch-postmortem-2026-06-04.md
+++ b/docs/reports/autoresearch-postmortem-2026-06-04.md
@@ -1,0 +1,161 @@
+# Autoresearch Post-Mortem (June 2026)
+
+**Period:** 2026-06-03 — 2026-06-04
+**Objective:** Find up to 10 independent trading agents that pass standard walk-forward/bootstrap gates and together support ~8–20 trades/month for faster forward validation.
+**Outcome:** One candidate validated and deployed. All other lanes closed or rejected. **Autoresearch sweeps paused** until live forward data or a materially new signal surface.
+
+Detail ledger: [autoresearch-candidate-ledger.md](./autoresearch-candidate-ledger.md)
+
+---
+
+## Executive Summary
+
+| Metric | Value |
+|--------|-------|
+| Total search runs | ~1,040+ |
+| Standard-gate passes (new) | 0 beyond SOL |
+| Deployable technical agents | **1** |
+| Live technical | `agent_sol_1h_trend_pullback_overlay_live` |
+| Independent live strategy | `agent_sentiment_macro` |
+| Gates lowered to inflate count | **No** |
+
+The process worked: weak candidates were filtered at bootstrap=1000; near-misses did not survive promotion; BNB/BTC 1h surfaces were closed when evidence showed no robust edge. The bottleneck is **lack of independent edge**, not tooling.
+
+---
+
+## What Was Deployed
+
+**SOLUSDT 1h `trend_pullback_overlay`** — the only configuration that passed:
+
+- Standard gate at bootstrap=100 (WFO discovery)
+- Full promotion path including bootstrap=1000
+- Live service: `agent_sol_1h_trend_pullback_overlay_live`
+
+Representative metrics at promotion (bootstrap=100): ~26 WFO trades, +19% compound OOS, Sharpe ~1.7, max DD ~7.4%, P(loss) ~14%, concentration ~29%.
+
+---
+
+## What Failed Promotion (and Why)
+
+### AVAX / ETH near-misses (Wave 2 → bootstrap=1000)
+
+Tracked configs looked acceptable at bootstrap=100 (e.g. AVAX regime +6.55% OOS, 18 trades). At **bootstrap=1000** both collapsed:
+
+| Candidate | b=100 story | b=1000 result |
+|-----------|-------------|---------------|
+| AVAX 1h regime-gated #0004 | Near-miss | −0.72% OOS, P(loss) 81% → **REJECT** |
+| ETH 1h breakout #0004 | Near-miss | −2.35% OOS, 9 trades, P(loss) 88% → **REJECT** |
+
+**Lesson:** bootstrap=100 is for discovery only; bootstrap=1000 is the real promotion gate. Do not paper or live-deploy from b=100 alone.
+
+### BNB 1h — closed
+
+| Lane | Best OOS | WFO trades | Verdict |
+|------|----------|------------|---------|
+| Pass1 overlay | +6.70% | 26 | REJECT (Sharpe −0.36, conc 72%) |
+| Wave 5 standalone | **0%** | **0** | **CLOSED** — surface too silent |
+
+Fifty standalone runs with best **zero trades** is not a tuning problem; the search surface does not fire on BNB 1h.
+
+### BTC 1h — closed
+
+| Lane | Best OOS | WFO trades | P(loss) | Verdict |
+|------|----------|------------|---------|---------|
+| Wave 5 standalone | **+2.83%** | 10 | 38% | NEAR_MISS — sparse, not deployable |
+| Wave 6 overlay | **−2.23%** | 16 | 94% | **REJECT** — worse than standalone |
+
+**Tradeoff confirmed:** standalone BTC had a small positive, low-DD pocket but too few trades and weak confidence; overlay added trades but destroyed return and bootstrap robustness. **No bootstrap=1000, no paper, no live** for BTC 1h.
+
+### Other lanes (no promotion)
+
+- Phase 1 pass1 (ETH/BNB/BTC/AVAX/SOL 4h): 0 standard passes
+- Waves 2–3 (new overlay families, bridges, funding): 0 standard passes
+- SOL 4h standalone / SOL 1h `mtf_breakout_standalone`: REJECT (gates or catastrophic over-trading)
+
+---
+
+## Standards Preserved
+
+| Rule | Status |
+|------|--------|
+| Standard gate for discovery | Unchanged |
+| `promotion_candidate` pre-filter before b=1000 | Added and kept |
+| bootstrap=1000 required for promotion | Enforced; killed AVAX/ETH |
+| No lowering gates to reach “5–10 agents” | Honored |
+| Independence check (SOL) | OOS entry overlap overlay vs sentiment-macro: **0 shared bars** |
+
+Gate reference:
+
+- **standard:** WFO trades ≥ 20, Sharpe ≥ 0.5, OOS > 0, DD ≤ 10%, P(loss) ≤ 25%, conc ≤ 50%
+- **promotion_candidate:** stricter pre-b=1000 (OOS ≥ 1%, DD ≤ 8%, P(loss) ≤ 20%, conc ≤ 40%, etc.)
+
+---
+
+## Live Portfolio (Current)
+
+| Agent | Symbol | TF | Role |
+|-------|--------|-----|------|
+| `agent_sol_1h_trend_pullback_overlay_live` | SOLUSDT | 1h | Only deployable technical (standard + b=1000) |
+| `agent_sentiment_macro` | SOLUSDT | 1h | Independent sentiment/macro futures |
+| `agent_sol_sparse` / `agent_sol_panic_block_paper` | SOLUSDT | 4h | Paper research — not promotion queue |
+
+Goal of 5–10 agents remains valid in principle, but **count is subordinate to gates and independence**. Current evidence does not support adding agents via more 1h trend-pullback or overlay parameter search.
+
+---
+
+## Closed Search Surfaces (Do Not Re-run Without New Hypothesis)
+
+- BNBUSDT 1h standalone and overlay variants
+- BTCUSDT 1h standalone and overlay (Wave 5–6)
+- AVAX/ETH Wave 2 #0004 tracked overlays
+- Repeated SOL 1h MTF standalone (over-trading risk)
+- Threshold / aggregator sweeps on the same 1h technical stack
+
+---
+
+## What Worked in the Process
+
+1. **Remote autoresearch loop** on production TimescaleDB with frozen overlays and reproducible artifacts.
+2. **bootstrap=1000** as a noise filter for near-misses.
+3. **`promotion_candidate`** to avoid wasting b=1000 runs.
+4. **Entry-overlap analysis** — justified running SOL overlay + sentiment-macro together (historical OOS timing independent).
+5. **Discipline** — stopping after Wave 6 instead of chasing BTC with more knobs.
+
+---
+
+## Recommended Next Steps
+
+### 1. Forward validation (primary)
+
+Keep **SOL 1h overlay live** and **sentiment-macro** running. Measure on real data, not more backtests:
+
+- Entries per month (vs ~1–2/month design intent for overlay)
+- Fills, slippage, SL/TP placement reliability
+- Realized PnL and drawdown
+- Loss correlation between the two live agents
+
+Do not judge profitability from the first handful of trades.
+
+### 2. Pause autoresearch sweeps
+
+No new campaigns until either:
+
+- Live SOL produces enough closed trades for a forward verdict, or
+- A **new research brief** defines a materially different surface.
+
+### 3. When research resumes — new surfaces only
+
+Candidates must differ from “another 1h trend-pullback variant”:
+
+- Longer-history **BTC/ETH 4h** with regime conditioning
+- **Bounded high-density** families (explicit trade-count caps in design)
+- **Funding / range / regime** logic (Wave 2 funding overlays were explored lightly; not exhausted, but not 1h pullback tweaks)
+- Short-side or market-neutral only if safely supported by execution and risk stack
+
+Each new lane needs: hypothesis, independence plan (entry overlap vs live agents), standard discovery, `promotion_candidate`, then bootstrap=1000.
+
+---
+
+## Conclusion
+
+One robust, promoted agent exists: **SOLUSDT 1h trend_pullback overlay live**. The search infrastructure and gates behaved correctly; ~1,040 runs did not produce additional deployable independent edge on BNB/BTC/AVAX/ETH 1h surfaces tested. **Next value is forward validation and new signal design—not incremental parameter search.**

--- a/docs/reports/autoresearch-profitability-search-2026-06-03.md
+++ b/docs/reports/autoresearch-profitability-search-2026-06-03.md
@@ -1,0 +1,241 @@
+# Autoresearch Profitability Search - 2026-06-03
+
+## Summary
+
+The Karpathy-style autoresearch loop is now implemented for this repo as a bounded,
+config-only research controller. It generated candidate YAML overlays, evaluated
+them through the fixed `experiment_autopilot` WFO/bootstrap harness, and recorded
+`keep`/`discard` decisions in TSV artifacts.
+
+The search found one candidate that clears the standard WFO/bootstrap gate:
+
+- Symbol/timeframe: `SOLUSDT 1h`
+- Tracked paper/probe config:
+  `config/settings.sol_1h_trend_pullback_overlay_paper.yaml`
+- Tracked risk guardrails:
+  `config/risk.sol-1h-trend-pullback-overlay-paper.yaml`
+- Validation artifact:
+  `/tmp/crypto-agent-autoresearch-tracked-sol-1h-trend-pullback-overlay/archive/experiment-autopilot-20260603-205536-773725-2bdb15-20260603-155544.json`
+- Gate profile: `standard`
+- Bootstrap samples: `1000`
+- Result: `PASS`
+
+The earlier threshold-only search also found one candidate worth a limited probe:
+
+- Symbol/timeframe: `SOLUSDT 1h`
+- Tracked paper/probe config:
+  `config/settings.sol_1h_probe_paper.yaml`
+- Tracked risk guardrails:
+  `config/risk.sol-1h-probe-paper.yaml`
+- Validation artifact:
+  `/tmp/crypto-agent-autoresearch-tracked-sol-1h-probe/archive/experiment-autopilot-20260603-161242-382648-8b5e0e-20260603-111250.json`
+- Gate profile: `probe_1h`
+- Result: `PASS`
+
+This is not a full production-promotion pass under the standard 1h profile. It
+passes all risk and profitability gates, but the standard aggregate WFO trade
+gate requires 20 trades and this candidate has 17.
+
+## Best Candidate
+
+### Standard-Gate Candidate
+
+| Metric | Value |
+|---|---:|
+| Full-period trades | 43 |
+| Full-period win rate | 51.16% |
+| Full-period return | 12.46% |
+| Full-period max drawdown | 7.39% |
+| Full-period Sharpe | 0.79 |
+| WFO windows | 7 |
+| Aggregate WFO trades | 26 |
+| Mean OOS Sharpe | 1.72 |
+| Compound OOS return | 19.13% |
+| Bootstrap P(loss), 1000 samples | 14.10% |
+| Profit concentration | 28.65% |
+
+This candidate adds `trend_pullback` as a complementary long-biased signal on
+top of the previous SOLUSDT 1h technical stack. It clears the standard
+trade-count gate without breaking drawdown, bootstrap loss, or concentration
+limits.
+
+### Earlier Probe Candidate
+
+| Metric | Value |
+|---|---:|
+| Full-period trades | 27 |
+| Full-period win rate | 51.85% |
+| Full-period return | 6.12% |
+| Full-period max drawdown | 4.55% |
+| Full-period Sharpe | 0.51 |
+| WFO windows | 7 |
+| Aggregate WFO trades | 17 |
+| Mean OOS Sharpe | 0.74 |
+| Compound OOS return | 8.98% |
+| Bootstrap P(loss), 1000 samples | 23.50% |
+| Profit concentration | 30.55% |
+
+The candidate passed `probe_1h`:
+
+```text
+min_trades: 0
+min_wfo_trades: 15
+min_wfo_sharpe: 0.5
+max_drawdown_pct: 10.0
+max_bootstrap_p_loss_pct: 25.0
+min_oos_return_pct: 0.0
+max_profit_concentration_pct: 50.0
+```
+
+It failed only this standard gate:
+
+```text
+min_wfo_trades failed (17 < 20)
+```
+
+## Search Campaigns
+
+All campaigns used local TimescaleDB indicator data and the canonical
+`scripts/run_autoresearch.py` wrapper.
+
+| Campaign | Result |
+|---|---:|
+| SOLUSDT 4h broad config search | 0 / 21 passes |
+| SOLUSDT 4h aggregator focus | 0 / 40 passes |
+| SOLUSDT 4h combined focus | 0 / 60 passes |
+| SOLUSDT 4h near-pass expansion | 0 / 80 passes |
+| BTCUSDT 4h combined focus | 0 / 40 passes |
+| ETHUSDT 4h combined focus | 0 / 40 passes |
+| BNBUSDT 4h combined focus | 0 / 40 passes |
+| AVAXUSDT 4h combined focus | 0 / 40 passes |
+| BNBUSDT 1h combined focus | 0 / 30 passes |
+| SOLUSDT 1h combined focus | 0 / 30 standard passes |
+| SOLUSDT 1h near-pass expansion | 0 / 100 standard passes |
+| SOLUSDT 1h standard-gate bridge | 0 / 30 standard passes |
+| SOLUSDT 1h near-miss trade lift | 0 / 30 standard passes |
+| SOLUSDT 1h trend-pullback overlay | 2 / 30 standard passes |
+
+The SOLUSDT 1h combined-focus campaign produced the best standard-gate near
+miss:
+
+```text
+OOS return: 8.98%
+OOS Sharpe: 0.74
+Max DD: 4.55%
+Bootstrap P(loss): 23.50% after 1000-sample validation
+Profit concentration: 30.55%
+WFO trades: 17
+```
+
+The later SOLUSDT 1h standard-gate bridge campaign did not beat that standard
+score. Its best candidate improved return quality but became too sparse in OOS
+walk-forward windows:
+
+```text
+Campaign artifact: /tmp/crypto-agent-autoresearch-sol-1h-standard-bridge-local-escalated-30
+Best bridge score: -7.0
+Full trades: 21
+WFO trades: 13
+OOS return: 10.28%
+OOS Sharpe: 0.95
+Max DD: 4.61%
+Bootstrap P(loss): 19.00%
+Profit concentration: 27.26%
+Failure: min_wfo_trades failed (13 < 20)
+```
+
+The bridge campaign confirms the current tradeoff: moving far enough to reach
+20+ WFO trades usually raises bootstrap loss and weakens Sharpe, while stricter
+high-quality variants remain below the standard WFO trade-count gate.
+
+The near-miss trade-lift campaign reproduced the best standard near miss but
+did not solve the WFO trade-count gate:
+
+```text
+Campaign artifact: /tmp/crypto-agent-autoresearch-sol-1h-near-miss-lift-local-escalated-30
+Best lift score: -3.0
+Full trades: 27
+WFO trades: 17
+OOS return: 8.98%
+OOS Sharpe: 0.74
+Max DD: 4.55%
+Bootstrap P(loss): 22.00% with 100 samples
+Profit concentration: 30.55%
+Failure: min_wfo_trades failed (17 < 20)
+```
+
+This reinforces the current conclusion: the existing indicator/aggregator surface
+has a narrow robust pocket around 16-17 WFO trades. Attempts to lift trade count
+to 20+ on this surface usually admit lower-quality trades and break bootstrap
+or Sharpe gates.
+
+The trend-pullback overlay campaign changed the result by adding a complementary
+trend-consistent entry source instead of loosening the same threshold surface:
+
+```text
+Campaign artifact: /tmp/crypto-agent-autoresearch-sol-1h-trend-pullback-overlay-local-escalated-30
+Passing candidates: 2 / 30
+Best validation artifact: /tmp/crypto-agent-autoresearch-tracked-sol-1h-trend-pullback-overlay/archive/experiment-autopilot-20260603-205536-773725-2bdb15-20260603-155544.json
+Best standard score: 101922.767413
+Full trades: 43
+WFO trades: 26
+OOS return: 19.13%
+OOS Sharpe: 1.72
+Max DD: 7.39%
+Bootstrap P(loss): 14.10% with 1000 samples
+Profit concentration: 28.65%
+Result: standard gate PASS
+```
+
+## Interpretation
+
+The original live-bleed problem was partly a parity and risk-control issue, but
+the profitability search shows a separate strategy-edge constraint:
+
+- Strict filters can produce low drawdown and positive OOS return, but they were
+  too sparse on the original threshold-only surface.
+- Loosening thresholds increased trade count but worsened drawdown and bootstrap
+  loss probability.
+- Adding `trend_pullback` as a complementary signal added enough WFO trades while
+  keeping risk gates intact.
+- The strongest current candidate clears the standard research gate, but should
+  still move only to paper/shadow validation before live promotion.
+
+## Recommendation
+
+Treat the `SOLUSDT 1h trend-pullback overlay` candidate as the current paper
+validation candidate. It clears the standard WFO/bootstrap gate, but live
+promotion still requires paper/shadow observation and operator review.
+
+The tracked config is intentionally paper/probe-safe by default:
+
+```text
+mode: paper
+trading_execution.enabled: false
+futures.enabled: false
+futures.test_mode: true
+```
+
+## Operational Status
+
+The standard-gate candidate is wired as an opt-in production paper service in
+`docker-compose.prod.yml`:
+
+```text
+agent_sol_1h_trend_pullback_overlay_paper
+AGENT_ID=sol-1h-trend-pullback-overlay-paper
+SETTINGS_PATH=config/settings.sol_1h_trend_pullback_overlay_paper.yaml
+```
+
+The service remains commented out by default. Enable it only for paper/shadow
+validation. When enabled, also add a matching target to
+`config/prometheus/agents.json`; while it is disabled, leaving it out prevents
+false down-target alerts.
+
+The runtime risk manager will load the dedicated guardrails automatically from:
+
+```text
+config/risk.sol-1h-trend-pullback-overlay-paper.yaml
+```
+
+because the filename matches the agent id.

--- a/docs/reports/candidate-search-options-2026-06-04.md
+++ b/docs/reports/candidate-search-options-2026-06-04.md
@@ -1,0 +1,212 @@
+# Candidate Search Options — June 2026
+
+**Portfolio goal (still open):** 5–10 **independent** agents, each passing standard +
+bootstrap=1000 gates. **Current:** 1 deployable technical (`agent_sol_1h_trend_pullback_overlay_live`)
++ `agent_sentiment_macro` (independent on OOS entries).
+
+**Principle:** agent count is subordinate to gates and independence. A correlated
+second agent adds risk faster than it adds validation speed.
+
+This document elaborates **what to do next**, with trade-offs, after ~1,440+
+autoresearch runs, Wave 7 (4h surfaces), relative-strength probe failure, and
+funding-normalization probe failure at default thresholds.
+
+---
+
+## Option A — Phase 0 forward validation (always on)
+
+**What:** Keep live agents running; measure **real** execution and independence from
+**attributed** fills (`agent_id` on positions since `bc309ae`).
+
+**Weekly command:**
+
+```bash
+./scripts/run_phase0_weekly.sh
+# or manually:
+./scripts/run_entry_overlap_remote.sh
+```
+
+**Track:**
+
+| Milestone | Why |
+|-----------|-----|
+| 5 closed SOL overlay trades | Execution sanity, frequency |
+| 10 closed | Weak forward-quality read |
+| 20 closed | Stronger validation read |
+
+**Also watch:** fill/slippage, exchange SL/TP placement, correlated losses with
+sentiment-macro on the same SOL regime.
+
+**Pros:** Uses real money path; no research compute; validates the one promoted edge.
+**Cons:** Slow (~1–2 trades/month on overlay); does not by itself create candidate #2.
+**When to prefer:** Always — this is the floor. Do not scale notional until milestones pass.
+
+**Status:** Active. Live overlap DB rows still **0** — too early for realized overlap;
+OOS overlap remains **0** shared entries vs sentiment-macro.
+
+---
+
+## Option B — Funding normalization primary (reshape, not abandon yet)
+
+**What:** Treat funding/crowding as the **primary** trigger when funding **normalizes**
+from an extreme, net of funding drag, one entry per cycle.
+
+**Already done:**
+
+- Surface brief: `docs/specs/funding-crowding-primary-surface-v0.md`
+- Probe: `scripts/probe_funding_normalization.py`
+- DB coverage: BTC/ETH/SOL backfilled
+- Default-threshold prod result: **NO_PULSE / SPARSE / negative net** — see
+  `funding-normalization-probe-2026-06-04.md`
+
+**Why defaults failed:**
+
+| Symbol | Issue |
+|--------|--------|
+| BTC/ETH | Never reached −0.05% funding in 2024–2026; long-side extreme is rare |
+| SOL | Only 6 normalization events at −0.05%; net forward negative; concentration fail |
+
+**Reshape sub-options (run before any implementation):**
+
+| Sub-option | Command / tool | Hypothesis |
+|------------|----------------|------------|
+| **B1 Fixed lower entry** | `--entry-threshold 0.00015` | More events; ETH ~12, SOL ~53 — still SPARSE/WEAK_EDGE |
+| **B2 Per-symbol negative tail** | `run_funding_probe_reshape.py` scenario `neg_tail_5pct` | Threshold = 5% most negative observed rate per symbol |
+| **B3 Short-side normalization (probe only)** | `--include-short-events` / `both_norm_probe` | BTC/ETH crowding is often **positive** funding; shorts deferred for live until parity review |
+| **B4 Longer hold windows** | `--forward-bars-24h 48` | Normalization edge may appear slower than 12h |
+| **B5 Price confirmation gate** | Add to probe v2: only fire if RSI/EMA agree | Reduces false normalizations in chop |
+
+**Decision rule (unchanged):**
+
+- Implement `funding_normalization_standalone` **only** if some scenario gets
+  **HAS_PULSE**: ≥20 long events, positive mean **net** 12h or 24h, concentration ≤30%.
+
+**Pros:** Different primitive from exhausted 1h technical stack; data now exists.
+**Cons:** First probe pass weak; may be structurally low edge in 2024–2026 spot bull regime.
+**When to prefer:** After reshape matrix shows at least one HAS_PULSE cell.
+
+**Run reshape matrix on prod:**
+
+```bash
+ssh crypto-agent 'cd /opt/crypto-agent && docker run --rm ... python scripts/run_funding_probe_reshape.py'
+```
+
+---
+
+## Option C — Relative strength rotation (paused)
+
+**What:** Cross-asset RS vs BTC anchor + controlled pullback.
+
+**Probe result:** 14 events / 20,508 rows, **negative** mean excess vs BTC on ETH/BTC 1h.
+
+**Reshape ideas (only if revisiting):**
+
+- Loosen RS persistence / pullback gates (probe v2)
+- SOL target vs BTC anchor (independent from live SOL overlay if entries differ)
+- 4h timeframe for fewer, cleaner events
+
+**Pros:** True cross-asset hypothesis.
+**Cons:** Failed first probe; implementation cost high (anchor plumbing, 6 components).
+**When to prefer:** Only after a **reshaped** RS probe shows positive crude excess and ≥20 events.
+
+**Status:** **Paused** — do not implement v0 spec.
+
+---
+
+## Option D — ETH 4h `range_reversion_bounded` (formal stress only)
+
+**What:** Wave 7 best near-miss: **+13.55% OOS**, 24 WFO trades; fails DD ~20%, P(loss) ~56%.
+
+**Sub-options:**
+
+| Sub-option | Action | Expected outcome |
+|------------|--------|------------------|
+| **D1 Single b=1000** | One validation run on best overlay archive | Likely reject (like AVAX Wave-2) — documents formal record |
+| **D2 Do nothing** | Skip compute | Accept near-miss as research signal only |
+
+**Pros:** Only positive OOS in Wave 7 besides SOL.
+**Cons:** Fails promotion pre-filter badly; different symbol (ETH) — independence by symbol, not proven by entries.
+**When to prefer:** D1 if you want a paper trail before closing the 4h bounded lane entirely.
+
+---
+
+## Option E — Short-side / two-sided futures (queued)
+
+**What:** Failed-breakdown short, trend short, **positive-funding normalization short**.
+
+**Preconditions (all required):**
+
+- Futures short lifecycle parity in backtest and live
+- Risk manager liquidation proximity blocks
+- Notifications label shorts clearly
+- Paper/shadow agent before live
+
+**Pros:** Portfolio may stay correlated on broad selloffs with only long agents.
+**Cons:** Engineering + risk review before any research campaign; funding probe short leg is research-only today.
+**When to prefer:** After Phase 0 proves long-side execution; funding reshape B3 may inform whether short normalization has pulse.
+
+---
+
+## Option F — New first-principles brief (if B and C fail)
+
+**What:** Stop incremental tuning; write a **new** spec (like RS and funding), probe first, then implement.
+
+**Candidate ideas (not vetted):**
+
+| Idea | Different primitive | Notes |
+|------|---------------------|-------|
+| Volatility squeeze breakout bounded | Regime expansion | Complements mean reversion |
+| Session / liquidity window router | Time microstructure | Needs session labels |
+| Cross-exchange basis / premium | Crowding | Data not in DB today |
+| Liquidation cascade proxy | Microstructure | Needs L2 or agg trades |
+
+**Pros:** Avoids repeating failed lanes.
+**Cons:** Highest spec + data cost.
+**When to prefer:** Funding reshape matrix all fail AND Phase 0 still shows only one edge.
+
+---
+
+## Option G — Merge research/ops PR and freeze sweeps
+
+**What:** Merge `docs/relative-strength-rotation` → `main` ([PR #55](https://github.com/Trujillofa/crypto-trading-agent/pull/55)).
+
+**Contains:** RS probe, funding spec/probe, Phase 0 fixes, forward snapshot, plan index updates.
+
+**Pros:** Single source of truth for humans and agents.
+**Cons:** Resolve merge conflicts (futures_executor done on branch).
+**When to prefer:** **Now** — before more campaigns.
+
+---
+
+## Recommended priority stack
+
+```text
+1. Merge PR #55 (Option G)
+2. Continue Option A weekly
+3. Run Option B reshape matrix (B1–B3); stop if no HAS_PULSE
+4. If B fails: Option F (new brief) OR Option D1 (ETH b=1000 record only)
+5. Option E only after execution parity doc exists
+6. Option C only if RS probe v2 passes
+```
+
+**Do not:** Rerun BNB/BTC 1h standalone, AVAX/ETH #0004, SOL 1h clones, or lower gates.
+
+---
+
+## Quick reference — scripts
+
+| Script | Purpose |
+|--------|---------|
+| `run_phase0_weekly.sh` | Overlap + optional PnL snapshot |
+| `run_entry_overlap_remote.sh` | SOL 1h WFO + live overlap |
+| `probe_funding_normalization.py` | Single-symbol funding probe |
+| `run_funding_probe_reshape.py` | Multi-scenario reshape matrix |
+| `probe_relative_strength_rotation.py` | RS feasibility (paused) |
+
+---
+
+## One-line takeaway
+
+The **5–10 agent goal is not failed** — it needs **independent edge**. Run Phase 0
+continuously, merge the research record, reshape funding probes once; if still no
+pulse, pick **Option F** (new brief) rather than another 1h parameter sweep.

--- a/docs/reports/candidate-search-options-2026-06-04.md
+++ b/docs/reports/candidate-search-options-2026-06-04.md
@@ -85,10 +85,16 @@ from an extreme, net of funding drag, one entry per cycle.
 **Cons:** First probe pass weak; may be structurally low edge in 2024–2026 spot bull regime.
 **When to prefer:** After reshape matrix shows at least one HAS_PULSE cell.
 
-**Run reshape matrix on prod:**
+**Reshape matrix result (prod, 2026-06-04):** Only **SOL `neg_tail_10pct`** hit
+`HAS_PULSE` (44 long events, +0.06% mean net 24h; 12h mean still negative).
+BTC/ETH best cells stay SPARSE. `both_norm_probe` adds many short events — research
+only until short parity review.
 
 ```bash
-ssh crypto-agent 'cd /opt/crypto-agent && docker run --rm ... python scripts/run_funding_probe_reshape.py'
+ssh crypto-agent 'cd /opt/crypto-agent && docker run --rm --network crypto-agent_crypto-net \
+  -v /opt/crypto-agent:/app -w /app -e PYTHONPATH=/app --env-file /opt/crypto-agent/.env \
+  -e POSTGRES_HOST=timescaledb crypto-agent-agent_sentiment_macro:latest \
+  python scripts/run_funding_probe_reshape.py'
 ```
 
 ---

--- a/docs/reports/entry-overlap-sol-1h.json
+++ b/docs/reports/entry-overlap-sol-1h.json
@@ -1,0 +1,83 @@
+{
+  "generated_at": "2026-06-04T14:35:13.842811+00:00",
+  "symbol": "SOLUSDT",
+  "timeframe": "1h",
+  "train_months": 3,
+  "test_months": 2,
+  "tolerance_hours": 1,
+  "entry_counts": [
+    {
+      "label": "sol_1h_trend_pullback_overlay_live",
+      "symbol": "SOLUSDT",
+      "entries": 32,
+      "note": null
+    },
+    {
+      "label": "sentiment_macro",
+      "symbol": "SOLUSDT",
+      "entries": 2,
+      "note": null
+    },
+    {
+      "label": "sol_1h_trend_pullback_overlay_paper",
+      "symbol": "SOLUSDT",
+      "entries": 36,
+      "note": "Second SOL 1h config variant (same signal stack as live)"
+    }
+  ],
+  "pairwise_oos": [
+    {
+      "left": "sol_1h_trend_pullback_overlay_live",
+      "right": "sentiment_macro",
+      "shared_entries": 0,
+      "left_entries": 32,
+      "right_entries": 2,
+      "jaccard": 0.0,
+      "pct_of_left_also_in_right": 0.0,
+      "pct_of_right_also_in_left": 0.0
+    },
+    {
+      "left": "sol_1h_trend_pullback_overlay_live",
+      "right": "sol_1h_trend_pullback_overlay_paper",
+      "shared_entries": 31,
+      "left_entries": 32,
+      "right_entries": 36,
+      "jaccard": 0.8378,
+      "pct_of_left_also_in_right": 96.88,
+      "pct_of_right_also_in_left": 86.11
+    },
+    {
+      "left": "sentiment_macro",
+      "right": "sol_1h_trend_pullback_overlay_paper",
+      "shared_entries": 0,
+      "left_entries": 2,
+      "right_entries": 36,
+      "jaccard": 0.0,
+      "pct_of_left_also_in_right": 0.0,
+      "pct_of_right_also_in_left": 0.0
+    }
+  ],
+  "live_entry_counts": [
+    {
+      "label": "live:sol-1h-trend-pullback-overlay-live",
+      "entries": 0
+    },
+    {
+      "label": "live:sentiment-macro-bot",
+      "entries": 0
+    }
+  ],
+  "pairwise_live": [
+    {
+      "left": "live:sol-1h-trend-pullback-overlay-live",
+      "right": "live:sentiment-macro-bot",
+      "shared_entries": 0,
+      "left_entries": 0,
+      "right_entries": 0,
+      "jaccard": 0.0,
+      "pct_of_left_also_in_right": 0.0,
+      "pct_of_right_also_in_left": 0.0
+    }
+  ],
+  "interpretation": "Low OOS entry overlap between SOL 1h overlay and sentiment-macro. A second SOL 1h agent may add diversification if it passes promotion gates independently."
+}

--- a/docs/reports/entry-overlap-sol-1h.md
+++ b/docs/reports/entry-overlap-sol-1h.md
@@ -1,0 +1,32 @@
+# Entry overlap report
+
+- Symbol: `SOLUSDT`
+- Timeframe: `1h`
+- WFO: train=3mo test=2mo
+- Tolerance: 1h
+
+## OOS entry counts (backtest)
+
+| Agent | Symbol | Entries | Note |
+|-------|--------|---------|------|
+| sol_1h_trend_pullback_overlay_live | SOLUSDT | 32 |  |
+| sentiment_macro | SOLUSDT | 2 |  |
+| sol_1h_trend_pullback_overlay_paper | SOLUSDT | 36 | Second SOL 1h config variant (same signal stack as live) |
+
+## Pairwise overlap (OOS backtest)
+
+| A | B | Shared | Jaccard | %A in B | %B in A |
+|---|---|---:|---:|---:|---:|
+| sol_1h_trend_pullback_overlay_live | sentiment_macro | 0 | 0.00% | 0.0% | 0.0% |
+| sol_1h_trend_pullback_overlay_live | sol_1h_trend_pullback_overlay_paper | 31 | 83.78% | 96.9% | 86.1% |
+| sentiment_macro | sol_1h_trend_pullback_overlay_paper | 0 | 0.00% | 0.0% | 0.0% |
+
+## Pairwise overlap (live DB)
+
+| A | B | Shared | Jaccard | %A in B | %B in A |
+|---|---|---:|---:|---:|---:|
+| live:sol-1h-trend-pullback-overlay-live | live:sentiment-macro-bot | 0 | 0.00% | 0.0% | 0.0% |
+
+## Interpretation
+
+Low OOS entry overlap between SOL 1h overlay and sentiment-macro. A second SOL 1h agent may add diversification if it passes promotion gates independently.

--- a/docs/reports/forward-validation-snapshot-2026-06-04.md
+++ b/docs/reports/forward-validation-snapshot-2026-06-04.md
@@ -1,0 +1,59 @@
+# Forward Validation Snapshot — 2026-06-04
+
+Operational read from Phase 0 of the [next-candidate-path](./autoresearch-next-candidate-path-2026-06-04.md).
+
+## Live services (Hetzner)
+
+| Service | Status |
+|---------|--------|
+| `agent_sol_1h_trend_pullback_overlay_live` | Up (healthy) |
+| `agent_sentiment_macro` | Up (healthy) |
+
+## Entry overlap (WFO OOS + live DB)
+
+Refreshed `research/entry-overlap-sol-1h.json` on production:
+
+| Pair | Shared entries | Jaccard |
+|------|----------------|---------|
+| SOL overlay live vs sentiment-macro | 0 / 32 vs 2 | 0.0 |
+| SOL overlay live vs overlay paper | 31 / 32 vs 36 | 0.84 |
+
+**Live DB (last 730d, agent-scoped):** 0 entries for both
+`sol-1h-trend-pullback-overlay-live` and `sentiment-macro-bot` — agents redeployed
+recently; accumulate fills before realized overlap is meaningful.
+
+## PnL / trade count milestones
+
+| Agent | Closed trades (DB) | Notes |
+|-------|-------------------|--------|
+| `sol-1h-trend-pullback-overlay-live` | 0 | No rows with this `agent_id` yet |
+| `sentiment-macro-bot` | 96 (historical) | Includes pre-isolation rows |
+| `default` (SOL since May) | — | Legacy bucket; do not use for forward reads |
+
+**Milestone gates:** 5 / 10 / 20 closed SOL overlay trades — not reached under
+correct `agent_id` attribution.
+
+## Relative-strength probe (research stop)
+
+ETH/BTC 1h default parameters: **14 events**, mean excess **−0.66%** vs BTC.
+Full `relative_strength_rotation_standalone` implementation remains **paused**.
+
+## Funding data audit (Phase 3 prerequisite)
+
+| Symbol | Rows | Range |
+|--------|------|-------|
+| AVAXUSDT | 3,582 | 2023-01-01 → 2026-04-08 |
+| BTCUSDT | 2,655 | 2024-01-01 → 2026-06-03 |
+| ETHUSDT | 2,655 | 2024-01-01 → 2026-06-03 |
+| SOLUSDT | 2,655 | 2024-01-01 → 2026-06-03 |
+
+**Action taken (2026-06-04):** backfilled BTC/ETH/SOL via
+`import_funding_rates.py` on production. Phase 3 funding-primary research can
+use DB coverage; still requires a new surface brief (not the old overlay vote).
+
+## Next operational steps
+
+1. Weekly re-run: `scripts/run_entry_overlap_remote.sh` + PnL by agent once fills exist.
+2. Backfill funding rates for BTC, ETH, SOL on production DB.
+3. Do not launch RS autoresearch until probe is reshaped with positive crude edge.
+4. Optional research: single bootstrap=1000 on ETH 4h `range_reversion_bounded` near-miss (formal reject record only).

--- a/docs/reports/funding-normalization-probe-2026-06-04.md
+++ b/docs/reports/funding-normalization-probe-2026-06-04.md
@@ -61,3 +61,27 @@ short** (deferred until short-side parity review).
 
 Promotion gates unchanged. Agent-count target remains **5–10**; current deployable
 technical count **1**.
+
+---
+
+## Reshape matrix (2026-06-04, production DB)
+
+Command: `python scripts/run_funding_probe_reshape.py` (see
+[`candidate-search-options-2026-06-04.md`](./candidate-search-options-2026-06-04.md)).
+
+| Scenario | BTC long | BTC net24h | ETH long | ETH net24h | SOL long | SOL net24h | Verdict (long) |
+|----------|----------|------------|----------|------------|----------|------------|----------------|
+| fixed_0.05pct | 0 | — | 0 | — | 6 | −0.20% | NO_PULSE / SPARSE |
+| fixed_0.015pct | 1 | +3.18% | 12 | +0.19% | 53 | −0.12% | SPARSE / WEAK_EDGE |
+| neg_tail_5pct | 17 | +0.45% | 18 | +0.54% | 18 | +0.99% | SPARSE (all) |
+| neg_tail_10pct | 22 | +0.26% | 26 | +0.38% | **44** | **+0.06%** | **SOL HAS_PULSE** |
+| both_norm_probe | 17+178 short | +0.45% | 18+35 short | +0.54% | 18+20 short | +0.99% | SPARSE (long leg) |
+
+**Read:** Only **SOLUSDT** with **10% negative funding tail** clears the cheap probe
+(`44` events, positive mean net on **24h only**; 12h mean still negative). BTC/ETH
+remain sparse or concentration-limited at best. **Short-side** events are numerous in
+`both_norm_probe` but are **not** cleared for live (parity review required).
+
+**Recommendation:** If pursuing funding-primary further, scope v1 to **SOL-only**
+with quantile entry, then re-run WFO/autoresearch — still must pass full
+`standard` + bootstrap=1000 + overlap checks. Do not deploy from probe alone.

--- a/docs/reports/funding-normalization-probe-2026-06-04.md
+++ b/docs/reports/funding-normalization-probe-2026-06-04.md
@@ -1,0 +1,63 @@
+# Funding Normalization Probe — 2026-06-04
+
+**Surface:** [`funding-crowding-primary-surface-v0.md`](../specs/funding-crowding-primary-surface-v0.md)
+**Script:** `scripts/probe_funding_normalization.py`
+**Window:** 2024-01-01 → 2026-06-01, 1h price bars, production TimescaleDB
+
+---
+
+## Default thresholds (probe v0)
+
+| Parameter | Value |
+|-----------|-------|
+| `entry_threshold` | 0.0005 (0.05%) |
+| `exit_threshold` | 0.00015 (0.015%) |
+| Horizons | 12h / 24h net of funding drag |
+| Concentration cap | 30% |
+
+---
+
+## Production results (default thresholds)
+
+| Symbol | Funding ticks | Long norm events | Mean net 12h | Mean net 24h | Verdict |
+|--------|---------------|------------------|--------------|--------------|---------|
+| BTCUSDT | 2,646 | **0** | — | — | **NO_PULSE** |
+| ETHUSDT | 2,646 | **0** | — | — | **NO_PULSE** |
+| SOLUSDT | 2,646 | **6** (0.23%) | −0.43% | −0.20% | **SPARSE** |
+
+**Read:** At 0.05% entry, BTC/ETH never register an extreme-negative → normalization cycle in
+this window (max negative funding BTC −0.015%, ETH −0.037%). SOL has 13 ticks below
+−0.05% but only 6 completed normalization events; crude net forward edge is negative
+and concentration fails the 30% cap.
+
+**Do not implement** `funding_normalization_standalone` from these defaults.
+
+---
+
+## DB extreme check (why BTC/ETH are silent)
+
+| Symbol | Min funding | Max funding | Ticks ≤ −0.05% | Ticks ≥ +0.05% |
+|--------|-------------|-------------|----------------|----------------|
+| BTCUSDT | −0.015% | +0.088% | 0 | 24 |
+| ETHUSDT | −0.037% | +0.102% | 0 | 25 |
+| SOLUSDT | −0.303% | +0.119% | 13 | 52 |
+
+Crowding on BTC/ETH in 2024–2026 rarely reaches the default long-side extreme; the
+surface may need **symbol-specific thresholds** or a **positive-funding normalization
+short** (deferred until short-side parity review).
+
+---
+
+## Next steps (goal still open)
+
+1. **Phase 0** — weekly overlap + PnL once `sol-1h-trend-pullback-overlay-live` has closed trades.
+2. **Probe reshape** (if revisiting funding primary):
+   - per-symbol `entry_threshold` from historical quantiles,
+   - or test positive-extreme → normalization short in probe-only mode (`--include-short-events`),
+   - require ≥ 20 events and positive mean net before any implementation.
+3. **Merge PR #55** — preserves RS pause + funding spec + probe tooling.
+4. **Alternative surface** — if reshaped funding probe still fails, pick another
+   first-principles brief (not another 1h technical sweep).
+
+Promotion gates unchanged. Agent-count target remains **5–10**; current deployable
+technical count **1**.

--- a/docs/reports/relative-strength-rotation-implementation-summary-2026-06-04.md
+++ b/docs/reports/relative-strength-rotation-implementation-summary-2026-06-04.md
@@ -1,7 +1,7 @@
 # Relative Strength Rotation Implementation Summary
 
 **Date:** 2026-06-04
-**Status:** design-ready; implementation pending
+**Status:** design-ready; feasibility probe implemented; full surface pending
 **Surface:** `relative_strength_rotation_standalone`
 **First target:** `ETHUSDT`
 **First anchor:** `BTCUSDT`
@@ -16,8 +16,9 @@ is intentionally different from the exhausted surfaces: instead of tuning anothe
 single-symbol indicator stack, it tests whether capital is rotating into a target
 asset versus a market anchor, then enters on a controlled pullback.
 
-The plan is ready as a design and implementation spec. It is **not runnable yet**.
-The campaign command in the spec must wait until the cross-symbol reader path,
+The plan is ready as a design and implementation spec. A cheap feasibility probe
+now exists, but the full autoresearch campaign is **not runnable yet**. The
+campaign command in the spec must wait until the cross-symbol reader path,
 anchor plumbing, strategy, autoresearch family, and launcher passthrough are
 implemented and tested.
 
@@ -60,7 +61,38 @@ can we enter after a pullback without losing that leadership?"
 
 ---
 
-## Implementation Scope
+## Feasibility Probe Before Full Implementation
+
+Run the probe before building the full six-piece surface:
+
+```bash
+uv run python -m scripts.probe_relative_strength_rotation \
+  --target-symbol ETHUSDT \
+  --anchor-symbol BTCUSDT \
+  --timeframe 1h \
+  --start 2024-01-01T00:00:00 \
+  --end 2026-06-01T00:00:00
+```
+
+The probe is deliberately throwaway/offline. It reads existing target and anchor
+indicator rows, aligns same-timeframe closed candles, computes relative strength,
+counts how often the planned preconditions fire, and measures crude forward
+returns after those events.
+
+Use it as a kill/go gate:
+
+- **Kill or reshape** if it produces zero/near-zero events.
+- **Kill or reshape** if it produces many events but non-positive excess forward
+  return versus the anchor.
+- **Proceed to implementation** only if it has enough events to be analyzable and
+  positive crude forward excess.
+
+This probe does not replace the standard gate, bootstrap=1000, or overlap checks.
+It only decides whether the full implementation is worth building.
+
+---
+
+## Full Implementation Scope
 
 The implementation has six required pieces.
 
@@ -152,7 +184,7 @@ OHLCV/indicator data, standard gate.
 
 ---
 
-## First Campaign After Implementation
+## First Campaign After Full Implementation
 
 Run only after the implementation pieces above pass tests:
 
@@ -202,10 +234,12 @@ Do not paper or live-deploy from bootstrap=100 alone.
 | Research rationale | Ready |
 | Formal spec | Ready |
 | Implementation checklist | Ready |
+| Feasibility probe script | Ready: `scripts/probe_relative_strength_rotation.py` |
 | Campaign command | Ready after plumbing exists |
 | Code implementation | Missing |
 | Tests for implementation | Missing |
 | Hetzner campaign | Not started |
 | Deployable candidate | None yet |
 
-The next engineering task is implementation, not more planning.
+The next engineering task is to run the probe on production data. Full
+implementation should wait for that result.

--- a/docs/reports/relative-strength-rotation-implementation-summary-2026-06-04.md
+++ b/docs/reports/relative-strength-rotation-implementation-summary-2026-06-04.md
@@ -1,7 +1,7 @@
 # Relative Strength Rotation Implementation Summary
 
 **Date:** 2026-06-04
-**Status:** design-ready; feasibility probe implemented; full surface pending
+**Status:** design-ready; initial feasibility probe failed; full surface paused
 **Surface:** `relative_strength_rotation_standalone`
 **First target:** `ETHUSDT`
 **First anchor:** `BTCUSDT`
@@ -17,10 +17,11 @@ single-symbol indicator stack, it tests whether capital is rotating into a targe
 asset versus a market anchor, then enters on a controlled pullback.
 
 The plan is ready as a design and implementation spec. A cheap feasibility probe
-now exists, but the full autoresearch campaign is **not runnable yet**. The
-campaign command in the spec must wait until the cross-symbol reader path,
-anchor plumbing, strategy, autoresearch family, and launcher passthrough are
-implemented and tested.
+now exists, and the first production run says **do not build the full surface
+yet**. The default ETH/BTC 1h preconditions were too sparse and had negative
+forward edge. The full campaign command must wait until the surface is reshaped
+and the cross-symbol reader path, anchor plumbing, strategy, autoresearch family,
+and launcher passthrough are implemented and tested.
 
 ---
 
@@ -89,6 +90,32 @@ Use it as a kill/go gate:
 
 This probe does not replace the standard gate, bootstrap=1000, or overlap checks.
 It only decides whether the full implementation is worth building.
+
+### Initial Production Probe Result
+
+Run on Hetzner against production TimescaleDB from inside
+`agent_sentiment_macro`:
+
+```text
+Target / anchor: ETHUSDT / BTCUSDT
+Timeframe:        1h
+Window:           2024-01-01T00:00:00 -> 2026-06-01T00:00:00
+Rows:             target=20508 anchor=20508
+Aligned rows:     20508
+Events:           14 (0.07% of rows)
+Forward bars:     12
+Mean target return:    -1.50%
+Median target return:  -0.60%
+Target win rate:       28.6%
+Mean excess vs anchor: -0.66%
+Median excess:         -1.05%
+Excess win rate:       28.6%
+```
+
+Read: the default ETH/BTC 1h surface is too sparse and crude forward edge is
+negative. Do **not** implement the full six-piece production surface from these
+defaults. The next useful work is either threshold/surface reshaping in the probe
+or a different first-principles surface.
 
 ---
 
@@ -235,11 +262,13 @@ Do not paper or live-deploy from bootstrap=100 alone.
 | Formal spec | Ready |
 | Implementation checklist | Ready |
 | Feasibility probe script | Ready: `scripts/probe_relative_strength_rotation.py` |
+| Initial ETH/BTC 1h probe | Failed: sparse, negative forward excess |
 | Campaign command | Ready after plumbing exists |
-| Code implementation | Missing |
+| Code implementation | Paused pending probe redesign |
 | Tests for implementation | Missing |
 | Hetzner campaign | Not started |
 | Deployable candidate | None yet |
 
-The next engineering task is to run the probe on production data. Full
-implementation should wait for that result.
+The next engineering task is not the full implementation. Either reshape the
+probe thresholds/surface and re-run the cheap check, or choose a different
+first-principles surface.

--- a/docs/reports/relative-strength-rotation-implementation-summary-2026-06-04.md
+++ b/docs/reports/relative-strength-rotation-implementation-summary-2026-06-04.md
@@ -1,0 +1,211 @@
+# Relative Strength Rotation Implementation Summary
+
+**Date:** 2026-06-04
+**Status:** design-ready; implementation pending
+**Surface:** `relative_strength_rotation_standalone`
+**First target:** `ETHUSDT`
+**First anchor:** `BTCUSDT`
+
+---
+
+## Executive Summary
+
+The relative-strength rotation surface is the next candidate-search direction
+after ~1,440 autoresearch runs produced only one deployable technical agent. It
+is intentionally different from the exhausted surfaces: instead of tuning another
+single-symbol indicator stack, it tests whether capital is rotating into a target
+asset versus a market anchor, then enters on a controlled pullback.
+
+The plan is ready as a design and implementation spec. It is **not runnable yet**.
+The campaign command in the spec must wait until the cross-symbol reader path,
+anchor plumbing, strategy, autoresearch family, and launcher passthrough are
+implemented and tested.
+
+---
+
+## Related Documentation
+
+| Document | Purpose |
+|----------|---------|
+| [`../specs/relative-strength-rotation-surface-v0.md`](../specs/relative-strength-rotation-surface-v0.md) | Canonical requirements and implementation plan for this surface |
+| [`autoresearch-plan-overview.md`](./autoresearch-plan-overview.md) | Current portfolio/search state and document index |
+| [`autoresearch-next-candidate-path-2026-06-04.md`](./autoresearch-next-candidate-path-2026-06-04.md) | Forward research plan and why this surface is next |
+| [`autoresearch-postmortem-2026-06-04.md`](./autoresearch-postmortem-2026-06-04.md) | Why prior sweeps paused and what failed |
+| [`autoresearch-candidate-ledger.md`](./autoresearch-candidate-ledger.md) | Campaign results, gate definitions, and promotion labels |
+| [`entry-overlap-sol-1h.md`](./entry-overlap-sol-1h.md) | Independence evidence for the existing live SOL overlay vs sentiment-macro |
+
+---
+
+## Why This Exists
+
+The original goal remains open: build 5-10 independent agents, each passing the
+same promotion standard. The current portfolio has one deployable technical
+agent:
+
+- `agent_sol_1h_trend_pullback_overlay_live`
+
+And one independent live sentiment/macro agent:
+
+- `agent_sentiment_macro`
+
+The failed sweeps were informative. BTC/BNB 1h standalone and overlay searches
+did not produce promotable candidates. AVAX/ETH near-misses collapsed at
+bootstrap=1000. ETH/BTC 4h regime and bounded surfaces produced no standard
+passes. Repeating those lanes would mostly spend compute on already-failed
+hypotheses.
+
+Relative-strength rotation changes the research question from "is this symbol
+locally oversold or trending?" to "is this symbol leading the market anchor, and
+can we enter after a pullback without losing that leadership?"
+
+---
+
+## Implementation Scope
+
+The implementation has six required pieces.
+
+1. **Cross-symbol reader join**
+
+   Add a no-lookahead join that attaches anchor data to each target decision row.
+   Same-timeframe joins may use same-timestamp closed bars (`anchor_time <=
+   target_time`). Different-timeframe joins must use completed anchor bars only.
+
+   Required row fields:
+
+   - `anchor_time`
+   - `anchor_data_age_bars`
+   - `anchor_close_price`
+   - `anchor_return_fast`
+   - `anchor_return_slow`
+   - `target_return_fast`
+   - `target_return_slow`
+   - `rs_fast`
+   - `rs_slow`
+   - `rs_deterioration`
+
+2. **Anchor plumbing**
+
+   Thread the anchor symbol through the full research path:
+
+   ```text
+   scripts/run_autoresearch_campaign_remote.sh
+      → ANCHOR_SYMBOL
+      → scripts/autoresearch_loop.py --anchor-symbol
+      → BacktestConfig.anchor_symbol
+      → BacktestEngine
+      → IndicatorReader cross-symbol join
+      → strategy row fields
+   ```
+
+3. **Fail-fast behavior**
+
+   A `relative_strength_rotation_standalone` run must fail fast if the anchor is
+   missing or if anchor coverage is not available for the target WFO window. It
+   must not silently run as a single-symbol campaign.
+
+4. **Strategy implementation**
+
+   Add and register `relative_strength_rotation`.
+
+   The strategy must be standalone, long-only first, and require:
+
+   - anchor non-panic / risk-on regime,
+   - positive relative-strength persistence,
+   - controlled pullback,
+   - pullback resolution,
+   - rotation-failure exit or exit rule,
+   - strategy-local cooldown after its own emitted entries/exits/time stops.
+
+5. **Autoresearch family**
+
+   Add `relative_strength_rotation_standalone` to candidate generation. It must
+   generate standalone overlays only and avoid the five-vote technical stack.
+
+6. **Tests**
+
+   Required tests:
+
+   - cross-symbol join cannot use future anchor bars,
+   - same-timeframe anchor joins allow same closed timestamp,
+   - anchor fields exist in backtest rows,
+   - missing anchor fails fast,
+   - remote launcher maps `ANCHOR_SYMBOL=BTCUSDT` to `--anchor-symbol BTCUSDT`,
+   - strategy holds when RS is absent/negative,
+   - strategy buys only after RS persistence plus controlled pullback resolution,
+   - strategy exits or blocks re-entry on rotation failure/cooldown.
+
+---
+
+## Out Of Scope For First Implementation
+
+Do not add these until a baseline result exists:
+
+- multi-anchor baskets,
+- new market-data ingestion,
+- short-side trading,
+- SOL clone variants,
+- broad BTC/BNB/AVAX campaigns,
+- extra tunable parameters beyond the bounded spec list.
+
+The first implementation should stay narrow: ETH target, BTC anchor, existing
+OHLCV/indicator data, standard gate.
+
+---
+
+## First Campaign After Implementation
+
+Run only after the implementation pieces above pass tests:
+
+```bash
+FAMILIES=relative_strength_rotation_standalone \
+ANCHOR_SYMBOL=BTCUSDT \
+MAX_RUNS=80 \
+GATE_PROFILE=standard \
+./scripts/run_autoresearch_campaign_remote.sh ETHUSDT 1h w9-eth-1h-relative-strength
+```
+
+If 1h overtrades or fails risk gates, review the failure mode before running:
+
+```bash
+FAMILIES=relative_strength_rotation_standalone \
+ANCHOR_SYMBOL=BTCUSDT \
+MAX_RUNS=80 \
+GATE_PROFILE=standard \
+./scripts/run_autoresearch_campaign_remote.sh ETHUSDT 4h w9-eth-4h-relative-strength
+```
+
+Do not launch BTC/BNB/SOL variants until ETH has a readable result.
+
+---
+
+## Promotion Rules Stay Unchanged
+
+No candidate from this surface gets special treatment. The promotion path remains:
+
+```text
+b=100 discovery under standard gate
+   → promotion_candidate / eligible_for_bootstrap_1000
+   → bootstrap=1000 under the same standard gate
+   → entry-overlap analysis vs live agents
+   → tracked paper config
+   → small live notional review
+```
+
+Do not paper or live-deploy from bootstrap=100 alone.
+
+---
+
+## Current Readiness
+
+| Area | Status |
+|------|--------|
+| Research rationale | Ready |
+| Formal spec | Ready |
+| Implementation checklist | Ready |
+| Campaign command | Ready after plumbing exists |
+| Code implementation | Missing |
+| Tests for implementation | Missing |
+| Hetzner campaign | Not started |
+| Deployable candidate | None yet |
+
+The next engineering task is implementation, not more planning.

--- a/docs/reports/sentiment-macro-live-bleed-investigation-2026-06-01.md
+++ b/docs/reports/sentiment-macro-live-bleed-investigation-2026-06-01.md
@@ -1,0 +1,232 @@
+# Sentiment-Macro Live Bleed Investigation
+
+**Date:** 2026-06-01
+**Service:** `agent_sentiment_macro` on Hetzner
+**Agent ID:** `sentiment-macro-bot`
+**Scope:** Diagnose why the live strategy is losing despite earlier profitable results.
+
+## Executive Summary
+
+The current losses are not caused by failed order placement, missing protective orders, or
+exchange reconciliation drift. The inspected BTC losses were valid strategy entries and were
+closed by exchange-side stop-loss orders close to their configured stop prices.
+
+The strategy should not be described as currently validated by profitable backtesting. The
+existing replay-backed, executor-like backtest from 2026-03-27 through 2026-04-27 was negative
+for BTC, ETH, and SOL. Production performance also changed after the 2026-04-20 futures
+rollback: 32 closed trades produced `-3.54 USDT`, with a `28.1%` win rate.
+
+Recommendation: keep the intentionally small live allocation unchanged, restore strict EMA200
+filtering, and treat the live agent as a controlled production experiment. Do not increase
+size until a replay-backed portfolio backtest reproduces the actual runtime behavior.
+
+## Applied Mitigations
+
+The following risk reductions were deployed on 2026-06-01:
+
+- Restored strict EMA200 filtering with `global_trend_filter_buffer_pct: 0.0`.
+- Removed `BTCUSDT` from the live sentiment-macro scope after BTC dominated both post-rollback
+  live losses and corrected replay losses.
+- Preserved the small `22 USDT` order budget, `3x` leverage, one-position portfolio limit,
+  and live observation mode for `ETHUSDT` and `SOLUSDT`.
+- Rebuilt the production service and verified healthy startup, zero open positions, and clean
+  spot and futures reconciliation for both remaining symbols.
+
+## Production State
+
+The Hetzner service was healthy during inspection:
+
+- Container: `crypto-agent-agent_sentiment_macro-1`
+- Status: healthy, running for 7 days
+- Deployed commit: `26e75bdcc96d44299fac43e38f9814fb38a34f8d`
+- Reconciliation: repeated clean spot and futures checks with zero divergences
+- Open positions at inspection time: `0`
+
+The deployed configuration is live futures trading with:
+
+- Symbols: `BTCUSDT`, `ETHUSDT`, `SOLUSDT`
+- Timeframe: `1h`
+- Order budget: `22 USDT`
+- Futures leverage: `3x`
+- Exit model: `2.0 ATR` stop loss, `3.5 ATR` take profit
+- Portfolio limit: one concurrent long across all three symbols
+- Stop-loss cooldown: 240 minutes per symbol
+
+## Inspected BTC Losses
+
+### 2026-05-27 BTC trade
+
+- Signal: RSI `29.1`, lower Bollinger distance `-0.0041`, live sentiment `52`
+- Signal price: `75073.40`
+- Filled entry: `74932.80`
+- Quantity: `0.001 BTC`
+- Exchange stop: `74293.7914`
+- Exchange take profit: `76051.0650`
+- Exit: `74280.00`
+- Realized P&L: `-0.6528 USDT`
+
+### 2026-05-31 BTC trade
+
+- Signal: RSI `29.1`, lower Bollinger distance `-0.0015`, live sentiment `62`
+- Signal price: `73602.17`
+- Filled entry: `73619.40`
+- Quantity: `0.001 BTC`
+- Exchange stop: `73233.4000`
+- Exchange take profit: `74294.9000`
+- Exit: `73227.80`
+- Realized P&L: `-0.3916 USDT`
+
+Both losses were ordinary mean-reversion failures: the bot bought oversold dips and price
+continued lower. Protective orders were active and executed correctly.
+
+## Live Performance Evidence
+
+Lifetime production data remains positive:
+
+| Scope | Closed trades | Win rate | Realized P&L |
+|---|---:|---:|---:|
+| Lifetime | 96 | 47.9% | `+605.43 USDT` |
+| Since 2026-04-20 futures rollback | 32 | 28.1% | `-3.54 USDT` |
+
+Post-rollback results by symbol:
+
+| Symbol | Closed trades | Win rate | Realized P&L | Expectancy |
+|---|---:|---:|---:|---:|
+| BTCUSDT | 16 | 25.0% | `-3.15 USDT` | `-0.197 USDT` |
+| ETHUSDT | 9 | 33.3% | `-0.05 USDT` | `-0.005 USDT` |
+| SOLUSDT | 7 | 28.6% | `-0.34 USDT` | `-0.048 USDT` |
+
+The degradation is broad across all three symbols. BTC is the main contributor, but this is
+not a BTC-only defect.
+
+## Why Earlier Results Did Not Protect Against This
+
+### Live edge changed after April 20
+
+The config comments justify futures mode using an earlier window: 95 live trades, 70% win
+rate, and `+727 USDT` from 2026-03-13 through 2026-04-16. That historical window is not
+representative of the 32 post-rollback trades.
+
+### Replay-backed backtests were already negative
+
+The 2026-05-06 replay study tested real xAI observations with executor-like exits over
+2026-03-27 through 2026-04-27:
+
+| Symbol | Trades | Win rate | Return | Sharpe | Profit factor |
+|---|---:|---:|---:|---:|---:|
+| BTCUSDT | 12 | 33.33% | `-5.85%` | `-5.99` | `0.21` |
+| ETHUSDT | 17 | 41.18% | `-7.03%` | `-5.07` | `0.38` |
+| SOLUSDT | 13 | 30.77% | `-5.33%` | `-4.18` | `0.43` |
+
+That study explicitly concluded replay coverage was too sparse to prove a live-parity edge.
+The production strategy therefore continued based on historical live performance, not a
+positive replay-backed out-of-sample validation.
+
+### Portfolio behavior differs from per-symbol backtests
+
+Production permits only one concurrent long. On 2026-05-31, BTC occupied that slot while
+valid ETH and SOL signals were rejected. Any validation that runs each symbol independently
+does not reproduce the live portfolio selector or opportunity cost.
+
+### Replay data must be read from the production Docker volume
+
+The host checkout file `data/event_log_sentiment-macro-bot.jsonl` contains only 270
+`sentiment_score` observations and ends at `2026-04-27 00:58 UTC`. It is stale because the
+production container writes to the `agent-data` Docker volume mounted at `/app/data`.
+
+The mounted production event log is current through `2026-06-01` and contains recent
+`sentiment_score` observations from BTC, ETH, and SOL. Replay research must read the mounted
+volume or copy the current volume file explicitly; using the host checkout silently evaluates
+stale sentiment data.
+
+### Corrected dense replay remains negative
+
+After exporting the mounted production log, replay coverage increased from 270 stale host-file
+observations to 4703 mounted-volume observations through `2026-06-01 19:52 UTC`. The corrected
+executor-like replay used strict EMA200 filtering, `2.0 ATR` stops, `3.5 ATR` take profits, and
+a 24-hour sentiment max age:
+
+| Symbol | Trades | Win rate | Return | Sharpe | Profit factor |
+|---|---:|---:|---:|---:|---:|
+| BTCUSDT | 8 | 37.50% | `-3.70%` | `-3.86` | `0.25` |
+| ETHUSDT | 1 | 0.00% | `-0.14%` | `-0.80` | `0.00` |
+| SOLUSDT | 1 | 0.00% | `-0.03%` | `-0.06` | `0.00` |
+
+Replay lookup coverage was dense: BTC had 1553 hits and ETH/SOL had 1560 hits each, with only
+34 stale lookups per symbol. Sparse replay data is no longer the explanation for poor results.
+The remaining ETH and SOL samples are too small to establish an edge.
+
+### ETH/SOL portfolio replay after BTC quarantine
+
+A portfolio-level replay then modeled the deployed ETH/SOL symbol order, one concurrent long,
+ATR exits, 240-minute stop-loss cooldown, strict EMA200 gate, live `22 USDT` order budget, and
+futures-style fees:
+
+| Scope | Trades | Win rate | Realized P&L | Profit factor | Slot-skipped buys |
+|---|---:|---:|---:|---:|---:|
+| ETHUSDT/SOLUSDT portfolio | 2 | 50.00% | `+0.0076 USDT` | `1.86` | 1 |
+
+This is directionally better after BTC quarantine but remains too sparse to establish a live
+edge or justify increasing risk.
+
+### Close-only 30-day production attribution
+
+The authoritative `trades` table shows that ETH should also be quarantined from the live
+sentiment agent:
+
+| Symbol | Closed trades | Win rate | Realized P&L | Expectancy |
+|---|---:|---:|---:|---:|
+| BTCUSDT | 11 | 18.2% | `-3.2757 USDT` | `-0.2978 USDT` |
+| ETHUSDT | 4 | 0.0% | `-0.7133 USDT` | `-0.1783 USDT` |
+| SOLUSDT | 2 | 50.0% | `+0.0390 USDT` | `+0.0195 USDT` |
+
+BTC quarantine is deployed. ETH quarantine is the next production change. SOL is the only
+remaining sentiment-macro symbol with positive recent realized expectancy, but its sample is
+still too small to justify increasing risk.
+
+ETH quarantine was deployed later on 2026-06-01. The live sentiment-macro service now routes
+only `SOLUSDT` with the original `22 USDT` budget, `3x` leverage, strict EMA200 gate, and
+240-minute stop-loss cooldown.
+
+## Operational Drift Cleanup
+
+The production audit also found enabled services missing from runtime and stale monitoring
+targets. The following repairs were applied on 2026-06-01:
+
+- Restored `agent_sol_sparse` and `agent_sol_panic_block_paper` as healthy paper services.
+- Restored Grafana as a healthy internal observability service.
+- Removed the disabled AVAX scrape target and added the panic-block paper target.
+- Disabled this stack's duplicate nginx definition because `tailscaled` already owns host port
+  `443`.
+- Fixed the production drift sentinel to inspect `docker-compose.prod.yml` instead of the
+  default development Compose file.
+
+After cleanup, Prometheus reported all three agent targets healthy and the corrected drift
+sentinel reported no production errors.
+
+## Additional Observations
+
+- Telegram displays roughly `74 USDT` BTC exposure because BTC minimum lot size truncation
+  results in `0.001 BTC`; the configured `22 USDT` budget is not the final exchange notional.
+- One transient Binance position-risk HTML response and timestamp resync occurred on
+  2026-06-01. Neither affected the inspected trades.
+- The database stores position symbols with an agent prefix such as
+  `sentiment-macro-bot::BTCUSDT`. This is unusual but did not prevent the queried reporting.
+
+## Recommendations
+
+1. Keep the current order budget and leverage unchanged; do not scale the live allocation.
+2. Keep BTC quarantined from this strategy until a replay-backed redesign passes validation.
+3. Continue low-risk live observation on SOL only.
+4. Re-run replay-backed walk-forward validation across the post-2026-04-20 regime.
+5. Require positive out-of-sample expectancy and controlled drawdown before increasing live
+   orders. Do not treat lifetime P&L as sufficient evidence.
+
+## Evidence Sources
+
+- Hetzner `docker compose -f docker-compose.prod.yml ps agent_sentiment_macro`
+- Hetzner `agent_sentiment_macro` container logs
+- Hetzner TimescaleDB `positions` rows for `agent_id='sentiment-macro-bot'`
+- `config/settings.sentiment_macro.yaml`
+- `docs/reports/sentiment-macro-replay-and-tuning-2026-05-06.md`
+- `docs/reports/SENTIMENT_REPLAY_FINDINGS_2026-03-27.md`

--- a/docs/specs/funding-crowding-primary-surface-v0.md
+++ b/docs/specs/funding-crowding-primary-surface-v0.md
@@ -1,0 +1,162 @@
+# Funding / Crowding Primary Surface v0
+
+**Status:** design + feasibility probe (no full implementation until probe shows pulse)
+**Date:** 2026-06-04
+**Goal:** candidate #2+ with **independent** edge versus SOL 1h overlay and sentiment-macro
+
+---
+
+## Why this surface
+
+Prior waves treated funding as one vote in a five-strategy stack or as an extreme-level
+trigger. Those lanes produced 0 trades or negative OOS. This surface changes the
+question:
+
+> After crowded positioning **unwinds** (funding normalizes from an extreme), is there
+> a tradeable mean-reversion edge **net of funding costs**?
+
+Production DB now has `funding_rates` for **BTCUSDT, ETHUSDT, SOLUSDT** (2024-01-01 →
+present). Phase 3 research may proceed only after a cheap probe passes.
+
+---
+
+## Hypothesis
+
+**HYP-001:** Entering **long** when funding normalizes from an extreme **negative**
+(crowded shorts paying longs) yields positive forward return after netting funding
+paid/received during the hold window.
+
+**HYP-002:** Entering on the **extreme level alone** (without normalization) is weaker
+or negative — normalization is the primary trigger, not the extreme.
+
+**HYP-003:** Edge must not be dominated by one funding event (concentration cap).
+
+---
+
+## Scope (v0)
+
+| In scope | Out of scope (v0) |
+|----------|-------------------|
+| BTCUSDT, ETHUSDT, SOLUSDT | BNB, AVAX, alt baskets |
+| Futures perpetual funding | New ingestion pipelines |
+| Long-only entries first | Live short-side until parity review |
+| Normalization-triggered entries | Re-running `funding_extreme_overlay` vote stack |
+| One entry per funding cycle | Repeated entries on same unwind |
+| Net return after funding drag | Gross-only promotion |
+
+---
+
+## Signal definition
+
+### States (per symbol)
+
+1. **Idle** — funding inside normal band.
+2. **Extreme negative** — `funding_rate <= -entry_threshold`.
+3. **Extreme positive** — `funding_rate >= +entry_threshold` (tracked; shorts deferred).
+4. **Normalization event (long)** — transition from extreme negative to
+   `|funding_rate| < exit_threshold` without re-entering extreme negative on the same
+   tick.
+
+### Parameters (bounded in autoresearch later)
+
+| Parameter | Default (probe) | Role |
+|-----------|-----------------|------|
+| `entry_threshold` | 0.0005 (0.05%) | Crowding extreme |
+| `exit_threshold` | 0.00015 (0.015%) | Normalized band |
+| `cooldown_funding_periods` | 1 | Block re-entry until next extreme cycle |
+
+### Entry rules (long v0)
+
+- Fire **once** per negative extreme → normalization cycle.
+- Require liquid symbol; optional price filter (close above EMA200) in full impl only.
+- Reject entry if forward window would include a known liquidation cascade proxy
+  (full impl: ATR percentile cap).
+
+### Exit / hold (full implementation)
+
+- Time-stop aligned to funding cadence (e.g. 12–24h on 1h chart).
+- Exit when funding re-extremes opposite direction or rotation failure.
+- Model executor SL/TP parity in backtest.
+
+---
+
+## Funding cost
+
+For each event, compute:
+
+```
+gross_forward_pct = (close[t+H] / close[t] - 1) * 100
+funding_drag_pct  = sum(funding_rate over payments in (t, t+H]) * 100  # long pays +rate
+net_forward_pct   = gross_forward_pct - funding_drag_pct
+```
+
+Probe reports **12h and 24h** horizons (1h bars: 12 and 24).
+
+---
+
+## Concentration guard
+
+Reject full implementation if, on probe events with positive net return:
+
+```
+max_single_event_net / sum(positive_net) > 0.30
+```
+
+Promotion gate (unchanged): profit concentration ≤ 50% on WFO — probe uses a stricter
+30% pre-filter.
+
+---
+
+## Feasibility probe (required before code)
+
+```bash
+uv run python -m scripts.probe_funding_normalization \
+  --symbol ETHUSDT \
+  --timeframe 1h \
+  --start 2024-01-01T00:00:00 \
+  --end 2026-06-01T00:00:00
+```
+
+**Kill / reshape if:**
+
+- Normalization events < 20 in window (too sparse for standard gate path).
+- Mean **net** forward return ≤ 0 at both 12h and 24h.
+- Concentration > 30% on positive net events.
+
+**Proceed to implementation if:**
+
+- Events ≥ 20 and mean net forward > 0 on at least one horizon, with concentration OK.
+
+Probe script: `scripts/probe_funding_normalization.py`
+
+---
+
+## Promotion path (unchanged)
+
+```
+b=100 standard discovery
+  → promotion_candidate / eligible_for_bootstrap_1000
+  → bootstrap=1000 (same standard gate)
+  → entry overlap vs SOL overlay + sentiment-macro
+  → paper → small live
+```
+
+No gate lowering to reach the 5–10 agent portfolio goal.
+
+---
+
+## Implementation checklist (after probe pulse)
+
+1. `funding_normalization_standalone` autoresearch family (not overlay vote).
+2. Strategy `funding_normalization` with cycle cooldown and net-cost-aware backtest notes.
+3. Fail-fast if `funding_rates` coverage missing for symbol/window.
+4. Tests: state machine, no double-entry per cycle, no future funding leakage.
+5. First campaign: ETHUSDT 1h, 80 runs, `GATE_PROFILE=standard`.
+
+---
+
+## Related docs
+
+- [`autoresearch-next-candidate-path-2026-06-04.md`](../reports/autoresearch-next-candidate-path-2026-06-04.md)
+- [`forward-validation-snapshot-2026-06-04.md`](../reports/forward-validation-snapshot-2026-06-04.md)
+- Wave 7 ledger: BTC 4h `funding_primary_standalone` had **0 trades** — different trigger; do not conflate.

--- a/docs/specs/relative-strength-rotation-surface-v0.md
+++ b/docs/specs/relative-strength-rotation-surface-v0.md
@@ -353,6 +353,25 @@ failure mode.
 > surface as **medium**, with the join as the critical path; the strategy itself
 > (Step 2) is small by comparison.
 
+### Step 0 — Feasibility Probe
+
+Before building the production backtest path, run the cheap offline probe:
+
+```bash
+uv run python -m scripts.probe_relative_strength_rotation \
+  --target-symbol ETHUSDT \
+  --anchor-symbol BTCUSDT \
+  --timeframe 1h \
+  --start 2024-01-01T00:00:00 \
+  --end 2026-06-01T00:00:00
+```
+
+The probe MUST NOT be treated as a promotion result. It only decides whether the
+surface has enough frequency and crude forward edge to justify implementing the
+full reader/engine/strategy path. Stop or reshape the surface before Step 1 if
+the probe produces zero/near-zero events or non-positive excess forward return
+versus the anchor.
+
 ### Step 1 — Data Join
 
 Add a no-lookahead cross-symbol reader path for backtest and runtime by

--- a/docs/specs/relative-strength-rotation-surface-v0.md
+++ b/docs/specs/relative-strength-rotation-surface-v0.md
@@ -127,6 +127,18 @@ through `scripts/autoresearch_loop.py` (`--anchor-symbol`), `BacktestConfig`,
   asserts the engine fails fast (not silently) if RS fields cannot be computed
   because the anchor was not supplied.
 
+**REQ-002b**: The remote campaign launcher MUST pass the anchor symbol through to
+the loop. `scripts/run_autoresearch_campaign_remote.sh` MUST translate
+`ANCHOR_SYMBOL=<symbol>` into `--anchor-symbol <symbol>` when launching
+`scripts/autoresearch_loop.py`.
+
+- Rationale: Step 5 uses the remote campaign launcher, not
+  `autoresearch_loop.py` directly. Without the launcher bridge, the documented
+  command can still run single-symbol even after `--anchor-symbol` exists.
+- Verification: launcher tests or a dry-run assertion prove `ANCHOR_SYMBOL=BTCUSDT`
+  appears in the child command as `--anchor-symbol BTCUSDT`; relative-strength
+  launcher runs fail fast if `ANCHOR_SYMBOL` is missing.
+
 **REQ-003**: The first implementation SHOULD use existing `ohlcv` and
 `indicators` data only.
 
@@ -382,6 +394,12 @@ The engine MUST fail fast if a `relative_strength_rotation` run is launched
 without an anchor symbol, rather than running single-symbol silently. Mixed
 single-symbol and cross-symbol strategies MAY be rejected initially to keep scope
 controlled.
+
+Also wire the outer remote launcher (per REQ-002b): `ANCHOR_SYMBOL=BTCUSDT` in
+`scripts/run_autoresearch_campaign_remote.sh` MUST become `--anchor-symbol
+BTCUSDT` in the `scripts/autoresearch_loop.py` invocation. The launcher MUST fail
+fast when `FAMILIES=relative_strength_rotation_standalone` is requested without
+`ANCHOR_SYMBOL`.
 
 ### Step 4 — Autoresearch Family
 

--- a/docs/specs/relative-strength-rotation-surface-v0.md
+++ b/docs/specs/relative-strength-rotation-surface-v0.md
@@ -372,6 +372,10 @@ full reader/engine/strategy path. Stop or reshape the surface before Step 1 if
 the probe produces zero/near-zero events or non-positive excess forward return
 versus the anchor.
 
+Initial ETH/BTC 1h production probe result (2026-06-04): 14 events across 20,508
+aligned rows, mean target forward return -1.50%, mean excess versus BTC -0.66%.
+That hits the Step 0 stop condition for the default parameters.
+
 ### Step 1 — Data Join
 
 Add a no-lookahead cross-symbol reader path for backtest and runtime by

--- a/docs/specs/relative-strength-rotation-surface-v0.md
+++ b/docs/specs/relative-strength-rotation-surface-v0.md
@@ -106,9 +106,13 @@ no-lookahead semantics.
   the target decision timestamp and never newer.
 - Precedent: reuse the alignment logic in
   `IndicatorReader.fetch_multi_timeframe` / `_join_timeframes`
-  (`src/features/reader.py`), which already joins a second series by timestamp
-  using only completed bars ("same-timestamp bars are NOT available"). Generalize
-  it from second-*timeframe* to second-*symbol*; do not invent a new join.
+  (`src/features/reader.py`) as the no-lookahead pattern, but adapt the
+  availability rule for cross-symbol data. For the same target and anchor
+  timeframe, the join MUST use the anchor bar with `anchor_time <= target_time`;
+  same-timestamp closed bars MAY be used because both symbols' 1h/4h candles are
+  complete at the decision timestamp. For a different anchor timeframe, the join
+  MUST use the latest anchor bar whose close time is less than or equal to the
+  target decision time. In all cases, a newer anchor row MUST NOT be joined.
 
 **REQ-002a**: The anchor symbol MUST be a first-class campaign parameter threaded
 through `scripts/autoresearch_loop.py` (`--anchor-symbol`), `BacktestConfig`,
@@ -195,12 +199,23 @@ rule.
 - Verification: backtest tests cover SELL or executor exit when RS falls below
   the configured failure threshold.
 
-**REQ-010**: The strategy MUST support a cooldown measured in bars after an exit
-or stop loss.
+**REQ-010**: The strategy MUST support a cooldown measured in bars after its own
+entry, rotation-failure exit, or time-stop exit signal.
 
 - Rationale: repeated entries in the same rotation failure caused poor risk in
   earlier densified surfaces.
 - Verification: tests cover no immediate re-entry during cooldown.
+
+**REQ-010a**: The first backtest implementation MUST NOT claim stop-loss
+cooldown behavior unless execution feedback is added to the strategy row stream.
+
+- Rationale: the current strategy evaluation path sees market rows and emitted
+  signals, not executor stop-loss fills. Live stop-loss cooldown belongs to the
+  executor/risk configuration (for example `sl_cooldown_minutes`) until the
+  backtest engine exposes stop-loss outcomes back to the strategy.
+- Verification: the research report distinguishes strategy-local cooldown from
+  executor stop-loss cooldown; tests do not assert stop-loss cooldown unless the
+  execution feedback path exists.
 
 ### Risk And Execution Requirements
 
@@ -309,7 +324,7 @@ Initial bounded search MAY vary only these parameters:
 | `max_vwap_distance_pct` | 0.5%-3.0% |
 | `rsi_reset_min` | 35-45 |
 | `rsi_reset_max` | 55-65 |
-| `anchor_max_drawdown_pct` | -2.0% to -5.0% |
+| `anchor_max_fast_loss_pct` | 2.0%-5.0% |
 | `cooldown_bars` | 3-12 |
 | `time_stop_hours` | 12-72 |
 
@@ -332,10 +347,15 @@ Add a no-lookahead cross-symbol reader path for backtest and runtime by
 **generalizing** `IndicatorReader.fetch_multi_timeframe` / `_join_timeframes`
 (`src/features/reader.py`) from a second timeframe to a second symbol. That code
 already aligns a second series by timestamp using only completed bars; reuse its
-no-lookahead guarantee rather than writing a new join.
+no-lookahead guarantee rather than writing a new join. Same-timeframe
+cross-symbol joins MUST allow the same closed timestamp (`anchor_time <=
+target_time`), while higher-timeframe anchor joins MUST preserve completed-bar
+close-time semantics.
 
 Required output fields:
 
+- `anchor_time`,
+- `anchor_data_age_bars`,
 - `anchor_close_price`,
 - `anchor_return_fast`,
 - `anchor_return_slow`,
@@ -385,6 +405,7 @@ Run one discovery campaign:
 
 ```bash
 FAMILIES=relative_strength_rotation_standalone \
+ANCHOR_SYMBOL=BTCUSDT \
 MAX_RUNS=80 \
 GATE_PROFILE=standard \
 ./scripts/run_autoresearch_campaign_remote.sh ETHUSDT 1h w9-eth-1h-relative-strength
@@ -395,6 +416,7 @@ failure mode:
 
 ```bash
 FAMILIES=relative_strength_rotation_standalone \
+ANCHOR_SYMBOL=BTCUSDT \
 MAX_RUNS=80 \
 GATE_PROFILE=standard \
 ./scripts/run_autoresearch_campaign_remote.sh ETHUSDT 4h w9-eth-4h-relative-strength

--- a/docs/specs/relative-strength-rotation-surface-v0.md
+++ b/docs/specs/relative-strength-rotation-surface-v0.md
@@ -104,6 +104,24 @@ no-lookahead semantics.
 - Rationale: cross-symbol joins can accidentally leak future anchor closes.
 - Verification: a test proves the anchor row timestamp is less than or equal to
   the target decision timestamp and never newer.
+- Precedent: reuse the alignment logic in
+  `IndicatorReader.fetch_multi_timeframe` / `_join_timeframes`
+  (`src/features/reader.py`), which already joins a second series by timestamp
+  using only completed bars ("same-timestamp bars are NOT available"). Generalize
+  it from second-*timeframe* to second-*symbol*; do not invent a new join.
+
+**REQ-002a**: The anchor symbol MUST be a first-class campaign parameter threaded
+through `scripts/autoresearch_loop.py` (`--anchor-symbol`), `BacktestConfig`,
+`BacktestEngine`, and the reader join — **not** an overlay field alone.
+
+- Rationale: `autoresearch_loop.py` and `BacktestEngine` are single-symbol today
+  (`BacktestConfig.symbol` is singular; the loop calls
+  `strategy.evaluate(symbol, row)` with one symbol's dict). Without a real
+  `--anchor-symbol` param, a campaign launched per Step 5 silently runs
+  single-symbol with no anchor and the RS fields are undefined.
+- Verification: a campaign run records the resolved `anchor_symbol`, and a test
+  asserts the engine fails fast (not silently) if RS fields cannot be computed
+  because the anchor was not supplied.
 
 **REQ-003**: The first implementation SHOULD use existing `ohlcv` and
 `indicators` data only.
@@ -119,6 +137,25 @@ names such as `anchor_close_price`, `anchor_return_fast`,
 - Rationale: strategy code must not infer anchor data from ambiguous indicator
   names.
 - Verification: integration tests assert the joined row schema.
+
+**REQ-004a**: Before the first campaign, the implementation MUST verify the anchor
+symbol has `ohlcv` + `indicators` coverage over the same window and timeframe as
+the target.
+
+- Rationale: the join is only valid where both series exist; gaps produce silent
+  NaN/zero RS and false HOLDs rather than an honest error.
+- Verification: a coverage check (or the join itself) raises/records when anchor
+  rows are missing for target decision bars; partial-coverage campaigns are not
+  scored as clean rejects.
+
+**REQ-004b**: The pullback logic MUST confirm the semantics of the existing `vwap`
+column at the campaign timeframe before relying on "near VWAP."
+
+- Rationale: VWAP is anchored to a session/window; its meaning on 4h bars depends
+  on how `src/features/technical.py` computes it. "Distance from VWAP" is only
+  meaningful if the anchor period is known.
+- Verification: a note or test documents the VWAP anchoring used; if ambiguous on
+  4h, fall back to EMA distance for the pullback gate.
 
 ### Signal Requirements
 
@@ -274,7 +311,7 @@ Initial bounded search MAY vary only these parameters:
 | `rsi_reset_max` | 55-65 |
 | `anchor_max_drawdown_pct` | -2.0% to -5.0% |
 | `cooldown_bars` | 3-12 |
-| `time_stop_minutes` | 12-72 hours |
+| `time_stop_hours` | 12-72 |
 
 The first search MUST NOT vary more than these parameters. Adding more knobs
 before a baseline result exists risks recreating the prior threshold-sweep
@@ -284,9 +321,18 @@ failure mode.
 
 ## Implementation Plan
 
+> **Sizing note:** the cross-symbol join (Steps 1 + 3) is the dominant cost of
+> this surface — the backtest stack is single-symbol today. Treat the whole
+> surface as **medium**, with the join as the critical path; the strategy itself
+> (Step 2) is small by comparison.
+
 ### Step 1 — Data Join
 
-Add a no-lookahead cross-symbol reader path for backtest and runtime.
+Add a no-lookahead cross-symbol reader path for backtest and runtime by
+**generalizing** `IndicatorReader.fetch_multi_timeframe` / `_join_timeframes`
+(`src/features/reader.py`) from a second timeframe to a second symbol. That code
+already aligns a second series by timestamp using only completed bars; reuse its
+no-lookahead guarantee rather than writing a new join.
 
 Required output fields:
 
@@ -306,11 +352,16 @@ Add `src/strategy/relative_strength_rotation.py` and export/register it.
 The strategy MUST be usable as a single-strategy standalone candidate. It SHOULD
 not require the five-vote aggregator stack.
 
-### Step 3 — Backtest Parity
+### Step 3 — Anchor Plumbing + Backtest Parity
 
-Extend `BacktestEngine` and `StrategyEngine` only as much as needed to pass joined
-cross-symbol rows to the strategy. Mixed single-symbol and cross-symbol
-strategies MAY be rejected initially to keep scope controlled.
+Thread the anchor symbol end-to-end (per REQ-002a): add `--anchor-symbol` to
+`scripts/autoresearch_loop.py`, an `anchor_symbol` field to `BacktestConfig`, and
+pass it through `BacktestEngine` into the reader join so each target `row` carries
+the `anchor_*` / `rs_*` keys before `strategy.evaluate(symbol, row)` is called.
+The engine MUST fail fast if a `relative_strength_rotation` run is launched
+without an anchor symbol, rather than running single-symbol silently. Mixed
+single-symbol and cross-symbol strategies MAY be rejected initially to keep scope
+controlled.
 
 ### Step 4 — Autoresearch Family
 
@@ -357,13 +408,15 @@ Do not run BTC/BNB/SOL variants before ETH has a readable result.
 
 Close the surface if the first two ETH campaigns show:
 
-- best WFO trades < 15,
+- best WFO trades < 20 (cannot clear the `standard` gate the run is scored
+  against — a 15-19 trade "near-miss" is not promotable under REQ-015),
 - best P(loss) > 40%,
 - best max DD > 15%,
 - best Sharpe < 0.3,
 - or all positive OOS candidates have concentration > 60%.
 
-Continue only if at least one candidate is close to `promotion_candidate`.
+Continue only if at least one candidate is close to `promotion_candidate`
+(≥ 20 WFO trades and within reach on return / DD / P(loss) / concentration).
 
 ---
 

--- a/docs/specs/relative-strength-rotation-surface-v0.md
+++ b/docs/specs/relative-strength-rotation-surface-v0.md
@@ -1,0 +1,405 @@
+# Relative Strength Rotation Surface v0.1.0
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHOULD",
+"SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document
+are to be interpreted as described in RFC 2119.
+
+---
+
+## Overview
+
+This specification defines a new candidate-search surface for crypto futures:
+**relative strength rotation with controlled pullback entry**.
+
+The first-principles hypothesis is that crypto returns are dominated by a shared
+market beta, but capital rotates into stronger assets during risk-on phases. A
+tradeable edge MAY exist when a target asset persistently outperforms BTC/ETH,
+then pulls back without losing relative strength. This surface trades that
+rotation directly instead of sweeping another single-symbol indicator stack.
+
+This is a design specification. It intentionally defines requirements before
+implementation so future research does not collapse into another threshold-only
+campaign.
+
+---
+
+## Why This Surface
+
+The prior autoresearch waves mostly searched:
+
+- single-symbol technical indicators,
+- indicator overlays,
+- ATR exits,
+- bounded range reversion,
+- funding as an overlay or standalone trigger.
+
+Those surfaces produced one deployable SOL 1h candidate and many failures. The
+failure pattern was consistent: either too few trades, more trades with worse
+risk, or bootstrap collapse. The missing element is a **cross-asset market
+hypothesis**.
+
+Relative strength rotation changes the question from:
+
+> "Is this symbol oversold or trending?"
+
+to:
+
+> "Is capital rotating into this symbol versus the crypto market anchor, and can
+> we enter after a pullback without losing that leadership?"
+
+That makes the surface different in kind, not just different parameters.
+
+---
+
+## Definitions
+
+| Term | Definition |
+|------|------------|
+| Target symbol | The instrument being traded, e.g. `ETHUSDT` or `SOLUSDT`. |
+| Anchor symbol | Market beta reference used for relative strength, initially `BTCUSDT`; optionally `ETHUSDT` for alt targets. |
+| Relative strength (RS) | Target return over lookback minus anchor return over the same lookback. |
+| RS persistence | RS remains positive across more than one lookback and does not sharply deteriorate on the current bar. |
+| Risk-on anchor regime | Anchor trend and volatility conditions that permit long rotation trades. |
+| Controlled pullback | Target price resets toward VWAP/EMA or RSI reset zone without breaking target trend or RS persistence. |
+| Rotation entry | A long entry after target leadership persists and a controlled pullback resolves. |
+| Rotation failure | Exit or hold condition when target loses leadership versus anchor after entry. |
+
+---
+
+## Hypothesis
+
+**HYP-001**: A long-only relative-strength rotation strategy SHOULD have better
+out-of-sample robustness than another standalone target-symbol technical sweep
+because it conditions entries on cross-asset capital flow, not only target-local
+oscillators.
+
+**HYP-002**: The surface SHOULD be most testable on liquid symbols with enough
+history and clean execution:
+
+- `ETHUSDT`,
+- `SOLUSDT`,
+- `BTCUSDT` only when using ETH or a crypto basket proxy as the anchor,
+- optionally `AVAXUSDT` after liquidity and slippage review.
+
+**HYP-003**: Candidate #2 SHOULD start with `ETHUSDT` before adding another SOL
+technical-style agent, because SOL already has a live technical candidate and
+additional SOL agents require stronger overlap evidence.
+
+---
+
+## Requirements
+
+### Data Requirements
+
+**REQ-001**: The implementation MUST compute target and anchor returns over at
+least two configurable lookbacks.
+
+- Rationale: RS based on one lookback is fragile and can select one-bar noise.
+- Verification: unit tests cover 4h/24h or equivalent bar-count return
+  calculations for target and anchor.
+
+**REQ-002**: The implementation MUST join anchor data to target bars with
+no-lookahead semantics.
+
+- Rationale: cross-symbol joins can accidentally leak future anchor closes.
+- Verification: a test proves the anchor row timestamp is less than or equal to
+  the target decision timestamp and never newer.
+
+**REQ-003**: The first implementation SHOULD use existing `ohlcv` and
+`indicators` data only.
+
+- Rationale: this lets research start without adding a new ingestion dependency.
+- Verification: the first campaign can run on production TimescaleDB without
+  new tables.
+
+**REQ-004**: The reader/backtest path MUST expose anchor fields under explicit
+names such as `anchor_close_price`, `anchor_return_fast`,
+`anchor_return_slow`, and `rs_fast`.
+
+- Rationale: strategy code must not infer anchor data from ambiguous indicator
+  names.
+- Verification: integration tests assert the joined row schema.
+
+### Signal Requirements
+
+**REQ-005**: The strategy MUST NOT issue a BUY unless the anchor is in a
+risk-on or non-panic regime.
+
+- Rationale: relative strength during market-wide liquidation can be false
+  strength.
+- Verification: tests cover anchor drawdown/panic bars blocking otherwise valid
+  target setups.
+
+**REQ-006**: The strategy MUST require positive RS persistence before entry.
+
+- Rationale: the surface is rotation, not generic pullback buying.
+- Verification: tests cover HOLD when target pullback is valid but RS is flat or
+  negative.
+
+**REQ-007**: The strategy MUST require a controlled pullback before BUY.
+
+- Rationale: buying leadership at maximum extension increases concentration and
+  drawdown.
+- Verification: tests cover HOLD when RS is strong but target is overextended
+  from VWAP/EMA.
+
+**REQ-008**: The strategy SHOULD require pullback resolution, such as reclaiming
+VWAP/EMA, RSI reset recovery, or a close above the prior bar high.
+
+- Rationale: this avoids entering during an unresolved falling pullback.
+- Verification: tests cover HOLD while pullback is still deteriorating and BUY
+  after configured resolution.
+
+**REQ-009**: The strategy MUST include a rotation-failure exit signal or exit
+rule.
+
+- Rationale: if target leadership disappears, the original hypothesis is no
+  longer valid.
+- Verification: backtest tests cover SELL or executor exit when RS falls below
+  the configured failure threshold.
+
+**REQ-010**: The strategy MUST support a cooldown measured in bars after an exit
+or stop loss.
+
+- Rationale: repeated entries in the same rotation failure caused poor risk in
+  earlier densified surfaces.
+- Verification: tests cover no immediate re-entry during cooldown.
+
+### Risk And Execution Requirements
+
+**REQ-011**: Initial research MUST be long-only.
+
+- Rationale: short-side futures lifecycle requires a separate execution parity
+  review.
+- Verification: strategy tests assert no short SELL entry behavior when flat.
+
+**REQ-012**: Backtests MUST use executor-style ATR exits for parity with live
+futures candidates.
+
+- Rationale: promotion failures are often caused by backtest/live exit mismatch.
+- Verification: config overlays set `backtest_use_executor_exit_model: true`.
+
+**REQ-013**: The first live candidate, if any, MUST use conservative fixed
+notional and isolated futures settings consistent with current live risk.
+
+- Rationale: this is a new surface with no forward record.
+- Verification: tracked live config uses small fixed notional, isolated margin,
+  leverage cap, and one open position.
+
+### Research Process Requirements
+
+**REQ-014**: The first campaign MUST target `ETHUSDT` with `BTCUSDT` as anchor.
+
+- Rationale: ETH is liquid, independent from the live SOL technical candidate,
+  and has enough history to test rotation without adding SOL concentration.
+- Verification: campaign launcher or overlay records `symbol=ETHUSDT` and
+  `anchor_symbol=BTCUSDT`.
+
+**REQ-015**: The first campaign MUST run under the `standard` gate and MUST NOT
+use `probe_1h` for promotion.
+
+- Rationale: the original goal is deployable candidates, not weaker near-miss
+  labels.
+- Verification: campaign command uses `--gate-profile standard`.
+
+**REQ-016**: A candidate MUST have `eligible_for_bootstrap_1000=true` before
+bootstrap=1000 validation.
+
+- Rationale: bootstrap=1000 compute should only be spent on candidates that meet
+  the stricter pre-filter.
+- Verification: `last_result.json` or archive-level scanner confirms the flag or
+  recomputed promotion-candidate gate.
+
+**REQ-017**: Any candidate passing bootstrap=1000 MUST undergo entry-overlap
+analysis against:
+
+- `agent_sol_1h_trend_pullback_overlay_live`,
+- `agent_sentiment_macro`,
+- every other promoted live agent.
+
+- Rationale: candidate count matters only when entries add independent evidence.
+- Verification: overlap report exists before tracked paper/live config.
+
+---
+
+## Initial Strategy Shape
+
+The first implementation SHOULD be a single strategy named
+`relative_strength_rotation`.
+
+Initial signal logic:
+
+1. Load target and anchor rows for the same decision timestamp.
+2. Compute:
+   - fast target return,
+   - slow target return,
+   - fast anchor return,
+   - slow anchor return,
+   - fast RS,
+   - slow RS,
+   - RS deterioration versus previous bar.
+3. Confirm anchor regime:
+   - anchor is above a trend filter or not in panic drawdown,
+   - anchor volatility is not extreme unless explicitly configured.
+4. Confirm target leadership:
+   - fast RS > configured minimum,
+   - slow RS > configured minimum,
+   - RS deterioration is above configured floor.
+5. Confirm controlled pullback:
+   - target close is near VWAP or EMA,
+   - RSI is reset but not panic,
+   - ATR regime is not extreme.
+6. Confirm resolution:
+   - close reclaims VWAP/EMA,
+   - or RSI slope turns positive,
+   - or close reclaims previous bar high.
+7. Emit BUY with confidence proportional to RS strength and pullback quality.
+8. Emit SELL or HOLD-exit condition when RS failure occurs while in position.
+
+---
+
+## Candidate Parameters
+
+Initial bounded search MAY vary only these parameters:
+
+| Parameter | Intended Bound |
+|-----------|----------------|
+| `fast_lookback_bars` | 4-12 on 1h, 3-8 on 4h |
+| `slow_lookback_bars` | 18-48 on 1h, 6-18 on 4h |
+| `min_fast_rs_pct` | 0.5%-3.0% |
+| `min_slow_rs_pct` | 1.0%-8.0% |
+| `max_rs_deterioration_pct` | -1.5%-0.0% |
+| `max_vwap_distance_pct` | 0.5%-3.0% |
+| `rsi_reset_min` | 35-45 |
+| `rsi_reset_max` | 55-65 |
+| `anchor_max_drawdown_pct` | -2.0% to -5.0% |
+| `cooldown_bars` | 3-12 |
+| `time_stop_minutes` | 12-72 hours |
+
+The first search MUST NOT vary more than these parameters. Adding more knobs
+before a baseline result exists risks recreating the prior threshold-sweep
+failure mode.
+
+---
+
+## Implementation Plan
+
+### Step 1 — Data Join
+
+Add a no-lookahead cross-symbol reader path for backtest and runtime.
+
+Required output fields:
+
+- `anchor_close_price`,
+- `anchor_return_fast`,
+- `anchor_return_slow`,
+- `target_return_fast`,
+- `target_return_slow`,
+- `rs_fast`,
+- `rs_slow`,
+- `rs_deterioration`.
+
+### Step 2 — Strategy
+
+Add `src/strategy/relative_strength_rotation.py` and export/register it.
+
+The strategy MUST be usable as a single-strategy standalone candidate. It SHOULD
+not require the five-vote aggregator stack.
+
+### Step 3 — Backtest Parity
+
+Extend `BacktestEngine` and `StrategyEngine` only as much as needed to pass joined
+cross-symbol rows to the strategy. Mixed single-symbol and cross-symbol
+strategies MAY be rejected initially to keep scope controlled.
+
+### Step 4 — Autoresearch Family
+
+Add one family:
+
+```text
+relative_strength_rotation_standalone
+```
+
+The family MUST generate standalone overlays only. It MUST set:
+
+```text
+strategy.strategies = [relative_strength_rotation]
+strategy.default_trading_mode = futures
+trading_execution.exit_rules.backtest_use_executor_exit_model = true
+```
+
+### Step 5 — First Campaign
+
+Run one discovery campaign:
+
+```bash
+FAMILIES=relative_strength_rotation_standalone \
+MAX_RUNS=80 \
+GATE_PROFILE=standard \
+./scripts/run_autoresearch_campaign_remote.sh ETHUSDT 1h w9-eth-1h-relative-strength
+```
+
+If 1h overtrades or fails risk gates, run a second campaign only after reviewing
+failure mode:
+
+```bash
+FAMILIES=relative_strength_rotation_standalone \
+MAX_RUNS=80 \
+GATE_PROFILE=standard \
+./scripts/run_autoresearch_campaign_remote.sh ETHUSDT 4h w9-eth-4h-relative-strength
+```
+
+Do not run BTC/BNB/SOL variants before ETH has a readable result.
+
+---
+
+## Stop Conditions
+
+Close the surface if the first two ETH campaigns show:
+
+- best WFO trades < 15,
+- best P(loss) > 40%,
+- best max DD > 15%,
+- best Sharpe < 0.3,
+- or all positive OOS candidates have concentration > 60%.
+
+Continue only if at least one candidate is close to `promotion_candidate`.
+
+---
+
+## Compliance
+
+The surface design is complete when:
+
+1. this specification is committed,
+2. implementation tasks are identified,
+3. a first campaign can be launched without adding new market-data ingestion,
+4. success/failure criteria are explicit,
+5. and the surface is clearly different from prior single-symbol threshold
+   sweeps.
+
+The surface is promotion-compliant only when a concrete candidate passes:
+
+1. standard gate at bootstrap=100,
+2. `promotion_candidate`,
+3. bootstrap=1000,
+4. entry-overlap analysis,
+5. paper/tracked config review,
+6. and conservative live deployment review.
+
+---
+
+## Open Questions
+
+1. Should the first target be `ETHUSDT` only, or should `SOLUSDT` be allowed if
+   ETH is too sparse?
+2. Should anchor regime use only BTC, or a BTC/ETH composite for SOL/AVAX?
+3. Should the first implementation support exits on RS failure, or rely on ATR
+   and time-stop exits for the initial campaign?
+
+Default answers for v0:
+
+1. start with `ETHUSDT`,
+2. use `BTCUSDT` only,
+3. include RS failure exit in strategy logic, but keep ATR/time-stop as primary
+   hard exits.

--- a/ops/systemd/crypto-agent-production-drift-sentinel.service
+++ b/ops/systemd/crypto-agent-production-drift-sentinel.service
@@ -5,6 +5,7 @@ Requires=docker.service
 
 [Service]
 Type=oneshot
+User=emilio
 WorkingDirectory=/opt/crypto-agent
 Environment=EXPECTED_DEPLOY_BRANCH=main
 EnvironmentFile=-/etc/default/crypto-agent-production-drift-sentinel

--- a/ops/systemd/crypto-agent-production-drift-sentinel.service
+++ b/ops/systemd/crypto-agent-production-drift-sentinel.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Audit crypto-agent production drift
+After=docker.service
+Requires=docker.service
+
+[Service]
+Type=oneshot
+WorkingDirectory=/opt/crypto-agent
+Environment=EXPECTED_DEPLOY_BRANCH=main
+EnvironmentFile=-/etc/default/crypto-agent-production-drift-sentinel
+ExecStart=/usr/bin/python3 scripts/production_drift_sentinel.py --production-local --remote-dir /opt/crypto-agent --watch-service agent_sol_sparse --signal-stale-hours 72 --fail-on error --output-prefix data/reports/production-drift-sentinel
+
+[Install]
+WantedBy=multi-user.target

--- a/ops/systemd/crypto-agent-production-drift-sentinel.service
+++ b/ops/systemd/crypto-agent-production-drift-sentinel.service
@@ -2,6 +2,7 @@
 Description=Audit crypto-agent production drift
 After=docker.service
 Requires=docker.service
+OnFailure=crypto-agent-telegram-failure@%n.service
 
 [Service]
 Type=oneshot

--- a/ops/systemd/crypto-agent-production-drift-sentinel.timer
+++ b/ops/systemd/crypto-agent-production-drift-sentinel.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Audit crypto-agent production drift hourly
+
+[Timer]
+OnCalendar=hourly
+Persistent=true
+Unit=crypto-agent-production-drift-sentinel.service
+
+[Install]
+WantedBy=timers.target

--- a/ops/systemd/crypto-agent-telegram-failure@.service
+++ b/ops/systemd/crypto-agent-telegram-failure@.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Send Telegram alert for failed crypto-agent unit %i
+
+[Service]
+Type=oneshot
+User=emilio
+WorkingDirectory=/opt/crypto-agent
+EnvironmentFile=/opt/crypto-agent/.env
+ExecStart=/usr/bin/python3 scripts/notify_systemd_failure.py --unit %i

--- a/scripts/analyze_entry_overlap.py
+++ b/scripts/analyze_entry_overlap.py
@@ -254,7 +254,7 @@ async def _collect_oos_entries(
                 )
                 result_bt = await _run_backtest(reader, window_config)
                 for trade in result_bt.trades:
-                    if trade.side.lower() != "long":
+                    if trade.side.upper() not in {"BUY", "LONG"}:
                         continue
                     entries.append(_normalize_entry(trade.entry_time, timeframe=run_timeframe))
     finally:

--- a/scripts/analyze_entry_overlap.py
+++ b/scripts/analyze_entry_overlap.py
@@ -1,0 +1,490 @@
+#!/usr/bin/env python3
+"""Compare entry-time overlap across agent configs on the same symbol/timeframe."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from itertools import combinations
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from scripts.experiment_autopilot import (  # noqa: E402
+    _build_backtest_config,
+    _db_config_from_settings,
+    _resolve_data_range,
+    _run_backtest,
+)
+from scripts.run_autoresearch import _deep_merge, _read_yaml  # noqa: E402
+from src.backtest.experiment_autopilot import build_wfo_windows  # noqa: E402
+from src.db import close_pool, get_pool, init_pool  # noqa: E402
+from src.features.reader import IndicatorReader  # noqa: E402
+from src.main import _resolve_strategy_config, load_settings  # noqa: E402
+from src.utils.logger import configure_logger  # noqa: E402
+
+
+@dataclass(frozen=True)
+class AgentSpec:
+    label: str
+    config_path: Path
+    base_config_path: Path | None
+    replay_sentiment_log: str | None
+    replay_sentiment_max_age_hours: float | None
+    note: str | None
+
+
+@dataclass(frozen=True)
+class EntrySet:
+    label: str
+    symbol: str
+    timeframe: str
+    entries: list[datetime]
+    note: str | None = None
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Analyze entry-time overlap across agents")
+    parser.add_argument(
+        "--manifest",
+        default="config/autoresearch/overlap_manifest_sol_1h.yaml",
+        help="YAML manifest listing agents to compare",
+    )
+    parser.add_argument("--symbol", help="Override manifest symbol")
+    parser.add_argument("--timeframe", help="Override manifest timeframe")
+    parser.add_argument("--train-months", type=int, help="WFO train months")
+    parser.add_argument("--test-months", type=int, help="WFO test months")
+    parser.add_argument(
+        "--tolerance-hours",
+        type=int,
+        default=1,
+        help="Match entries within this many hours as overlapping",
+    )
+    parser.add_argument(
+        "--output",
+        default="docs/reports/entry-overlap-sol-1h.json",
+        help="JSON report output path",
+    )
+    parser.add_argument(
+        "--include-live-db",
+        action="store_true",
+        help="Append live positions overlap from TimescaleDB (last 730 days)",
+    )
+    parser.add_argument("--live-days", type=int, default=730)
+    parser.add_argument(
+        "--agent-ids",
+        nargs="*",
+        default=[
+            "sol-1h-trend-pullback-overlay-live",
+            "sentiment-macro-bot",
+        ],
+        help="agent_id values for live DB overlap section",
+    )
+    return parser.parse_args()
+
+
+def _load_manifest(path: Path) -> dict[str, Any]:
+    data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    if not isinstance(data, dict):
+        raise ValueError(f"Expected mapping in {path}")
+    return data
+
+
+def _parse_agents(manifest: dict[str, Any]) -> list[AgentSpec]:
+    agents_raw = manifest.get("agents")
+    if not isinstance(agents_raw, list):
+        raise ValueError("manifest.agents must be a list")
+
+    specs: list[AgentSpec] = []
+    for item in agents_raw:
+        if not isinstance(item, dict):
+            continue
+        label = str(item["label"])
+        config_path = Path(str(item["config"]))
+        base = item.get("base_config")
+        specs.append(
+            AgentSpec(
+                label=label,
+                config_path=config_path,
+                base_config_path=Path(str(base)) if base else None,
+                replay_sentiment_log=(
+                    str(item["replay_sentiment_log"]) if item.get("replay_sentiment_log") else None
+                ),
+                replay_sentiment_max_age_hours=(
+                    float(item["replay_sentiment_max_age_hours"])
+                    if item.get("replay_sentiment_max_age_hours") is not None
+                    else None
+                ),
+                note=str(item["note"]) if item.get("note") else None,
+            )
+        )
+    return specs
+
+
+def _resolve_config_path(spec: AgentSpec) -> Path:
+    if spec.base_config_path is None:
+        return spec.config_path
+    merged = _deep_merge(_read_yaml(spec.base_config_path), _read_yaml(spec.config_path))
+    out = Path("research/overlap-resolved") / f"{spec.label}.yaml"
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(yaml.safe_dump(merged, sort_keys=False), encoding="utf-8")
+    return out
+
+
+def _normalize_entry(ts: str, *, timeframe: str) -> datetime:
+    dt = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=UTC)
+    if timeframe.endswith("h"):
+        hours = int(timeframe[:-1])
+        floored = dt.replace(minute=0, second=0, microsecond=0)
+        hour_bucket = (floored.hour // hours) * hours
+        return floored.replace(hour=hour_bucket)
+    return dt.replace(minute=0, second=0, microsecond=0)
+
+
+def _entry_buckets(entries: list[datetime], *, tolerance: timedelta) -> list[datetime]:
+    if not entries:
+        return []
+    sorted_entries = sorted(entries)
+    buckets: list[datetime] = []
+    for entry in sorted_entries:
+        if not buckets or entry - buckets[-1] > tolerance:
+            buckets.append(entry)
+    return buckets
+
+
+def _match_overlap(a: list[datetime], b: list[datetime], *, tolerance: timedelta) -> int:
+    if not a or not b:
+        return 0
+    matches = 0
+    j = 0
+    for left in sorted(a):
+        while j < len(b) and b[j] < left - tolerance:
+            j += 1
+        if j < len(b) and abs((b[j] - left).total_seconds()) <= tolerance.total_seconds():
+            matches += 1
+    return matches
+
+
+def _pair_metrics(
+    left: EntrySet,
+    right: EntrySet,
+    *,
+    tolerance: timedelta,
+) -> dict[str, float | int]:
+    left_b = _entry_buckets(left.entries, tolerance=tolerance)
+    right_b = _entry_buckets(right.entries, tolerance=tolerance)
+    shared = _match_overlap(left_b, right_b, tolerance=tolerance)
+    union = len(left_b) + len(right_b) - shared
+    jaccard = (shared / union) if union else 0.0
+    pct_left = (shared / len(left_b) * 100.0) if left_b else 0.0
+    pct_right = (shared / len(right_b) * 100.0) if right_b else 0.0
+    return {
+        "shared_entries": shared,
+        "left_entries": len(left_b),
+        "right_entries": len(right_b),
+        "jaccard": round(jaccard, 4),
+        "pct_of_left_also_in_right": round(pct_left, 2),
+        "pct_of_right_also_in_left": round(pct_right, 2),
+    }
+
+
+async def _collect_oos_entries(
+    spec: AgentSpec,
+    *,
+    symbol: str,
+    timeframe: str,
+    train_months: int,
+    test_months: int,
+    start: str | None,
+    end: str | None,
+) -> EntrySet:
+    config_path = _resolve_config_path(spec)
+    settings = load_settings(config_path)
+    run_symbol = symbol or settings.trading_pairs[0]
+    run_timeframe = timeframe or settings.timeframe
+
+    result = _resolve_strategy_config(settings.strategy)
+    strategy_classes = result[0]
+    strategy_configs = result[1]
+    aggregator_config = dict(result[2])
+
+    raw_config = _read_yaml(config_path)
+    db_config = _db_config_from_settings(settings)
+    await init_pool(db_config)
+    try:
+        range_start, range_end = await _resolve_data_range(run_symbol, run_timeframe)
+        range_start = start or range_start
+        range_end = end or range_end
+
+        windows = build_wfo_windows(
+            start=range_start,
+            end=range_end,
+            train_months=train_months,
+            test_months=test_months,
+        )
+
+        reader = IndicatorReader(db_config)
+        entries: list[datetime] = []
+        async with reader:
+            for window in windows:
+                window_config = _build_backtest_config(
+                    settings=settings,
+                    raw_config=raw_config,
+                    symbol=run_symbol,
+                    timeframe=run_timeframe,
+                    start=window.test_start,
+                    end=window.test_end,
+                    strategy_classes=strategy_classes,
+                    strategy_configs=strategy_configs,
+                    aggregator_config=aggregator_config,
+                    initial_capital=10000.0,
+                    disable_trend_filter=False,
+                    replay_sentiment_path=spec.replay_sentiment_log,
+                    replay_sentiment_max_age_hours=spec.replay_sentiment_max_age_hours,
+                )
+                result_bt = await _run_backtest(reader, window_config)
+                for trade in result_bt.trades:
+                    if trade.side.lower() != "long":
+                        continue
+                    entries.append(_normalize_entry(trade.entry_time, timeframe=run_timeframe))
+    finally:
+        await close_pool()
+
+    return EntrySet(
+        label=spec.label,
+        symbol=run_symbol,
+        timeframe=run_timeframe,
+        entries=entries,
+        note=spec.note,
+    )
+
+
+async def _collect_live_entries(
+    *,
+    symbol: str,
+    agent_ids: list[str],
+    live_days: int,
+) -> list[EntrySet]:
+    pool = get_pool()
+    cutoff = datetime.now(UTC) - timedelta(days=live_days)
+    sets: list[EntrySet] = []
+    query = """
+        SELECT agent_id, entry_time
+        FROM positions
+        WHERE symbol = $1
+          AND agent_id = ANY($2::text[])
+          AND entry_time >= $3
+          AND position_side = 'LONG'
+        ORDER BY entry_time
+    """
+    async with pool.acquire() as conn:
+        rows = await conn.fetch(query, symbol, agent_ids, cutoff)
+
+    by_agent: dict[str, list[datetime]] = {agent_id: [] for agent_id in agent_ids}
+    for row in rows:
+        agent_id = str(row["agent_id"])
+        entry_time = row["entry_time"]
+        if entry_time.tzinfo is None:
+            entry_time = entry_time.replace(tzinfo=UTC)
+        by_agent.setdefault(agent_id, []).append(
+            entry_time.replace(minute=0, second=0, microsecond=0)
+        )
+
+    for agent_id, entries in by_agent.items():
+        sets.append(
+            EntrySet(
+                label=f"live:{agent_id}",
+                symbol=symbol,
+                timeframe="live",
+                entries=entries,
+            )
+        )
+    return sets
+
+
+def _render_markdown(report: dict[str, Any]) -> str:
+    lines = [
+        "# Entry overlap report",
+        "",
+        f"- Symbol: `{report['symbol']}`",
+        f"- Timeframe: `{report['timeframe']}`",
+        f"- WFO: train={report['train_months']}mo test={report['test_months']}mo",
+        f"- Tolerance: {report['tolerance_hours']}h",
+        "",
+        "## OOS entry counts (backtest)",
+        "",
+        "| Agent | Symbol | Entries | Note |",
+        "|-------|--------|---------|------|",
+    ]
+    for row in report["entry_counts"]:
+        note = row.get("note") or ""
+        lines.append(f"| {row['label']} | {row['symbol']} | {row['entries']} | {note} |")
+
+    lines.extend(["", "## Pairwise overlap (OOS backtest)", ""])
+    lines.append("| A | B | Shared | Jaccard | %A in B | %B in A |")
+    lines.append("|---|---|---:|---:|---:|---:|")
+    for pair in report["pairwise_oos"]:
+        lines.append(
+            f"| {pair['left']} | {pair['right']} | {pair['shared_entries']} | "
+            f"{pair['jaccard']:.2%} | {pair['pct_of_left_also_in_right']:.1f}% | "
+            f"{pair['pct_of_right_also_in_left']:.1f}% |"
+        )
+
+    if report.get("pairwise_live"):
+        lines.extend(["", "## Pairwise overlap (live DB)", ""])
+        lines.append("| A | B | Shared | Jaccard | %A in B | %B in A |")
+        lines.append("|---|---|---:|---:|---:|---:|")
+        for pair in report["pairwise_live"]:
+            lines.append(
+                f"| {pair['left']} | {pair['right']} | {pair['shared_entries']} | "
+                f"{pair['jaccard']:.2%} | {pair['pct_of_left_also_in_right']:.1f}% | "
+                f"{pair['pct_of_right_also_in_left']:.1f}% |"
+            )
+
+    lines.extend(["", "## Interpretation", "", report.get("interpretation", ""), ""])
+    return "\n".join(lines)
+
+
+def _interpret(report: dict[str, Any]) -> str:
+    pairs = report.get("pairwise_oos", [])
+    focus = [
+        p
+        for p in pairs
+        if "sol_1h_trend_pullback_overlay_live" in (p["left"], p["right"])
+        and "sentiment_macro" in (p["left"], p["right"])
+    ]
+    if not focus:
+        return "No live vs sentiment pair found in manifest."
+    row = focus[0]
+    jaccard = float(row["jaccard"])
+    pct_live = float(row.get("pct_of_left_also_in_right", 0.0))
+    if row["left"] != "sol_1h_trend_pullback_overlay_live":
+        pct_live = float(row.get("pct_of_right_also_in_left", 0.0))
+    if jaccard >= 0.35 or pct_live >= 40.0:
+        return (
+            "High overlap between SOL 1h trend_pullback overlay and sentiment-macro on "
+            "OOS entries. Adding another SOL 1h technical agent likely concentrates risk "
+            "rather than diversifying."
+        )
+    if jaccard >= 0.15 or pct_live >= 20.0:
+        return (
+            "Moderate overlap between SOL 1h overlay and sentiment-macro. Any second SOL "
+            "1h candidate needs explicit independence justification and lower size."
+        )
+    return (
+        "Low OOS entry overlap between SOL 1h overlay and sentiment-macro. A second SOL 1h "
+        "agent may add diversification if it passes promotion gates independently."
+    )
+
+
+async def main() -> None:
+    args = parse_args()
+    configure_logger("INFO")
+    manifest = _load_manifest(Path(args.manifest))
+    specs = _parse_agents(manifest)
+
+    symbol = args.symbol or str(manifest.get("symbol", "SOLUSDT"))
+    timeframe = args.timeframe or str(manifest.get("timeframe", "1h"))
+    train_months = args.train_months or int(manifest.get("train_months", 3))
+    test_months = args.test_months or int(manifest.get("test_months", 2))
+    tolerance = timedelta(hours=args.tolerance_hours)
+
+    entry_sets: list[EntrySet] = []
+    for spec in specs:
+        entry_sets.append(
+            await _collect_oos_entries(
+                spec,
+                symbol=symbol,
+                timeframe=timeframe,
+                train_months=train_months,
+                test_months=test_months,
+                start=None,
+                end=None,
+            )
+        )
+
+    sol_sets = [s for s in entry_sets if s.symbol == symbol]
+    pairwise_oos = []
+    for left, right in combinations(sol_sets, 2):
+        metrics = _pair_metrics(left, right, tolerance=tolerance)
+        pairwise_oos.append(
+            {
+                "left": left.label,
+                "right": right.label,
+                **metrics,
+            }
+        )
+
+    report: dict[str, Any] = {
+        "generated_at": datetime.now(UTC).isoformat(),
+        "symbol": symbol,
+        "timeframe": timeframe,
+        "train_months": train_months,
+        "test_months": test_months,
+        "tolerance_hours": args.tolerance_hours,
+        "entry_counts": [
+            {
+                "label": s.label,
+                "symbol": s.symbol,
+                "entries": len(_entry_buckets(s.entries, tolerance=tolerance)),
+                "note": s.note,
+            }
+            for s in entry_sets
+        ],
+        "pairwise_oos": pairwise_oos,
+    }
+
+    if args.include_live_db:
+        db_config = {
+            "host": str(os.getenv("POSTGRES_HOST", "localhost")),
+            "port": int(os.getenv("POSTGRES_PORT", 5432)),
+            "name": str(os.getenv("POSTGRES_DB", "marketdata")),
+            "user": str(os.getenv("POSTGRES_USER", "trading")),
+            "password": str(os.getenv("POSTGRES_PASSWORD", "")),
+        }
+        await init_pool(db_config)
+        try:
+            live_sets = await _collect_live_entries(
+                symbol=symbol,
+                agent_ids=list(args.agent_ids),
+                live_days=args.live_days,
+            )
+            report["live_entry_counts"] = [
+                {"label": s.label, "entries": len(s.entries)} for s in live_sets
+            ]
+            pairwise_live = []
+            for left, right in combinations(live_sets, 2):
+                pairwise_live.append(
+                    {
+                        "left": left.label,
+                        "right": right.label,
+                        **_pair_metrics(left, right, tolerance=tolerance),
+                    }
+                )
+            report["pairwise_live"] = pairwise_live
+        finally:
+            await close_pool()
+
+    report["interpretation"] = _interpret(report)
+
+    out_path = Path(args.output)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(report, indent=2), encoding="utf-8")
+    md_path = out_path.with_suffix(".md")
+    md_path.write_text(_render_markdown(report), encoding="utf-8")
+    print(json.dumps(report, indent=2))
+    print(f"\nWrote {out_path} and {md_path}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/scripts/audit_funding_coverage.py
+++ b/scripts/audit_funding_coverage.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Audit funding_rates table coverage for Phase 3 planning."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from src.db import close_pool, get_pool, init_pool  # noqa: E402
+
+
+async def main(symbols: list[str]) -> None:
+    pool = await get_pool()
+    async with pool.acquire() as conn:
+        for symbol in symbols:
+            row = await conn.fetchrow(
+                """
+                SELECT COUNT(*) AS n,
+                       MIN(funding_time) AS min_time,
+                       MAX(funding_time) AS max_time
+                FROM funding_rates
+                WHERE symbol = $1
+                """,
+                symbol,
+            )
+            print(f"{symbol}: rows={row['n']} range={row['min_time']} .. {row['max_time']}")
+    await close_pool()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--symbols",
+        default="BTCUSDT,ETHUSDT,SOLUSDT,BNBUSDT,AVAXUSDT",
+        help="Comma-separated symbols",
+    )
+    args = parser.parse_args()
+    init_pool(
+        host=os.environ.get("POSTGRES_HOST", "localhost"),
+        port=int(os.environ.get("POSTGRES_PORT", "5432")),
+        database=os.environ["POSTGRES_DB"],
+        user=os.environ["POSTGRES_USER"],
+        password=os.environ["POSTGRES_PASSWORD"],
+    )
+    asyncio.run(main([s.strip() for s in args.symbols.split(",") if s.strip()]))

--- a/scripts/autoresearch_loop.py
+++ b/scripts/autoresearch_loop.py
@@ -26,6 +26,10 @@ DEFAULT_FAMILIES = (
     "standard_gate_bridge",
     "near_miss_trade_lift",
     "trend_pullback_overlay",
+    "breakout_retest_overlay",
+    "volatility_squeeze_overlay",
+    "funding_extreme_overlay",
+    "regime_gated_pullback_overlay",
 )
 
 BASE_STRATEGY_CONFIGS: tuple[dict[str, Any], ...] = (
@@ -148,6 +152,41 @@ def _strategy_configs_with_overrides(
     return strategies
 
 
+def _per_symbol_aggregator_config(
+    symbol: str,
+    *,
+    buy: float,
+    sell: float,
+    buy_uptrend: float | None = None,
+    min_agreement: int = 1,
+    sell_min_agreement: int | None = None,
+) -> dict[str, dict[str, float | int]]:
+    uptrend = buy if buy_uptrend is None else buy_uptrend
+    sell_min = sell_min_agreement if sell_min_agreement is not None else 2
+    return {
+        symbol: {
+            "min_agreement": min_agreement,
+            "buy_threshold": buy,
+            "buy_threshold_uptrend": uptrend,
+            "sell_threshold": sell,
+            "sell_min_agreement": sell_min,
+        }
+    }
+
+
+def _sol_winner_stack_params(rng: random.Random) -> dict[str, float | int]:
+    """Parameter band around the SOL 1h trend_pullback_overlay winner."""
+    return {
+        "macd_min": _round(rng.uniform(0.0, 0.00025), 5),
+        "macd_atr_min": _round(rng.uniform(0.0075, 0.0092), 4),
+        "bb_distance": _round(rng.uniform(0.0045, 0.0058), 4),
+        "bb_rsi_oversold": rng.choice([30, 35]),
+        "bb_rsi_overbought": rng.choice([65, 70]),
+        "cci_atr_min": _round(rng.uniform(0.0105, 0.0118), 4),
+        "vwap_atr_multiplier": _round(rng.uniform(1.85, 2.12), 2),
+    }
+
+
 def _parse_families(raw: str) -> tuple[str, ...]:
     families = tuple(part.strip() for part in raw.split(",") if part.strip())
     if not families:
@@ -162,6 +201,7 @@ def generate_candidate(
     run_index: int,
     *,
     seed: int,
+    symbol: str = "SOLUSDT",
     families: tuple[str, ...] = DEFAULT_FAMILIES,
     aggregator_focus: bool = False,
 ) -> Candidate:
@@ -174,6 +214,7 @@ def generate_candidate(
 
     rng = random.Random(seed + run_index * 7919)
     family = rng.choice(families)
+    trading_symbol = symbol.upper()
 
     if family == "aggregator_thresholds":
         if aggregator_focus:
@@ -195,14 +236,14 @@ def generate_candidate(
                     "buy_threshold_uptrend": buy_uptrend,
                     "sell_threshold": sell,
                 },
-                "per_symbol_aggregator_config": {
-                    "SOLUSDT": {
-                        "min_agreement": min_agreement,
-                        "buy_threshold": buy,
-                        "sell_threshold": sell,
-                        "sell_min_agreement": sell_min_agreement,
-                    }
-                },
+                "per_symbol_aggregator_config": _per_symbol_aggregator_config(
+                    trading_symbol,
+                    buy=buy,
+                    sell=sell,
+                    buy_uptrend=buy_uptrend,
+                    min_agreement=min_agreement,
+                    sell_min_agreement=sell_min_agreement,
+                ),
             }
         }
         desc = (
@@ -304,16 +345,16 @@ def generate_candidate(
                     "buy_threshold_uptrend": buy_uptrend,
                     "sell_threshold": sell,
                 },
-                "per_symbol_aggregator_config": {
-                    "SOLUSDT": {
-                        "min_agreement": 1,
-                        "buy_threshold": buy,
-                        "sell_threshold": sell,
-                        "sell_min_agreement": rng.choice([1, 2]),
-                    }
-                },
             },
         }
+        combined_sell_min = rng.choice([1, 2])
+        overlay["strategy"]["per_symbol_aggregator_config"] = _per_symbol_aggregator_config(
+            trading_symbol,
+            buy=buy,
+            sell=sell,
+            buy_uptrend=buy_uptrend,
+            sell_min_agreement=combined_sell_min,
+        )
         desc = (
             f"combined buy={buy:.2f} uptrend={buy_uptrend:.2f} sell={sell:.2f} "
             f"bb={bb_distance:.4f} macd_atr={macd_atr_min:.4f} "
@@ -352,14 +393,13 @@ def generate_candidate(
                     "buy_threshold_uptrend": buy_uptrend,
                     "sell_threshold": sell,
                 },
-                "per_symbol_aggregator_config": {
-                    "SOLUSDT": {
-                        "min_agreement": 1,
-                        "buy_threshold": buy,
-                        "sell_threshold": sell,
-                        "sell_min_agreement": rng.choice([1, 2]),
-                    }
-                },
+                "per_symbol_aggregator_config": _per_symbol_aggregator_config(
+                    trading_symbol,
+                    buy=buy,
+                    sell=sell,
+                    buy_uptrend=buy_uptrend,
+                    sell_min_agreement=rng.choice([1, 2]),
+                ),
             },
         }
         desc = (
@@ -400,14 +440,13 @@ def generate_candidate(
                     "buy_threshold_uptrend": buy_uptrend,
                     "sell_threshold": sell,
                 },
-                "per_symbol_aggregator_config": {
-                    "SOLUSDT": {
-                        "min_agreement": 1,
-                        "buy_threshold": buy,
-                        "sell_threshold": sell,
-                        "sell_min_agreement": rng.choice([1, 2]),
-                    }
-                },
+                "per_symbol_aggregator_config": _per_symbol_aggregator_config(
+                    trading_symbol,
+                    buy=buy,
+                    sell=sell,
+                    buy_uptrend=buy_uptrend,
+                    sell_min_agreement=rng.choice([1, 2]),
+                ),
             },
         }
         desc = (
@@ -462,20 +501,224 @@ def generate_candidate(
                     "sell_threshold": sell,
                     "min_confidence": _round(rng.uniform(0.0, 0.45), 2),
                 },
-                "per_symbol_aggregator_config": {
-                    "SOLUSDT": {
-                        "min_agreement": 1,
-                        "buy_threshold": buy,
-                        "buy_threshold_uptrend": buy_uptrend,
-                        "sell_threshold": sell,
-                        "sell_min_agreement": rng.choice([1, 2]),
-                    }
-                },
+                "per_symbol_aggregator_config": _per_symbol_aggregator_config(
+                    trading_symbol,
+                    buy=buy,
+                    sell=sell,
+                    buy_uptrend=buy_uptrend,
+                    sell_min_agreement=rng.choice([1, 2]),
+                ),
             },
         }
         desc = (
             f"trend-pullback-overlay buy={buy:.2f} uptrend={buy_uptrend:.2f} "
             f"sell={sell:.2f} rsi={trend_pullback['config']['rsi_reclaim_level']} "
+            f"trend={trend_pullback['config']['min_trend_strength_pct']:.4f}"
+        )
+    elif family == "breakout_retest_overlay":
+        buy = _round(rng.uniform(1.12, 1.38), 2)
+        buy_uptrend = _round(rng.uniform(0.98, min(1.18, buy)), 2)
+        sell = _round(-rng.uniform(0.74, 0.86), 2)
+        stack = _sol_winner_stack_params(rng)
+        breakout_retest = {
+            "name": "breakout_retest",
+            "config": {
+                "min_trend_strength_pct": _round(rng.uniform(0.006, 0.010), 4),
+                "min_atr_pct": _round(rng.uniform(0.008, 0.011), 4),
+                "breakout_rsi_level": _round(rng.uniform(56.0, 60.0), 1),
+                "breakout_min_macd_hist": _round(rng.uniform(-0.002, 0.002), 4),
+                "breakout_band_distance_threshold": _round(rng.uniform(0.008, 0.012), 4),
+                "breakout_min_vwap_extension_pct": _round(rng.uniform(0.008, 0.014), 4),
+                "retest_window_bars": rng.choice([4, 5, 6]),
+                "retest_vwap_distance_pct": _round(rng.uniform(0.012, 0.020), 4),
+                "retest_ema50_distance_pct": _round(rng.uniform(0.012, 0.020), 4),
+                "reclaim_rsi_level": rng.choice([48, 50, 52]),
+                "retest_min_macd_hist": _round(rng.uniform(-0.012, 0.0), 4),
+                "max_extension_after_retest_pct": _round(rng.uniform(0.020, 0.030), 4),
+            },
+        }
+        overlay = {
+            "trading_execution": {
+                "sl_atr_multiplier": _round(rng.uniform(2.10, 2.45), 2),
+                "tp_atr_multiplier": _round(rng.uniform(3.60, 4.40), 2),
+                "trailing_activate_atr": _round(rng.uniform(1.55, 2.10), 2),
+                "trailing_offset_atr": _round(rng.uniform(0.80, 1.10), 2),
+            },
+            "strategy": {
+                "strategies": [
+                    *_strategy_configs_with_overrides(**stack),
+                    breakout_retest,
+                ],
+                "aggregator": {
+                    "buy_threshold": buy,
+                    "buy_threshold_uptrend": buy_uptrend,
+                    "sell_threshold": sell,
+                    "min_confidence": _round(rng.uniform(0.0, 0.40), 2),
+                },
+                "per_symbol_aggregator_config": _per_symbol_aggregator_config(
+                    trading_symbol,
+                    buy=buy,
+                    sell=sell,
+                    buy_uptrend=buy_uptrend,
+                    sell_min_agreement=rng.choice([1, 2]),
+                ),
+            },
+        }
+        desc = (
+            f"breakout-retest-overlay buy={buy:.2f} window="
+            f"{breakout_retest['config']['retest_window_bars']} "
+            f"reclaim={breakout_retest['config']['reclaim_rsi_level']}"
+        )
+    elif family == "volatility_squeeze_overlay":
+        buy = _round(rng.uniform(1.05, 1.28), 2)
+        buy_uptrend = _round(rng.uniform(0.92, min(1.12, buy)), 2)
+        sell = _round(-rng.uniform(0.74, 0.88), 2)
+        stack = _sol_winner_stack_params(rng)
+        volatility_squeeze = {
+            "name": "volatility_squeeze",
+            "config": {
+                "squeeze_lookback": rng.choice([40, 50, 60]),
+                "squeeze_percentile": _round(rng.uniform(0.15, 0.25), 2),
+                "sma_period": 20,
+                "momentum_period": rng.choice([8, 10, 12]),
+                "atr_trail_multiplier": _round(rng.uniform(2.5, 3.5), 2),
+                "max_hold_bars": rng.choice([20, 30, 40]),
+                "min_atr_pct": _round(rng.uniform(0.005, 0.009), 4),
+            },
+        }
+        overlay = {
+            "trading_execution": {
+                "sl_atr_multiplier": _round(rng.uniform(2.0, 2.6), 2),
+                "tp_atr_multiplier": _round(rng.uniform(3.2, 4.8), 2),
+                "trailing_activate_atr": _round(rng.uniform(1.4, 2.0), 2),
+                "trailing_offset_atr": _round(rng.uniform(0.75, 1.05), 2),
+            },
+            "strategy": {
+                "strategies": [
+                    *_strategy_configs_with_overrides(**stack),
+                    volatility_squeeze,
+                ],
+                "aggregator": {
+                    "buy_threshold": buy,
+                    "buy_threshold_uptrend": buy_uptrend,
+                    "sell_threshold": sell,
+                    "min_confidence": _round(rng.uniform(0.0, 0.35), 2),
+                },
+                "per_symbol_aggregator_config": _per_symbol_aggregator_config(
+                    trading_symbol,
+                    buy=buy,
+                    sell=sell,
+                    buy_uptrend=buy_uptrend,
+                    sell_min_agreement=rng.choice([1, 2]),
+                ),
+            },
+        }
+        desc = (
+            f"vol-squeeze-overlay buy={buy:.2f} pctile="
+            f"{volatility_squeeze['config']['squeeze_percentile']:.2f} "
+            f"hold={volatility_squeeze['config']['max_hold_bars']}"
+        )
+    elif family == "funding_extreme_overlay":
+        buy = _round(rng.uniform(0.85, 1.15), 2)
+        buy_uptrend = _round(rng.uniform(0.80, min(1.05, buy)), 2)
+        sell = _round(-rng.uniform(0.70, 0.85), 2)
+        stack = _sol_winner_stack_params(rng)
+        funding_rate = {
+            "name": "funding_rate",
+            "config": {
+                "entry_threshold": _round(rng.uniform(0.0003, 0.0008), 5),
+                "exit_threshold": _round(rng.uniform(0.00005, 0.00015), 5),
+                "lookback_periods": 1,
+            },
+        }
+        overlay = {
+            "trading_execution": {
+                "sl_atr_multiplier": _round(rng.uniform(2.0, 2.5), 2),
+                "tp_atr_multiplier": _round(rng.uniform(3.4, 4.2), 2),
+                "trailing_activate_atr": _round(rng.uniform(1.5, 2.0), 2),
+                "trailing_offset_atr": _round(rng.uniform(0.80, 1.05), 2),
+            },
+            "strategy": {
+                "strategies": [
+                    *_strategy_configs_with_overrides(**stack),
+                    funding_rate,
+                ],
+                "aggregator": {
+                    "buy_threshold": buy,
+                    "buy_threshold_uptrend": buy_uptrend,
+                    "sell_threshold": sell,
+                    "min_confidence": _round(rng.uniform(0.0, 0.30), 2),
+                },
+                "per_symbol_aggregator_config": _per_symbol_aggregator_config(
+                    trading_symbol,
+                    buy=buy,
+                    sell=sell,
+                    buy_uptrend=buy_uptrend,
+                    sell_min_agreement=1,
+                ),
+            },
+        }
+        desc = (
+            f"funding-extreme-overlay entry={funding_rate['config']['entry_threshold']:.5f} "
+            f"buy={buy:.2f}"
+        )
+    elif family == "regime_gated_pullback_overlay":
+        buy = _round(rng.uniform(1.15, 1.40), 2)
+        buy_uptrend = _round(rng.uniform(1.00, min(1.20, buy)), 2)
+        sell = _round(-rng.uniform(0.74, 0.86), 2)
+        stack = _sol_winner_stack_params(rng)
+        stack["macd_atr_min"] = _round(rng.uniform(0.0085, 0.0120), 4)
+        stack["cci_atr_min"] = _round(rng.uniform(0.0115, 0.0140), 4)
+        trend_pullback = {
+            "name": "trend_pullback",
+            "config": {
+                "rsi_reclaim_level": rng.choice([48, 50, 52]),
+                "min_trend_strength_pct": _round(rng.uniform(0.008, 0.014), 4),
+                "max_pullback_distance_pct": _round(rng.uniform(0.012, 0.025), 4),
+                "vwap_pullback_distance_pct": _round(rng.uniform(0.012, 0.030), 4),
+                "min_atr_pct": _round(rng.uniform(0.008, 0.014), 4),
+                "min_macd_hist": _round(rng.uniform(-0.010, 0.002), 4),
+                "strong_trend_strength_pct": _round(rng.uniform(0.014, 0.022), 4),
+                "continuation_rsi_level": rng.choice([52, 54, 56]),
+                "continuation_max_vwap_distance_pct": _round(rng.uniform(0.025, 0.045), 4),
+                "continuation_max_ema50_extension_pct": _round(rng.uniform(0.018, 0.035), 4),
+                "continuation_min_macd_hist": _round(rng.uniform(-0.010, 0.002), 4),
+            },
+        }
+        overlay = {
+            "trading_execution": {
+                "sl_atr_multiplier": _round(rng.uniform(2.15, 2.50), 2),
+                "tp_atr_multiplier": _round(rng.uniform(3.70, 4.50), 2),
+                "trailing_activate_atr": _round(rng.uniform(1.60, 2.15), 2),
+                "trailing_offset_atr": _round(rng.uniform(0.85, 1.10), 2),
+            },
+            "strategy": {
+                "global_trend_filter_buffer_pct": _round(rng.uniform(0.0, 0.01), 4),
+                "strategies": [
+                    *_strategy_configs_with_overrides(**stack),
+                    trend_pullback,
+                ],
+                "aggregator": {
+                    "buy_threshold": buy,
+                    "buy_threshold_uptrend": buy_uptrend,
+                    "sell_threshold": sell,
+                    "min_confidence": _round(rng.uniform(0.10, 0.50), 2),
+                    "btc_regime_filter_enabled": True,
+                    "btc_dump_threshold_pct": _round(rng.uniform(-1.2, -0.8), 2),
+                    "btc_dump_require_below_ema200": True,
+                },
+                "per_symbol_aggregator_config": _per_symbol_aggregator_config(
+                    trading_symbol,
+                    buy=buy,
+                    sell=sell,
+                    buy_uptrend=buy_uptrend,
+                    sell_min_agreement=rng.choice([1, 2]),
+                ),
+            },
+        }
+        desc = (
+            f"regime-gated-pullback buy={buy:.2f} atr="
+            f"{trend_pullback['config']['min_atr_pct']:.4f} "
             f"trend={trend_pullback['config']['min_trend_strength_pct']:.4f}"
         )
     else:
@@ -510,14 +753,13 @@ def generate_candidate(
                     "buy_threshold_uptrend": buy_uptrend,
                     "sell_threshold": sell,
                 },
-                "per_symbol_aggregator_config": {
-                    "SOLUSDT": {
-                        "min_agreement": 1,
-                        "buy_threshold": buy,
-                        "sell_threshold": sell,
-                        "sell_min_agreement": 2,
-                    }
-                },
+                "per_symbol_aggregator_config": _per_symbol_aggregator_config(
+                    trading_symbol,
+                    buy=buy,
+                    sell=sell,
+                    buy_uptrend=buy_uptrend,
+                    sell_min_agreement=2,
+                ),
             },
         }
         desc = (
@@ -622,6 +864,7 @@ def main() -> None:
         candidate = generate_candidate(
             run_index,
             seed=args.seed,
+            symbol=args.symbol,
             families=families,
             aggregator_focus=args.aggregator_focus,
         )

--- a/scripts/autoresearch_loop.py
+++ b/scripts/autoresearch_loop.py
@@ -30,6 +30,8 @@ DEFAULT_FAMILIES = (
     "volatility_squeeze_overlay",
     "funding_extreme_overlay",
     "regime_gated_pullback_overlay",
+    "breakout_retest_bridge",
+    "regime_gated_pullback_bridge",
 )
 
 BASE_STRATEGY_CONFIGS: tuple[dict[str, Any], ...] = (
@@ -720,6 +722,122 @@ def generate_candidate(
             f"regime-gated-pullback buy={buy:.2f} atr="
             f"{trend_pullback['config']['min_atr_pct']:.4f} "
             f"trend={trend_pullback['config']['min_trend_strength_pct']:.4f}"
+        )
+    elif family == "breakout_retest_bridge":
+        buy = _round(rng.uniform(1.045, 1.095), 2)
+        buy_uptrend = _round(rng.uniform(1.015, min(1.065, buy)), 2)
+        sell = _round(-rng.uniform(0.71, 0.78), 2)
+        sl_atr = _round(rng.uniform(2.05, 2.35), 2)
+        tp_atr = _round(rng.uniform(3.20, 4.75), 2)
+        breakout_retest = {
+            "name": "breakout_retest",
+            "config": {
+                "min_trend_strength_pct": _round(rng.uniform(0.007, 0.010), 4),
+                "min_atr_pct": _round(rng.uniform(0.008, 0.010), 4),
+                "breakout_rsi_level": _round(rng.uniform(57.0, 59.0), 1),
+                "retest_window_bars": rng.choice([4, 5]),
+                "retest_vwap_distance_pct": _round(rng.uniform(0.013, 0.018), 4),
+                "retest_ema50_distance_pct": _round(rng.uniform(0.013, 0.018), 4),
+                "reclaim_rsi_level": rng.choice([48, 50]),
+                "max_extension_after_retest_pct": _round(rng.uniform(0.022, 0.028), 4),
+            },
+        }
+        overlay = {
+            "trading_execution": {
+                "sl_atr_multiplier": sl_atr,
+                "tp_atr_multiplier": tp_atr,
+                "trailing_activate_atr": _round(rng.uniform(1.5, 2.1), 2),
+                "trailing_offset_atr": _round(rng.uniform(0.75, 1.05), 2),
+            },
+            "strategy": {
+                "strategies": [
+                    *_strategy_configs_with_overrides(
+                        macd_min=_round(rng.uniform(0.0, 0.00025), 5),
+                        macd_atr_min=_round(rng.uniform(0.0047, 0.0089), 4),
+                        bb_distance=_round(rng.uniform(0.0045, 0.0065), 4),
+                        bb_rsi_oversold=rng.choice([30, 35]),
+                        bb_rsi_overbought=rng.choice([65, 70]),
+                        cci_atr_min=_round(rng.uniform(0.0108, 0.0124), 4),
+                        vwap_atr_multiplier=_round(rng.uniform(1.25, 2.10), 2),
+                    ),
+                    breakout_retest,
+                ],
+                "aggregator": {
+                    "buy_threshold": buy,
+                    "buy_threshold_uptrend": buy_uptrend,
+                    "sell_threshold": sell,
+                    "min_confidence": _round(rng.uniform(0.0, 0.35), 2),
+                },
+                "per_symbol_aggregator_config": _per_symbol_aggregator_config(
+                    trading_symbol,
+                    buy=buy,
+                    sell=sell,
+                    buy_uptrend=buy_uptrend,
+                    sell_min_agreement=rng.choice([1, 2]),
+                ),
+            },
+        }
+        desc = (
+            f"breakout-retest-bridge buy={buy:.2f} window="
+            f"{breakout_retest['config']['retest_window_bars']} sl/tp={sl_atr:.2f}/{tp_atr:.2f}"
+        )
+    elif family == "regime_gated_pullback_bridge":
+        buy = _round(rng.uniform(1.05, 1.12), 2)
+        buy_uptrend = _round(rng.uniform(1.02, min(1.10, buy)), 2)
+        sell = _round(-rng.uniform(0.72, 0.80), 2)
+        stack = _sol_winner_stack_params(rng)
+        stack["macd_atr_min"] = _round(rng.uniform(0.0080, 0.0110), 4)
+        stack["cci_atr_min"] = _round(rng.uniform(0.0108, 0.0130), 4)
+        trend_pullback = {
+            "name": "trend_pullback",
+            "config": {
+                "rsi_reclaim_level": rng.choice([48, 50, 52]),
+                "min_trend_strength_pct": _round(rng.uniform(0.007, 0.012), 4),
+                "max_pullback_distance_pct": _round(rng.uniform(0.014, 0.028), 4),
+                "vwap_pullback_distance_pct": _round(rng.uniform(0.014, 0.032), 4),
+                "min_atr_pct": _round(rng.uniform(0.007, 0.012), 4),
+                "min_macd_hist": _round(rng.uniform(-0.011, 0.002), 4),
+                "strong_trend_strength_pct": _round(rng.uniform(0.012, 0.020), 4),
+                "continuation_rsi_level": rng.choice([52, 54]),
+                "continuation_max_vwap_distance_pct": _round(rng.uniform(0.028, 0.048), 4),
+                "continuation_max_ema50_extension_pct": _round(rng.uniform(0.020, 0.038), 4),
+                "continuation_min_macd_hist": _round(rng.uniform(-0.011, 0.002), 4),
+            },
+        }
+        overlay = {
+            "trading_execution": {
+                "sl_atr_multiplier": _round(rng.uniform(2.10, 2.40), 2),
+                "tp_atr_multiplier": _round(rng.uniform(3.50, 4.30), 2),
+                "trailing_activate_atr": _round(rng.uniform(1.55, 2.05), 2),
+                "trailing_offset_atr": _round(rng.uniform(0.80, 1.05), 2),
+            },
+            "strategy": {
+                "global_trend_filter_buffer_pct": _round(rng.uniform(0.0, 0.008), 4),
+                "strategies": [
+                    *_strategy_configs_with_overrides(**stack),
+                    trend_pullback,
+                ],
+                "aggregator": {
+                    "buy_threshold": buy,
+                    "buy_threshold_uptrend": buy_uptrend,
+                    "sell_threshold": sell,
+                    "min_confidence": _round(rng.uniform(0.05, 0.40), 2),
+                    "btc_regime_filter_enabled": True,
+                    "btc_dump_threshold_pct": _round(rng.uniform(-1.15, -0.85), 2),
+                    "btc_dump_require_below_ema200": True,
+                },
+                "per_symbol_aggregator_config": _per_symbol_aggregator_config(
+                    trading_symbol,
+                    buy=buy,
+                    sell=sell,
+                    buy_uptrend=buy_uptrend,
+                    sell_min_agreement=rng.choice([1, 2]),
+                ),
+            },
+        }
+        desc = (
+            f"regime-gated-pullback-bridge buy={buy:.2f} atr="
+            f"{trend_pullback['config']['min_atr_pct']:.4f}"
         )
     else:
         buy = _round(rng.uniform(1.00, 1.10), 2)

--- a/scripts/autoresearch_loop.py
+++ b/scripts/autoresearch_loop.py
@@ -1,0 +1,675 @@
+#!/usr/bin/env python3
+"""Run a bounded Karpathy-style autoresearch loop over config overlays."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import random
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+DEFAULT_FAMILIES = (
+    "aggregator_thresholds",
+    "risk_atr_exits",
+    "sentiment_filters",
+    "indicator_thresholds",
+    "combined_focus",
+    "near_pass_expansion",
+    "standard_gate_bridge",
+    "near_miss_trade_lift",
+    "trend_pullback_overlay",
+)
+
+BASE_STRATEGY_CONFIGS: tuple[dict[str, Any], ...] = (
+    {
+        "name": "rsi_reversal",
+        "config": {"rsi_period": 7, "oversold_threshold": 35, "overbought_threshold": 65},
+    },
+    {
+        "name": "macd_histogram",
+        "config": {"min_histogram_threshold": 0.0001, "use_atr_filter": True, "atr_min_pct": 0.003},
+    },
+    {
+        "name": "bollinger_bounce",
+        "config": {"band_distance_threshold": 0.003, "rsi_oversold": 35, "rsi_overbought": 65},
+    },
+    {
+        "name": "cci_breakout",
+        "config": {"cci_buy_threshold": 100, "cci_sell_threshold": -100, "atr_min_pct": 0.005},
+    },
+    {
+        "name": "vwap_reversion",
+        "config": {"vwap_atr_multiplier": 1.5, "rsi_oversold": 40, "rsi_overbought": 60},
+    },
+)
+
+
+@dataclass(frozen=True)
+class Candidate:
+    """One generated config-only research candidate."""
+
+    run_index: int
+    seed: int
+    family: str
+    description: str
+    overlay: dict[str, Any]
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run a bounded autoresearch loop that generates config overlays."
+    )
+    parser.add_argument("--config", default="config/settings.autoresearch.yaml")
+    parser.add_argument("--output-dir", default="research")
+    parser.add_argument("--symbol", default="SOLUSDT")
+    parser.add_argument("--timeframe", default="4h")
+    parser.add_argument("--start")
+    parser.add_argument("--end")
+    parser.add_argument("--train-months", type=int, default=6)
+    parser.add_argument("--test-months", type=int, default=3)
+    parser.add_argument("--bootstrap", type=int, default=500)
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--max-runs", type=int, default=10)
+    parser.add_argument("--max-hours", type=float)
+    parser.add_argument("--gate-profile", default="standard")
+    parser.add_argument("--timeout-seconds", type=int, default=1800)
+    parser.add_argument(
+        "--families",
+        default=",".join(DEFAULT_FAMILIES),
+        help=(
+            "Comma-separated candidate families to sample. Supported: "
+            + ", ".join(DEFAULT_FAMILIES)
+        ),
+    )
+    parser.add_argument(
+        "--aggregator-focus",
+        action="store_true",
+        help="Bias aggregator candidates around the best observed strict-threshold region.",
+    )
+    parser.add_argument(
+        "--include-baseline",
+        action="store_true",
+        help="Run the frozen base config before generated candidates.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Write candidate overlays and session plan without running evaluations.",
+    )
+    return parser.parse_args()
+
+
+def _candidate_path(output_dir: Path, candidate: Candidate) -> Path:
+    safe_family = candidate.family.replace("/", "-")
+    return output_dir / "candidates" / f"{candidate.run_index:04d}-{safe_family}.yaml"
+
+
+def _write_yaml(path: Path, data: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as handle:
+        yaml.safe_dump(data, handle, sort_keys=False)
+
+
+def _round(value: float, digits: int = 4) -> float:
+    return round(float(value), digits)
+
+
+def _strategy_configs_with_overrides(
+    *,
+    macd_min: float,
+    macd_atr_min: float,
+    bb_distance: float,
+    bb_rsi_oversold: int,
+    bb_rsi_overbought: int,
+    cci_atr_min: float,
+    vwap_atr_multiplier: float,
+) -> list[dict[str, Any]]:
+    strategies = []
+    for strategy in BASE_STRATEGY_CONFIGS:
+        copied = {"name": strategy["name"], "config": dict(strategy["config"])}
+        strategies.append(copied)
+
+    by_name = {strategy["name"]: strategy["config"] for strategy in strategies}
+    by_name["macd_histogram"]["min_histogram_threshold"] = macd_min
+    by_name["macd_histogram"]["atr_min_pct"] = macd_atr_min
+    by_name["bollinger_bounce"]["band_distance_threshold"] = bb_distance
+    by_name["bollinger_bounce"]["rsi_oversold"] = bb_rsi_oversold
+    by_name["bollinger_bounce"]["rsi_overbought"] = bb_rsi_overbought
+    by_name["cci_breakout"]["atr_min_pct"] = cci_atr_min
+    by_name["vwap_reversion"]["vwap_atr_multiplier"] = vwap_atr_multiplier
+    return strategies
+
+
+def _parse_families(raw: str) -> tuple[str, ...]:
+    families = tuple(part.strip() for part in raw.split(",") if part.strip())
+    if not families:
+        raise ValueError("At least one candidate family is required")
+    invalid = sorted(set(families) - set(DEFAULT_FAMILIES))
+    if invalid:
+        raise ValueError(f"Unsupported candidate families: {', '.join(invalid)}")
+    return families
+
+
+def generate_candidate(
+    run_index: int,
+    *,
+    seed: int,
+    families: tuple[str, ...] = DEFAULT_FAMILIES,
+    aggregator_focus: bool = False,
+) -> Candidate:
+    """Generate a bounded strategy config overlay.
+
+    The ranges are intentionally conservative and limited to research config
+    knobs. They do not affect production unless an operator manually promotes a
+    candidate after separate review.
+    """
+
+    rng = random.Random(seed + run_index * 7919)
+    family = rng.choice(families)
+
+    if family == "aggregator_thresholds":
+        if aggregator_focus:
+            buy = _round(rng.uniform(0.98, 1.14), 2)
+            buy_uptrend = _round(max(0.90, buy - rng.uniform(0.00, 0.08)), 2)
+            sell = _round(-rng.uniform(0.72, 0.92), 2)
+            min_agreement = 1
+            sell_min_agreement = rng.choice([1, 2])
+        else:
+            buy = _round(rng.uniform(0.65, 1.10), 2)
+            buy_uptrend = _round(max(0.55, buy - rng.uniform(0.0, 0.15)), 2)
+            sell = _round(-rng.uniform(0.50, 0.90), 2)
+            min_agreement = rng.choice([1, 2])
+            sell_min_agreement = rng.choice([1, 2])
+        overlay = {
+            "strategy": {
+                "aggregator": {
+                    "buy_threshold": buy,
+                    "buy_threshold_uptrend": buy_uptrend,
+                    "sell_threshold": sell,
+                },
+                "per_symbol_aggregator_config": {
+                    "SOLUSDT": {
+                        "min_agreement": min_agreement,
+                        "buy_threshold": buy,
+                        "sell_threshold": sell,
+                        "sell_min_agreement": sell_min_agreement,
+                    }
+                },
+            }
+        }
+        desc = (
+            f"aggregator buy={buy:.2f} uptrend={buy_uptrend:.2f} "
+            f"sell={sell:.2f} agree={min_agreement}"
+        )
+    elif family == "risk_atr_exits":
+        sl_atr = _round(rng.uniform(1.4, 2.8), 2)
+        tp_atr = _round(rng.uniform(2.2, 5.0), 2)
+        trail_activate = _round(rng.uniform(1.0, 2.4), 2)
+        trail_offset = _round(rng.uniform(0.6, 1.5), 2)
+        overlay = {
+            "trading_execution": {
+                "sl_atr_multiplier": sl_atr,
+                "tp_atr_multiplier": tp_atr,
+                "trailing_activate_atr": trail_activate,
+                "trailing_offset_atr": trail_offset,
+            }
+        }
+        desc = (
+            f"atr exits sl={sl_atr:.2f} tp={tp_atr:.2f} "
+            f"trail={trail_activate:.2f}/{trail_offset:.2f}"
+        )
+    elif family == "sentiment_filters":
+        gate = _round(rng.uniform(25.0, 55.0), 1)
+        panic = _round(rng.uniform(10.0, min(35.0, gate - 1.0)), 1)
+        boost = _round(rng.uniform(max(60.0, gate + 10.0), 80.0), 1)
+        overlay = {
+            "strategy": {
+                "strategies": [
+                    {
+                        "name": "sentiment_mean_reversion",
+                        "config": {
+                            "sentiment_gate_threshold": gate,
+                            "sentiment_panic_threshold": panic,
+                            "sentiment_boost_threshold": boost,
+                        },
+                    }
+                ]
+            }
+        }
+        desc = f"sentiment gate={gate:.1f} panic={panic:.1f} boost={boost:.1f}"
+    elif family == "indicator_thresholds":
+        bb_distance = _round(rng.uniform(0.002, 0.012), 4)
+        atr_min = _round(rng.uniform(0.002, 0.010), 4)
+        macd_min = _round(rng.uniform(0.0000, 0.0005), 5)
+        overlay = {
+            "strategy": {
+                "strategies": [
+                    {
+                        "name": "bollinger_bounce",
+                        "config": {
+                            "band_distance_threshold": bb_distance,
+                            "rsi_oversold": rng.choice([30, 35, 40]),
+                            "rsi_overbought": rng.choice([60, 65, 70]),
+                        },
+                    },
+                    {
+                        "name": "macd_histogram",
+                        "config": {
+                            "min_histogram_threshold": macd_min,
+                            "use_atr_filter": True,
+                            "atr_min_pct": atr_min,
+                        },
+                    },
+                ]
+            }
+        }
+        desc = f"indicator bb={bb_distance:.4f} atr_min={atr_min:.4f} macd={macd_min:.5f}"
+    elif family == "combined_focus":
+        buy = _round(rng.uniform(1.04, 1.16), 2)
+        buy_uptrend = _round(max(0.98, buy - rng.uniform(0.00, 0.08)), 2)
+        sell = _round(-rng.uniform(0.72, 0.92), 2)
+        bb_distance = _round(rng.uniform(0.004, 0.010), 4)
+        macd_atr_min = _round(rng.uniform(0.004, 0.010), 4)
+        cci_atr_min = _round(rng.uniform(0.004, 0.012), 4)
+        vwap_atr = _round(rng.uniform(1.2, 2.2), 2)
+        sl_atr = _round(rng.uniform(1.5, 2.4), 2)
+        tp_atr = _round(rng.uniform(2.8, 4.8), 2)
+        overlay = {
+            "trading_execution": {
+                "sl_atr_multiplier": sl_atr,
+                "tp_atr_multiplier": tp_atr,
+                "trailing_activate_atr": _round(rng.uniform(1.0, 2.0), 2),
+                "trailing_offset_atr": _round(rng.uniform(0.6, 1.2), 2),
+            },
+            "strategy": {
+                "strategies": _strategy_configs_with_overrides(
+                    macd_min=_round(rng.uniform(0.0, 0.00025), 5),
+                    macd_atr_min=macd_atr_min,
+                    bb_distance=bb_distance,
+                    bb_rsi_oversold=rng.choice([30, 35, 40]),
+                    bb_rsi_overbought=rng.choice([60, 65, 70]),
+                    cci_atr_min=cci_atr_min,
+                    vwap_atr_multiplier=vwap_atr,
+                ),
+                "aggregator": {
+                    "buy_threshold": buy,
+                    "buy_threshold_uptrend": buy_uptrend,
+                    "sell_threshold": sell,
+                },
+                "per_symbol_aggregator_config": {
+                    "SOLUSDT": {
+                        "min_agreement": 1,
+                        "buy_threshold": buy,
+                        "sell_threshold": sell,
+                        "sell_min_agreement": rng.choice([1, 2]),
+                    }
+                },
+            },
+        }
+        desc = (
+            f"combined buy={buy:.2f} uptrend={buy_uptrend:.2f} sell={sell:.2f} "
+            f"bb={bb_distance:.4f} macd_atr={macd_atr_min:.4f} "
+            f"cci_atr={cci_atr_min:.4f} vwap_atr={vwap_atr:.2f} "
+            f"sl/tp={sl_atr:.2f}/{tp_atr:.2f}"
+        )
+    elif family == "standard_gate_bridge":
+        buy = _round(rng.uniform(1.045, 1.085), 2)
+        buy_uptrend = _round(rng.uniform(1.015, min(1.065, buy)), 2)
+        sell = _round(-rng.uniform(0.71, 0.78), 2)
+        bb_distance = _round(rng.uniform(0.0045, 0.0065), 4)
+        macd_atr_min = _round(rng.uniform(0.0047, 0.0089), 4)
+        cci_atr_min = _round(rng.uniform(0.0108, 0.0124), 4)
+        vwap_atr = _round(rng.uniform(1.25, 2.10), 2)
+        sl_atr = _round(rng.uniform(2.05, 2.35), 2)
+        tp_atr = _round(rng.uniform(3.20, 4.75), 2)
+        overlay = {
+            "trading_execution": {
+                "sl_atr_multiplier": sl_atr,
+                "tp_atr_multiplier": tp_atr,
+                "trailing_activate_atr": _round(rng.uniform(1.5, 2.1), 2),
+                "trailing_offset_atr": _round(rng.uniform(0.75, 1.05), 2),
+            },
+            "strategy": {
+                "strategies": _strategy_configs_with_overrides(
+                    macd_min=_round(rng.uniform(0.0, 0.00025), 5),
+                    macd_atr_min=macd_atr_min,
+                    bb_distance=bb_distance,
+                    bb_rsi_oversold=rng.choice([30, 35]),
+                    bb_rsi_overbought=rng.choice([65, 70]),
+                    cci_atr_min=cci_atr_min,
+                    vwap_atr_multiplier=vwap_atr,
+                ),
+                "aggregator": {
+                    "buy_threshold": buy,
+                    "buy_threshold_uptrend": buy_uptrend,
+                    "sell_threshold": sell,
+                },
+                "per_symbol_aggregator_config": {
+                    "SOLUSDT": {
+                        "min_agreement": 1,
+                        "buy_threshold": buy,
+                        "sell_threshold": sell,
+                        "sell_min_agreement": rng.choice([1, 2]),
+                    }
+                },
+            },
+        }
+        desc = (
+            f"standard-bridge buy={buy:.2f} uptrend={buy_uptrend:.2f} sell={sell:.2f} "
+            f"bb={bb_distance:.4f} macd_atr={macd_atr_min:.4f} "
+            f"cci_atr={cci_atr_min:.4f} vwap_atr={vwap_atr:.2f} "
+            f"sl/tp={sl_atr:.2f}/{tp_atr:.2f}"
+        )
+    elif family == "near_miss_trade_lift":
+        buy = _round(rng.uniform(1.055, 1.095), 2)
+        buy_uptrend = _round(rng.uniform(1.030, min(1.065, buy)), 2)
+        sell = _round(-rng.uniform(0.74, 0.80), 2)
+        bb_distance = _round(rng.uniform(0.0045, 0.0058), 4)
+        macd_atr_min = _round(rng.uniform(0.0075, 0.0092), 4)
+        cci_atr_min = _round(rng.uniform(0.0105, 0.0118), 4)
+        vwap_atr = _round(rng.uniform(1.85, 2.12), 2)
+        sl_atr = _round(rng.uniform(2.15, 2.35), 2)
+        tp_atr = _round(rng.uniform(3.70, 4.20), 2)
+        overlay = {
+            "trading_execution": {
+                "sl_atr_multiplier": sl_atr,
+                "tp_atr_multiplier": tp_atr,
+                "trailing_activate_atr": _round(rng.uniform(1.65, 2.05), 2),
+                "trailing_offset_atr": _round(rng.uniform(0.80, 1.05), 2),
+            },
+            "strategy": {
+                "strategies": _strategy_configs_with_overrides(
+                    macd_min=_round(rng.uniform(0.0, 0.00025), 5),
+                    macd_atr_min=macd_atr_min,
+                    bb_distance=bb_distance,
+                    bb_rsi_oversold=rng.choice([30, 35]),
+                    bb_rsi_overbought=rng.choice([65, 70]),
+                    cci_atr_min=cci_atr_min,
+                    vwap_atr_multiplier=vwap_atr,
+                ),
+                "aggregator": {
+                    "buy_threshold": buy,
+                    "buy_threshold_uptrend": buy_uptrend,
+                    "sell_threshold": sell,
+                },
+                "per_symbol_aggregator_config": {
+                    "SOLUSDT": {
+                        "min_agreement": 1,
+                        "buy_threshold": buy,
+                        "sell_threshold": sell,
+                        "sell_min_agreement": rng.choice([1, 2]),
+                    }
+                },
+            },
+        }
+        desc = (
+            f"near-miss-lift buy={buy:.2f} uptrend={buy_uptrend:.2f} sell={sell:.2f} "
+            f"bb={bb_distance:.4f} macd_atr={macd_atr_min:.4f} "
+            f"cci_atr={cci_atr_min:.4f} vwap_atr={vwap_atr:.2f} "
+            f"sl/tp={sl_atr:.2f}/{tp_atr:.2f}"
+        )
+    elif family == "trend_pullback_overlay":
+        buy = _round(rng.uniform(1.10, 1.35), 2)
+        buy_uptrend = _round(rng.uniform(0.95, min(1.15, buy)), 2)
+        sell = _round(-rng.uniform(0.74, 0.86), 2)
+        trend_pullback = {
+            "name": "trend_pullback",
+            "config": {
+                "rsi_reclaim_level": rng.choice([48, 50, 52]),
+                "min_trend_strength_pct": _round(rng.uniform(0.006, 0.012), 4),
+                "max_pullback_distance_pct": _round(rng.uniform(0.015, 0.030), 4),
+                "vwap_pullback_distance_pct": _round(rng.uniform(0.015, 0.035), 4),
+                "min_atr_pct": _round(rng.uniform(0.006, 0.012), 4),
+                "min_macd_hist": _round(rng.uniform(-0.012, 0.002), 4),
+                "strong_trend_strength_pct": _round(rng.uniform(0.012, 0.020), 4),
+                "continuation_rsi_level": rng.choice([52, 54, 56]),
+                "continuation_max_vwap_distance_pct": _round(rng.uniform(0.030, 0.050), 4),
+                "continuation_max_ema50_extension_pct": _round(rng.uniform(0.020, 0.040), 4),
+                "continuation_min_macd_hist": _round(rng.uniform(-0.012, 0.002), 4),
+            },
+        }
+        overlay = {
+            "trading_execution": {
+                "sl_atr_multiplier": _round(rng.uniform(2.10, 2.45), 2),
+                "tp_atr_multiplier": _round(rng.uniform(3.60, 4.40), 2),
+                "trailing_activate_atr": _round(rng.uniform(1.55, 2.10), 2),
+                "trailing_offset_atr": _round(rng.uniform(0.80, 1.10), 2),
+            },
+            "strategy": {
+                "strategies": [
+                    *_strategy_configs_with_overrides(
+                        macd_min=_round(rng.uniform(0.0, 0.00025), 5),
+                        macd_atr_min=_round(rng.uniform(0.0075, 0.0092), 4),
+                        bb_distance=_round(rng.uniform(0.0045, 0.0058), 4),
+                        bb_rsi_oversold=rng.choice([30, 35]),
+                        bb_rsi_overbought=rng.choice([65, 70]),
+                        cci_atr_min=_round(rng.uniform(0.0105, 0.0118), 4),
+                        vwap_atr_multiplier=_round(rng.uniform(1.85, 2.12), 2),
+                    ),
+                    trend_pullback,
+                ],
+                "aggregator": {
+                    "buy_threshold": buy,
+                    "buy_threshold_uptrend": buy_uptrend,
+                    "sell_threshold": sell,
+                    "min_confidence": _round(rng.uniform(0.0, 0.45), 2),
+                },
+                "per_symbol_aggregator_config": {
+                    "SOLUSDT": {
+                        "min_agreement": 1,
+                        "buy_threshold": buy,
+                        "buy_threshold_uptrend": buy_uptrend,
+                        "sell_threshold": sell,
+                        "sell_min_agreement": rng.choice([1, 2]),
+                    }
+                },
+            },
+        }
+        desc = (
+            f"trend-pullback-overlay buy={buy:.2f} uptrend={buy_uptrend:.2f} "
+            f"sell={sell:.2f} rsi={trend_pullback['config']['rsi_reclaim_level']} "
+            f"trend={trend_pullback['config']['min_trend_strength_pct']:.4f}"
+        )
+    else:
+        buy = _round(rng.uniform(1.00, 1.10), 2)
+        buy_uptrend = _round(max(0.94, buy - rng.uniform(0.02, 0.10)), 2)
+        sell = _round(-rng.uniform(0.74, 0.90), 2)
+        bb_distance = _round(rng.uniform(0.008, 0.014), 4)
+        macd_atr_min = _round(rng.uniform(0.0035, 0.0070), 4)
+        cci_atr_min = _round(rng.uniform(0.0060, 0.0110), 4)
+        vwap_atr = _round(rng.uniform(1.8, 2.4), 2)
+        sl_atr = _round(rng.uniform(1.45, 1.85), 2)
+        tp_atr = _round(rng.uniform(2.6, 3.4), 2)
+        overlay = {
+            "trading_execution": {
+                "sl_atr_multiplier": sl_atr,
+                "tp_atr_multiplier": tp_atr,
+                "trailing_activate_atr": _round(rng.uniform(1.4, 2.2), 2),
+                "trailing_offset_atr": _round(rng.uniform(0.7, 1.1), 2),
+            },
+            "strategy": {
+                "strategies": _strategy_configs_with_overrides(
+                    macd_min=_round(rng.uniform(0.0, 0.00025), 5),
+                    macd_atr_min=macd_atr_min,
+                    bb_distance=bb_distance,
+                    bb_rsi_oversold=rng.choice([30, 35, 40]),
+                    bb_rsi_overbought=rng.choice([60, 65, 70]),
+                    cci_atr_min=cci_atr_min,
+                    vwap_atr_multiplier=vwap_atr,
+                ),
+                "aggregator": {
+                    "buy_threshold": buy,
+                    "buy_threshold_uptrend": buy_uptrend,
+                    "sell_threshold": sell,
+                },
+                "per_symbol_aggregator_config": {
+                    "SOLUSDT": {
+                        "min_agreement": 1,
+                        "buy_threshold": buy,
+                        "sell_threshold": sell,
+                        "sell_min_agreement": 2,
+                    }
+                },
+            },
+        }
+        desc = (
+            f"near-pass buy={buy:.2f} uptrend={buy_uptrend:.2f} sell={sell:.2f} "
+            f"bb={bb_distance:.4f} macd_atr={macd_atr_min:.4f} "
+            f"cci_atr={cci_atr_min:.4f} vwap_atr={vwap_atr:.2f} "
+            f"sl/tp={sl_atr:.2f}/{tp_atr:.2f}"
+        )
+
+    return Candidate(
+        run_index=run_index,
+        seed=seed,
+        family=family,
+        description=desc,
+        overlay=overlay,
+    )
+
+
+def build_run_command(
+    args: argparse.Namespace, *, overlay_path: Path | None, description: str
+) -> list[str]:
+    cmd = [
+        sys.executable,
+        "scripts/run_autoresearch.py",
+        "--config",
+        args.config,
+        "--description",
+        description,
+        "--output-dir",
+        args.output_dir,
+        "--symbol",
+        args.symbol,
+        "--timeframe",
+        args.timeframe,
+        "--train-months",
+        str(args.train_months),
+        "--test-months",
+        str(args.test_months),
+        "--bootstrap",
+        str(args.bootstrap),
+        "--seed",
+        str(args.seed),
+        "--gate-profile",
+        args.gate_profile,
+        "--timeout-seconds",
+        str(args.timeout_seconds),
+    ]
+    if overlay_path is not None:
+        cmd.extend(["--overlay", str(overlay_path)])
+    if args.start:
+        cmd.extend(["--start", args.start])
+    if args.end:
+        cmd.extend(["--end", args.end])
+    return cmd
+
+
+def _run_command(cmd: list[str], *, log_path: Path) -> int:
+    result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    with log_path.open("a", encoding="utf-8") as handle:
+        handle.write(f"$ {' '.join(cmd)}\n")
+        handle.write(f"returncode: {result.returncode}\n")
+        handle.write("[stdout]\n")
+        handle.write(result.stdout.rstrip())
+        handle.write("\n[stderr]\n")
+        handle.write(result.stderr.rstrip())
+        handle.write("\n\n")
+    return int(result.returncode)
+
+
+def _session_summary_path(output_dir: Path) -> Path:
+    return output_dir / "autoresearch_session.json"
+
+
+def main() -> None:
+    args = parse_args()
+    if args.max_runs < 1:
+        raise SystemExit("--max-runs must be >= 1")
+    try:
+        families = _parse_families(args.families)
+    except ValueError as exc:
+        raise SystemExit(str(exc)) from exc
+
+    output_dir = Path(args.output_dir)
+    (output_dir / "candidates").mkdir(parents=True, exist_ok=True)
+    loop_log_path = output_dir / "autoresearch_loop.log"
+    started_at = datetime.now(UTC)
+    deadline = time.monotonic() + args.max_hours * 3600 if args.max_hours else None
+    runs: list[dict[str, Any]] = []
+
+    if args.include_baseline:
+        baseline_cmd = build_run_command(args, overlay_path=None, description="baseline")
+        runs.append({"type": "baseline", "command": baseline_cmd})
+        if not args.dry_run:
+            code = _run_command(baseline_cmd, log_path=loop_log_path)
+            if code not in {0, 1, 124}:
+                raise SystemExit(code)
+
+    for run_index in range(1, args.max_runs + 1):
+        if deadline is not None and time.monotonic() >= deadline:
+            break
+
+        candidate = generate_candidate(
+            run_index,
+            seed=args.seed,
+            families=families,
+            aggregator_focus=args.aggregator_focus,
+        )
+        overlay_path = _candidate_path(output_dir, candidate)
+        _write_yaml(overlay_path, candidate.overlay)
+        command = build_run_command(
+            args,
+            overlay_path=overlay_path,
+            description=f"{candidate.family}: {candidate.description}",
+        )
+        run_record = {
+            "type": "candidate",
+            "run_index": run_index,
+            "seed": candidate.seed,
+            "family": candidate.family,
+            "description": candidate.description,
+            "overlay_path": str(overlay_path),
+            "command": command,
+        }
+        runs.append(run_record)
+
+        if args.dry_run:
+            continue
+
+        code = _run_command(command, log_path=loop_log_path)
+        run_record["returncode"] = code
+        if code not in {0, 1, 124}:
+            raise SystemExit(code)
+
+    summary = {
+        "started_at": started_at.isoformat(),
+        "finished_at": datetime.now(UTC).isoformat(),
+        "config": args.config,
+        "output_dir": args.output_dir,
+        "symbol": args.symbol,
+        "timeframe": args.timeframe,
+        "seed": args.seed,
+        "max_runs": args.max_runs,
+        "families": list(families),
+        "aggregator_focus": args.aggregator_focus,
+        "dry_run": args.dry_run,
+        "loop_log_path": str(loop_log_path),
+        "runs": runs,
+    }
+    summary_path = _session_summary_path(output_dir)
+    summary_path.write_text(json.dumps(summary, indent=2), encoding="utf-8")
+    print(json.dumps({"session_path": str(summary_path), "runs": len(runs)}, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/autoresearch_loop.py
+++ b/scripts/autoresearch_loop.py
@@ -36,6 +36,8 @@ DEFAULT_FAMILIES = (
     "breakout_retest_standalone",
     "volatility_squeeze_standalone",
     "mtf_breakout_standalone",
+    "range_reversion_bounded",
+    "funding_primary_standalone",
 )
 
 BASE_STRATEGY_CONFIGS: tuple[dict[str, Any], ...] = (
@@ -998,6 +1000,59 @@ def generate_candidate(
         desc = (
             f"mtf-breakout-standalone vol={mtf_breakout['config']['volatility_threshold']:.1f} "
             f"buy={buy:.2f}"
+        )
+    elif family == "range_reversion_bounded":
+        overlay, desc = _standalone_strategy_overlay(
+            trading_symbol=trading_symbol,
+            rng=rng,
+            strategy_entry={
+                "name": "bollinger_bounce",
+                "config": {
+                    "band_distance_threshold": _round(rng.uniform(0.002, 0.007), 4),
+                    "rsi_oversold": float(rng.choice([35, 38, 42])),
+                    "rsi_overbought": float(rng.choice([58, 62, 65])),
+                },
+            },
+            buy_low=0.48,
+            buy_high=0.72,
+            sl_atr=_round(rng.uniform(1.8, 2.4), 2),
+            tp_atr=_round(rng.uniform(2.4, 3.6), 2),
+        )
+        overlay["trading_execution"]["exit_rules"] = {
+            "backtest_use_executor_exit_model": True,
+            "time_stop_minutes": float(rng.choice([2880, 4320, 5760])),
+        }
+        overlay["strategy"]["global_trend_filter_buffer_pct"] = _round(rng.uniform(0.0, 0.005), 4)
+        desc = (
+            f"range-reversion-bounded bb={overlay['strategy']['strategies'][0]['config']['band_distance_threshold']:.4f} "
+            f"time_stop={overlay['trading_execution']['exit_rules']['time_stop_minutes']:.0f}m"
+        )
+    elif family == "funding_primary_standalone":
+        entry_thresh = _round(rng.uniform(0.00035, 0.0009), 5)
+        exit_thresh = _round(rng.uniform(entry_thresh * 0.25, entry_thresh * 0.65), 5)
+        overlay, desc = _standalone_strategy_overlay(
+            trading_symbol=trading_symbol,
+            rng=rng,
+            strategy_entry={
+                "name": "funding_rate",
+                "config": {
+                    "entry_threshold": entry_thresh,
+                    "exit_threshold": exit_thresh,
+                    "lookback_periods": rng.choice([1, 3, 6]),
+                },
+            },
+            buy_low=0.42,
+            buy_high=0.68,
+            sl_atr=_round(rng.uniform(2.0, 2.6), 2),
+            tp_atr=_round(rng.uniform(3.0, 4.5), 2),
+        )
+        overlay["trading_execution"]["exit_rules"] = {
+            "backtest_use_executor_exit_model": True,
+            "time_stop_minutes": float(rng.choice([1440, 2880, 4320])),
+        }
+        desc = (
+            f"funding-primary entry={entry_thresh:.5f} exit={exit_thresh:.5f} "
+            f"lookback={overlay['strategy']['strategies'][0]['config']['lookback_periods']}"
         )
     else:
         buy = _round(rng.uniform(1.00, 1.10), 2)

--- a/scripts/autoresearch_loop.py
+++ b/scripts/autoresearch_loop.py
@@ -32,6 +32,10 @@ DEFAULT_FAMILIES = (
     "regime_gated_pullback_overlay",
     "breakout_retest_bridge",
     "regime_gated_pullback_bridge",
+    "trend_pullback_standalone",
+    "breakout_retest_standalone",
+    "volatility_squeeze_standalone",
+    "mtf_breakout_standalone",
 )
 
 BASE_STRATEGY_CONFIGS: tuple[dict[str, Any], ...] = (
@@ -174,6 +178,49 @@ def _per_symbol_aggregator_config(
             "sell_min_agreement": sell_min,
         }
     }
+
+
+def _standalone_strategy_overlay(
+    *,
+    trading_symbol: str,
+    rng: random.Random,
+    strategy_entry: dict[str, Any],
+    buy_low: float,
+    buy_high: float,
+    sl_atr: float,
+    tp_atr: float,
+) -> tuple[dict[str, Any], str]:
+    """Single-strategy overlay without the five-vote technical stack."""
+    buy = _round(rng.uniform(buy_low, buy_high), 2)
+    buy_uptrend = _round(rng.uniform(max(0.35, buy - 0.12), buy), 2)
+    sell = _round(-rng.uniform(0.45, 0.75), 2)
+    strategy_name = str(strategy_entry["name"])
+    overlay: dict[str, Any] = {
+        "trading_execution": {
+            "sl_atr_multiplier": sl_atr,
+            "tp_atr_multiplier": tp_atr,
+            "trailing_activate_atr": _round(rng.uniform(1.2, 2.0), 2),
+            "trailing_offset_atr": _round(rng.uniform(0.65, 1.0), 2),
+        },
+        "strategy": {
+            "strategies": [strategy_entry],
+            "aggregator": {
+                "buy_threshold": buy,
+                "buy_threshold_uptrend": buy_uptrend,
+                "sell_threshold": sell,
+                "min_confidence": _round(rng.uniform(0.0, 0.25), 2),
+            },
+            "per_symbol_aggregator_config": _per_symbol_aggregator_config(
+                trading_symbol,
+                buy=buy,
+                sell=sell,
+                buy_uptrend=buy_uptrend,
+                sell_min_agreement=1,
+            ),
+        },
+    }
+    desc = f"{strategy_name}-standalone buy={buy:.2f} sl/tp={sl_atr:.2f}/{tp_atr:.2f}"
+    return overlay, desc
 
 
 def _sol_winner_stack_params(rng: random.Random) -> dict[str, float | int]:
@@ -838,6 +885,119 @@ def generate_candidate(
         desc = (
             f"regime-gated-pullback-bridge buy={buy:.2f} atr="
             f"{trend_pullback['config']['min_atr_pct']:.4f}"
+        )
+    elif family == "trend_pullback_standalone":
+        overlay, desc = _standalone_strategy_overlay(
+            trading_symbol=trading_symbol,
+            rng=rng,
+            strategy_entry={
+                "name": "trend_pullback",
+                "config": {
+                    "rsi_reclaim_level": rng.choice([48, 50, 52]),
+                    "min_trend_strength_pct": _round(rng.uniform(0.006, 0.012), 4),
+                    "max_pullback_distance_pct": _round(rng.uniform(0.015, 0.030), 4),
+                    "vwap_pullback_distance_pct": _round(rng.uniform(0.015, 0.035), 4),
+                    "min_atr_pct": _round(rng.uniform(0.006, 0.012), 4),
+                    "min_macd_hist": _round(rng.uniform(-0.012, 0.002), 4),
+                    "strong_trend_strength_pct": _round(rng.uniform(0.012, 0.020), 4),
+                    "continuation_rsi_level": rng.choice([52, 54, 56]),
+                    "continuation_max_vwap_distance_pct": _round(rng.uniform(0.030, 0.050), 4),
+                    "continuation_max_ema50_extension_pct": _round(rng.uniform(0.020, 0.040), 4),
+                    "continuation_min_macd_hist": _round(rng.uniform(-0.012, 0.002), 4),
+                },
+            },
+            buy_low=0.42,
+            buy_high=0.72,
+            sl_atr=_round(rng.uniform(2.0, 2.6), 2),
+            tp_atr=_round(rng.uniform(3.2, 4.8), 2),
+        )
+    elif family == "breakout_retest_standalone":
+        overlay, desc = _standalone_strategy_overlay(
+            trading_symbol=trading_symbol,
+            rng=rng,
+            strategy_entry={
+                "name": "breakout_retest",
+                "config": {
+                    "min_trend_strength_pct": _round(rng.uniform(0.006, 0.010), 4),
+                    "min_atr_pct": _round(rng.uniform(0.008, 0.011), 4),
+                    "breakout_rsi_level": _round(rng.uniform(56.0, 60.0), 1),
+                    "retest_window_bars": rng.choice([4, 5, 6]),
+                    "retest_vwap_distance_pct": _round(rng.uniform(0.012, 0.020), 4),
+                    "retest_ema50_distance_pct": _round(rng.uniform(0.012, 0.020), 4),
+                    "reclaim_rsi_level": rng.choice([48, 50, 52]),
+                    "max_extension_after_retest_pct": _round(rng.uniform(0.020, 0.030), 4),
+                },
+            },
+            buy_low=0.45,
+            buy_high=0.75,
+            sl_atr=_round(rng.uniform(2.0, 2.5), 2),
+            tp_atr=_round(rng.uniform(3.2, 4.5), 2),
+        )
+    elif family == "volatility_squeeze_standalone":
+        overlay, desc = _standalone_strategy_overlay(
+            trading_symbol=trading_symbol,
+            rng=rng,
+            strategy_entry={
+                "name": "volatility_squeeze",
+                "config": {
+                    "squeeze_lookback": rng.choice([40, 50, 60]),
+                    "squeeze_percentile": _round(rng.uniform(0.15, 0.28), 2),
+                    "sma_period": 20,
+                    "momentum_period": rng.choice([8, 10, 12]),
+                    "atr_trail_multiplier": _round(rng.uniform(2.5, 3.5), 2),
+                    "max_hold_bars": rng.choice([20, 30, 40]),
+                    "min_atr_pct": _round(rng.uniform(0.005, 0.009), 4),
+                },
+            },
+            buy_low=0.40,
+            buy_high=0.70,
+            sl_atr=_round(rng.uniform(2.2, 2.8), 2),
+            tp_atr=_round(rng.uniform(3.0, 5.0), 2),
+        )
+    elif family == "mtf_breakout_standalone":
+        buy = _round(rng.uniform(0.48, 0.72), 2)
+        buy_uptrend = _round(rng.uniform(0.42, buy), 2)
+        sell = _round(-rng.uniform(0.50, 0.72), 2)
+        mtf_breakout = {
+            "name": "mtf_breakout",
+            "config": {
+                "volatility_threshold": _round(rng.uniform(50.0, 65.0), 1),
+                "breakout_threshold": _round(rng.uniform(0.015, 0.030), 4),
+                "trend_slope_threshold": _round(rng.uniform(0.0015, 0.0035), 4),
+                "reclaim_rsi_level": rng.choice([48, 50, 52]),
+                "reclaim_vwap_distance_pct": _round(rng.uniform(0.010, 0.020), 4),
+                "reclaim_ema50_distance_pct": _round(rng.uniform(0.010, 0.020), 4),
+                "min_atr_pct": _round(rng.uniform(0.006, 0.010), 4),
+            },
+        }
+        overlay = {
+            "trading": {"timeframe": "1h"},
+            "trading_execution": {
+                "sl_atr_multiplier": _round(rng.uniform(2.0, 2.5), 2),
+                "tp_atr_multiplier": _round(rng.uniform(3.2, 4.5), 2),
+                "trailing_activate_atr": _round(rng.uniform(1.4, 2.0), 2),
+                "trailing_offset_atr": _round(rng.uniform(0.70, 1.0), 2),
+            },
+            "strategy": {
+                "strategies": [mtf_breakout],
+                "aggregator": {
+                    "buy_threshold": buy,
+                    "buy_threshold_uptrend": buy_uptrend,
+                    "sell_threshold": sell,
+                    "min_confidence": _round(rng.uniform(0.0, 0.30), 2),
+                },
+                "per_symbol_aggregator_config": _per_symbol_aggregator_config(
+                    trading_symbol,
+                    buy=buy,
+                    sell=sell,
+                    buy_uptrend=buy_uptrend,
+                    sell_min_agreement=1,
+                ),
+            },
+        }
+        desc = (
+            f"mtf-breakout-standalone vol={mtf_breakout['config']['volatility_threshold']:.1f} "
+            f"buy={buy:.2f}"
         )
     else:
         buy = _round(rng.uniform(1.00, 1.10), 2)

--- a/scripts/export_sentiment_replay.sh
+++ b/scripts/export_sentiment_replay.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Export replayable sentiment observations from the production Docker volume.
+
+set -euo pipefail
+
+REMOTE_HOST="${REMOTE_HOST:-crypto-agent}"
+REMOTE_DIR="${REMOTE_DIR:-/opt/crypto-agent}"
+OUTPUT_PATH="${1:-data/event_log_sentiment-macro-bot.jsonl}"
+
+mkdir -p "$(dirname "$OUTPUT_PATH")"
+TEMP_PATH=$(mktemp "${OUTPUT_PATH}.tmp.XXXXXX")
+trap 'rm -f "$TEMP_PATH"' EXIT
+
+ssh "$REMOTE_HOST" \
+    "cd '$REMOTE_DIR' && docker compose -f docker-compose.prod.yml exec -T agent_sentiment_macro cat /app/data/event_log_sentiment-macro-bot.jsonl" \
+    > "$TEMP_PATH"
+
+mv "$TEMP_PATH" "$OUTPUT_PATH"
+trap - EXIT
+
+OBSERVATIONS=$(grep -c '"type": "sentiment_score"' "$OUTPUT_PATH" || true)
+echo "Exported $OBSERVATIONS sentiment observations to $OUTPUT_PATH"

--- a/scripts/notify_systemd_failure.py
+++ b/scripts/notify_systemd_failure.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Send a Telegram alert when a production systemd unit fails."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import socket
+import urllib.parse
+import urllib.request
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Notify Telegram about a failed systemd unit")
+    parser.add_argument("--unit", required=True, help="Failed systemd unit name")
+    return parser.parse_args()
+
+
+def telegram_enabled(value: str | None) -> bool:
+    return (value or "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def build_message(unit: str, hostname: str) -> str:
+    return (
+        "CRITICAL: crypto-agent production monitor failed\n\n"
+        f"Host: {hostname}\n"
+        f"Unit: {unit}\n\n"
+        f"Inspect: journalctl -u {unit} --no-pager -n 100"
+    )
+
+
+def send_failure_alert(
+    *,
+    unit: str,
+    hostname: str,
+    bot_token: str | None,
+    chat_id: str | None,
+    enabled: str | None,
+    timeout: int = 10,
+) -> None:
+    if not telegram_enabled(enabled):
+        raise RuntimeError("Telegram notifications are disabled")
+    if not bot_token or not chat_id:
+        raise RuntimeError("Telegram notification credentials are incomplete")
+
+    payload = urllib.parse.urlencode(
+        {"chat_id": chat_id, "text": build_message(unit, hostname)}
+    ).encode("utf-8")
+    request = urllib.request.Request(
+        f"https://api.telegram.org/bot{bot_token}/sendMessage",
+        data=payload,
+        method="POST",
+    )
+    with urllib.request.urlopen(request, timeout=timeout) as response:
+        result = json.loads(response.read().decode("utf-8"))
+    if not result.get("ok"):
+        raise RuntimeError("Telegram API rejected the failure alert")
+
+
+def main() -> int:
+    args = parse_args()
+    send_failure_alert(
+        unit=args.unit,
+        hostname=socket.gethostname(),
+        bot_token=os.getenv("TELEGRAM_BOT_TOKEN"),
+        chat_id=os.getenv("TELEGRAM_CHAT_ID"),
+        enabled=os.getenv("TELEGRAM_ENABLED"),
+    )
+    print(f"Sent Telegram failure alert for {args.unit}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/notify_systemd_failure.py
+++ b/scripts/notify_systemd_failure.py
@@ -7,6 +7,7 @@ import argparse
 import json
 import os
 import socket
+import sys
 import urllib.parse
 import urllib.request
 
@@ -60,13 +61,17 @@ def send_failure_alert(
 
 def main() -> int:
     args = parse_args()
-    send_failure_alert(
-        unit=args.unit,
-        hostname=socket.gethostname(),
-        bot_token=os.getenv("TELEGRAM_BOT_TOKEN"),
-        chat_id=os.getenv("TELEGRAM_CHAT_ID"),
-        enabled=os.getenv("TELEGRAM_ENABLED"),
-    )
+    try:
+        send_failure_alert(
+            unit=args.unit,
+            hostname=socket.gethostname(),
+            bot_token=os.getenv("TELEGRAM_BOT_TOKEN"),
+            chat_id=os.getenv("TELEGRAM_CHAT_ID"),
+            enabled=os.getenv("TELEGRAM_ENABLED"),
+        )
+    except Exception:  # noqa: BLE001
+        print("Failed to send Telegram failure alert", file=sys.stderr)
+        return 1
     print(f"Sent Telegram failure alert for {args.unit}")
     return 0
 

--- a/scripts/probe_funding_normalization.py
+++ b/scripts/probe_funding_normalization.py
@@ -1,0 +1,500 @@
+#!/usr/bin/env python3
+"""Cheap feasibility probe for funding-normalization primary surface.
+
+Answers before full implementation (see docs/specs/funding-crowding-primary-surface-v0.md):
+- How often does funding normalize from an extreme?
+- After normalization, are 12h/24h forward returns positive net of funding drag?
+- Is edge concentrated in one event?
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import statistics
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from enum import StrEnum
+
+from src.db import close_pool, get_pool, init_pool
+from src.features.reader import IndicatorReader
+from src.utils.logger import configure_logger
+
+
+class FundingState(StrEnum):
+    IDLE = "idle"
+    EXTREME_NEGATIVE = "extreme_negative"
+    COOLDOWN_NEGATIVE = "cooldown_negative"
+    EXTREME_POSITIVE = "extreme_positive"
+    COOLDOWN_POSITIVE = "cooldown_positive"
+
+
+class NormalizationSide(StrEnum):
+    LONG_FROM_NEGATIVE = "long_from_negative"
+    SHORT_FROM_POSITIVE = "short_from_positive"
+
+
+@dataclass(frozen=True)
+class ProbeConfig:
+    symbol: str
+    timeframe: str
+    start: str
+    end: str
+    entry_threshold: float
+    exit_threshold: float
+    forward_bars_12h: int
+    forward_bars_24h: int
+    min_events_for_pulse: int
+    max_profit_concentration_pct: float
+    long_only: bool
+
+
+@dataclass(frozen=True)
+class FundingTick:
+    time: datetime
+    funding_rate: float
+
+
+@dataclass(frozen=True)
+class NormalizationEvent:
+    time: datetime
+    side: NormalizationSide
+    funding_rate: float
+    prior_extreme_rate: float
+    gross_forward_12h_pct: float
+    gross_forward_24h_pct: float
+    funding_drag_12h_pct: float
+    funding_drag_24h_pct: float
+
+    @property
+    def net_forward_12h_pct(self) -> float:
+        return self._net(self.gross_forward_12h_pct, self.funding_drag_12h_pct)
+
+    @property
+    def net_forward_24h_pct(self) -> float:
+        return self._net(self.gross_forward_24h_pct, self.funding_drag_24h_pct)
+
+    def _net(self, gross: float, drag: float) -> float:
+        if self.side == NormalizationSide.LONG_FROM_NEGATIVE:
+            return gross - drag
+        return gross + drag
+
+
+@dataclass(frozen=True)
+class HorizonStats:
+    horizon_bars: int
+    event_count: int
+    mean_gross_pct: float
+    mean_net_pct: float
+    median_net_pct: float
+    win_rate_pct: float
+    max_event_share_of_positive_net_pct: float
+
+
+@dataclass(frozen=True)
+class ProbeSummary:
+    symbol: str
+    timeframe: str
+    funding_ticks: int
+    price_bars: int
+    events: tuple[NormalizationEvent, ...]
+
+    @property
+    def long_events(self) -> tuple[NormalizationEvent, ...]:
+        return tuple(e for e in self.events if e.side == NormalizationSide.LONG_FROM_NEGATIVE)
+
+    def stats_for(self, horizon: str) -> HorizonStats:
+        if horizon == "12h":
+            bars = 12
+            gross_attr = "gross_forward_12h_pct"
+            net_prop = "net_forward_12h_pct"
+        else:
+            bars = 24
+            gross_attr = "gross_forward_24h_pct"
+            net_prop = "net_forward_24h_pct"
+
+        events = self.long_events
+        if not events:
+            return HorizonStats(bars, 0, 0.0, 0.0, 0.0, 0.0, 0.0)
+
+        gross_vals = [getattr(e, gross_attr) for e in events]
+        net_vals = [getattr(e, net_prop) for e in events]
+        positive = [v for v in net_vals if v > 0]
+        concentration = 0.0
+        if positive:
+            concentration = max(positive) / sum(positive) * 100.0
+
+        wins = sum(1 for v in net_vals if v > 0.0)
+        return HorizonStats(
+            horizon_bars=bars,
+            event_count=len(events),
+            mean_gross_pct=_mean(gross_vals),
+            mean_net_pct=_mean(net_vals),
+            median_net_pct=_median(net_vals),
+            win_rate_pct=wins / len(events) * 100.0,
+            max_event_share_of_positive_net_pct=concentration,
+        )
+
+
+def build_db_config(env: Mapping[str, str] | None = None) -> dict[str, object]:
+    source = env or os.environ
+    return {
+        "host": source.get("DB_HOST", source.get("POSTGRES_HOST", "localhost")),
+        "port": int(source.get("DB_PORT", source.get("POSTGRES_PORT", 5432))),
+        "name": source.get("DB_NAME", source.get("POSTGRES_DB", "marketdata")),
+        "user": source.get("DB_USER", source.get("POSTGRES_USER", "trading")),
+        "password": source.get("DB_PASSWORD", source.get("POSTGRES_PASSWORD", "change_me")),
+    }
+
+
+def parse_args(argv: Sequence[str] | None = None) -> ProbeConfig:
+    parser = argparse.ArgumentParser(
+        description="Probe funding normalization frequency and crude net forward edge."
+    )
+    parser.add_argument("--symbol", default="ETHUSDT")
+    parser.add_argument("--timeframe", default="1h")
+    parser.add_argument("--start", default="2024-01-01T00:00:00")
+    parser.add_argument("--end", default="2026-06-01T00:00:00")
+    parser.add_argument("--entry-threshold", type=float, default=0.0005)
+    parser.add_argument("--exit-threshold", type=float, default=0.00015)
+    parser.add_argument("--forward-bars-12h", type=int, default=12)
+    parser.add_argument("--forward-bars-24h", type=int, default=24)
+    parser.add_argument("--min-events", type=int, default=20)
+    parser.add_argument("--max-concentration-pct", type=float, default=30.0)
+    parser.add_argument(
+        "--include-short-events",
+        action="store_true",
+        help="Count positive-normalization short signals (research only)",
+    )
+    args = parser.parse_args(argv)
+    return ProbeConfig(
+        symbol=args.symbol.upper(),
+        timeframe=args.timeframe,
+        start=args.start,
+        end=args.end,
+        entry_threshold=args.entry_threshold,
+        exit_threshold=args.exit_threshold,
+        forward_bars_12h=args.forward_bars_12h,
+        forward_bars_24h=args.forward_bars_24h,
+        min_events_for_pulse=args.min_events,
+        max_profit_concentration_pct=args.max_concentration_pct,
+        long_only=not args.include_short_events,
+    )
+
+
+def _mean(values: Iterable[float]) -> float:
+    materialized = list(values)
+    if not materialized:
+        return 0.0
+    return sum(materialized) / len(materialized)
+
+
+def _median(values: Iterable[float]) -> float:
+    materialized = list(values)
+    if not materialized:
+        return 0.0
+    return float(statistics.median(materialized))
+
+
+def _parse_dt(value: str | datetime) -> datetime:
+    if isinstance(value, datetime):
+        return value
+    return datetime.fromisoformat(value)
+
+
+def index_price_bars(
+    rows: Sequence[Mapping[str, object]],
+) -> tuple[list[datetime], list[float]]:
+    times = [_parse_dt(row["time"]) for row in rows]
+    closes = [float(row["close_price"]) for row in rows]
+    return times, closes
+
+
+def _forward_return_pct(closes: Sequence[float], index: int, forward_bars: int) -> float | None:
+    if index + forward_bars >= len(closes):
+        return None
+    current = closes[index]
+    future = closes[index + forward_bars]
+    if current <= 0:
+        return None
+    return (future / current - 1.0) * 100.0
+
+
+def _find_price_index(price_times: Sequence[datetime], event_time: datetime) -> int | None:
+    for index, bar_time in enumerate(price_times):
+        if bar_time >= event_time:
+            return index
+    return None
+
+
+def _funding_drag_pct(
+    funding_ticks: Sequence[FundingTick],
+    event_index: int,
+    event_time: datetime,
+    end_time: datetime,
+    side: NormalizationSide,
+) -> float:
+    """Sum funding payments during hold window; long pays positive rate."""
+    drag = 0.0
+    for tick in funding_ticks[event_index:]:
+        if tick.time <= event_time:
+            continue
+        if tick.time > end_time:
+            break
+        if side == NormalizationSide.LONG_FROM_NEGATIVE:
+            drag += tick.funding_rate
+        else:
+            drag -= tick.funding_rate
+    return drag * 100.0
+
+
+def detect_normalization_events(
+    funding_ticks: Sequence[FundingTick],
+    price_times: Sequence[datetime],
+    price_closes: Sequence[float],
+    config: ProbeConfig,
+) -> list[NormalizationEvent]:
+    """Detect one entry per extreme→normalized cycle; long-only by default."""
+    events: list[NormalizationEvent] = []
+    state = FundingState.IDLE
+    prior_extreme_rate = 0.0
+    max_forward = max(config.forward_bars_12h, config.forward_bars_24h)
+
+    for index, tick in enumerate(funding_ticks):
+        rate = tick.funding_rate
+        normalized = abs(rate) < config.exit_threshold
+
+        if rate <= -config.entry_threshold:
+            if state in {FundingState.IDLE, FundingState.COOLDOWN_NEGATIVE}:
+                state = FundingState.EXTREME_NEGATIVE
+                prior_extreme_rate = rate
+            elif state == FundingState.EXTREME_NEGATIVE:
+                prior_extreme_rate = min(prior_extreme_rate, rate)
+            continue
+
+        if state == FundingState.EXTREME_NEGATIVE and normalized:
+            side = NormalizationSide.LONG_FROM_NEGATIVE
+            event = _build_event(
+                tick,
+                side,
+                prior_extreme_rate,
+                index,
+                funding_ticks,
+                price_times,
+                price_closes,
+                config,
+                max_forward,
+            )
+            if event is not None:
+                events.append(event)
+            state = FundingState.COOLDOWN_NEGATIVE
+            continue
+
+        if not config.long_only:
+            if rate >= config.entry_threshold:
+                if state in {FundingState.IDLE, FundingState.COOLDOWN_POSITIVE}:
+                    state = FundingState.EXTREME_POSITIVE
+                    prior_extreme_rate = rate
+                elif state == FundingState.EXTREME_POSITIVE:
+                    prior_extreme_rate = max(prior_extreme_rate, rate)
+                continue
+
+            if state == FundingState.EXTREME_POSITIVE and normalized:
+                side = NormalizationSide.SHORT_FROM_POSITIVE
+                event = _build_event(
+                    tick,
+                    side,
+                    prior_extreme_rate,
+                    index,
+                    funding_ticks,
+                    price_times,
+                    price_closes,
+                    config,
+                    max_forward,
+                )
+                if event is not None:
+                    events.append(event)
+                state = FundingState.COOLDOWN_POSITIVE
+                continue
+
+        if normalized and state not in {
+            FundingState.EXTREME_NEGATIVE,
+            FundingState.EXTREME_POSITIVE,
+        }:
+            state = FundingState.IDLE
+
+    return events
+
+
+def _build_event(
+    tick: FundingTick,
+    side: NormalizationSide,
+    prior_extreme_rate: float,
+    funding_index: int,
+    funding_ticks: Sequence[FundingTick],
+    price_times: Sequence[datetime],
+    price_closes: Sequence[float],
+    config: ProbeConfig,
+    max_forward: int,
+) -> NormalizationEvent | None:
+    price_index = _find_price_index(price_times, tick.time)
+    if price_index is None:
+        return None
+
+    gross_12 = _forward_return_pct(price_closes, price_index, config.forward_bars_12h)
+    gross_24 = _forward_return_pct(price_closes, price_index, config.forward_bars_24h)
+    if gross_12 is None or gross_24 is None:
+        return None
+
+    # Hold window follows bar count on the probe timeframe (1h bars => hours).
+    end_12 = tick.time + timedelta(hours=config.forward_bars_12h)
+    end_24 = tick.time + timedelta(hours=config.forward_bars_24h)
+    drag_12 = _funding_drag_pct(funding_ticks, funding_index, tick.time, end_12, side)
+    drag_24 = _funding_drag_pct(funding_ticks, funding_index, tick.time, end_24, side)
+
+    return NormalizationEvent(
+        time=tick.time,
+        side=side,
+        funding_rate=tick.funding_rate,
+        prior_extreme_rate=prior_extreme_rate,
+        gross_forward_12h_pct=gross_12,
+        gross_forward_24h_pct=gross_24,
+        funding_drag_12h_pct=drag_12,
+        funding_drag_24h_pct=drag_24,
+    )
+
+
+def probe_funding_series(
+    funding_ticks: Sequence[FundingTick],
+    price_rows: Sequence[Mapping[str, object]],
+    config: ProbeConfig,
+) -> ProbeSummary:
+    price_times, price_closes = index_price_bars(price_rows)
+    events = detect_normalization_events(funding_ticks, price_times, price_closes, config)
+    if config.long_only:
+        events = [event for event in events if event.side == NormalizationSide.LONG_FROM_NEGATIVE]
+    return ProbeSummary(
+        symbol=config.symbol,
+        timeframe=config.timeframe,
+        funding_ticks=len(funding_ticks),
+        price_bars=len(price_rows),
+        events=tuple(events),
+    )
+
+
+async def _fetch_funding_ticks(symbol: str, start: str, end: str) -> list[FundingTick]:
+    pool = get_pool()
+    query = """
+        SELECT funding_time, funding_rate
+        FROM funding_rates
+        WHERE symbol = $1
+          AND funding_time >= $2
+          AND funding_time <= $3
+        ORDER BY funding_time ASC
+    """
+    async with pool.acquire() as conn:
+        rows = await conn.fetch(
+            query,
+            symbol,
+            _parse_dt(start),
+            _parse_dt(end),
+        )
+    return [
+        FundingTick(time=row["funding_time"], funding_rate=float(row["funding_rate"]))
+        for row in rows
+    ]
+
+
+async def run_probe(config: ProbeConfig) -> ProbeSummary:
+    db_config = build_db_config()
+    await init_pool(db_config)
+    try:
+        funding_ticks = await _fetch_funding_ticks(config.symbol, config.start, config.end)
+        reader = IndicatorReader(db_config)
+        async with reader:
+            price_rows = await reader.fetch_range(
+                config.symbol,
+                config.timeframe,
+                config.start,
+                config.end,
+            )
+    finally:
+        await close_pool()
+
+    return probe_funding_series(funding_ticks, price_rows, config)
+
+
+def evaluate_pulse(summary: ProbeSummary, config: ProbeConfig) -> str:
+    long_count = len(summary.long_events)
+    if long_count == 0:
+        return "NO_PULSE"
+    if long_count < config.min_events_for_pulse:
+        return "SPARSE"
+
+    stats_12 = summary.stats_for("12h")
+    stats_24 = summary.stats_for("24h")
+    has_positive_horizon = stats_12.mean_net_pct > 0 or stats_24.mean_net_pct > 0
+    concentration_ok = (
+        stats_12.max_event_share_of_positive_net_pct <= config.max_profit_concentration_pct
+        and stats_24.max_event_share_of_positive_net_pct <= config.max_profit_concentration_pct
+    )
+
+    if not has_positive_horizon:
+        return "WEAK_EDGE"
+    if not concentration_ok:
+        return "CONCENTRATED"
+    return "HAS_PULSE"
+
+
+def print_summary(summary: ProbeSummary, config: ProbeConfig) -> None:
+    verdict = evaluate_pulse(summary, config)
+    long_events = summary.long_events
+    rate_pct = len(long_events) / summary.funding_ticks * 100.0 if summary.funding_ticks else 0.0
+
+    print("Funding Normalization Feasibility Probe")
+    print("=" * 52)
+    print(f"Symbol:           {summary.symbol}")
+    print(f"Timeframe:        {summary.timeframe}")
+    print(f"Window:           {config.start} -> {config.end}")
+    print(f"Funding ticks:    {summary.funding_ticks}")
+    print(f"Price bars:       {summary.price_bars}")
+    print(f"Long norm events: {len(long_events)} ({rate_pct:.2f}% of funding ticks)")
+    print(f"Thresholds:       entry={config.entry_threshold:.5f} exit={config.exit_threshold:.5f}")
+    print()
+
+    for label in ("12h", "24h"):
+        stats = summary.stats_for(label)
+        print(f"Horizon {label} ({stats.horizon_bars} bars)")
+        print("-" * 52)
+        print(f"  Mean gross:        {stats.mean_gross_pct:.2f}%")
+        print(f"  Mean net:          {stats.mean_net_pct:.2f}%")
+        print(f"  Median net:        {stats.median_net_pct:.2f}%")
+        print(f"  Win rate (net>0):  {stats.win_rate_pct:.1f}%")
+        print(
+            f"  Max event share:   {stats.max_event_share_of_positive_net_pct:.1f}% "
+            f"(cap {config.max_profit_concentration_pct:.0f}%)"
+        )
+        print()
+
+    messages = {
+        "NO_PULSE": "Verdict: NO PULSE - zero normalization events.",
+        "SPARSE": "Verdict: SPARSE - reshape thresholds before implementation.",
+        "WEAK_EDGE": "Verdict: WEAK EDGE - events exist but net forward edge non-positive.",
+        "CONCENTRATED": "Verdict: CONCENTRATED - edge dominated by one event.",
+        "HAS_PULSE": "Verdict: HAS PULSE - justify funding_normalization implementation.",
+    }
+    print(messages[verdict])
+
+
+async def _main() -> int:
+    configure_logger("WARNING")
+    config = parse_args()
+    summary = await run_probe(config)
+    print_summary(summary, config)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(_main()))

--- a/scripts/probe_funding_normalization.py
+++ b/scripts/probe_funding_normalization.py
@@ -168,19 +168,28 @@ def parse_args(argv: Sequence[str] | None = None) -> ProbeConfig:
         action="store_true",
         help="Count positive-normalization short signals (research only)",
     )
+    parser.add_argument(
+        "--entry-negative-tail-pct",
+        type=float,
+        default=None,
+        help="Override entry threshold from negative funding tail (e.g. 5 = 5%% most negative)",
+    )
     args = parser.parse_args(argv)
-    return ProbeConfig(
-        symbol=args.symbol.upper(),
-        timeframe=args.timeframe,
-        start=args.start,
-        end=args.end,
-        entry_threshold=args.entry_threshold,
-        exit_threshold=args.exit_threshold,
-        forward_bars_12h=args.forward_bars_12h,
-        forward_bars_24h=args.forward_bars_24h,
-        min_events_for_pulse=args.min_events,
-        max_profit_concentration_pct=args.max_concentration_pct,
-        long_only=not args.include_short_events,
+    return (
+        ProbeConfig(
+            symbol=args.symbol.upper(),
+            timeframe=args.timeframe,
+            start=args.start,
+            end=args.end,
+            entry_threshold=args.entry_threshold,
+            exit_threshold=args.exit_threshold,
+            forward_bars_12h=args.forward_bars_12h,
+            forward_bars_24h=args.forward_bars_24h,
+            min_events_for_pulse=args.min_events,
+            max_profit_concentration_pct=args.max_concentration_pct,
+            long_only=not args.include_short_events,
+        ),
+        args.entry_negative_tail_pct,
     )
 
 
@@ -196,6 +205,32 @@ def _median(values: Iterable[float]) -> float:
     if not materialized:
         return 0.0
     return float(statistics.median(materialized))
+
+
+def entry_threshold_negative_tail(
+    funding_rates: Sequence[float],
+    tail_pct: float,
+    floor: float = 0.00008,
+) -> float:
+    """Entry threshold from the most negative tail of observed funding (|rate|)."""
+    negatives = sorted(rate for rate in funding_rates if rate < 0)
+    if len(negatives) < 10:
+        return floor
+    index = max(0, min(len(negatives) - 1, int(len(negatives) * tail_pct / 100.0)))
+    return max(floor, abs(negatives[index]))
+
+
+def entry_threshold_positive_tail(
+    funding_rates: Sequence[float],
+    tail_pct: float,
+    floor: float = 0.00008,
+) -> float:
+    """Entry threshold from the most positive tail (for short-side normalization probe)."""
+    positives = sorted((rate for rate in funding_rates if rate > 0), reverse=True)
+    if len(positives) < 10:
+        return floor
+    index = max(0, min(len(positives) - 1, int(len(positives) * tail_pct / 100.0)))
+    return max(floor, positives[index])
 
 
 def _parse_dt(value: str | datetime) -> datetime:
@@ -407,11 +442,30 @@ async def _fetch_funding_ticks(symbol: str, start: str, end: str) -> list[Fundin
     ]
 
 
-async def run_probe(config: ProbeConfig) -> ProbeSummary:
+async def run_probe(
+    config: ProbeConfig,
+    *,
+    entry_negative_tail_pct: float | None = None,
+) -> ProbeSummary:
     db_config = build_db_config()
     await init_pool(db_config)
     try:
         funding_ticks = await _fetch_funding_ticks(config.symbol, config.start, config.end)
+        if entry_negative_tail_pct is not None:
+            rates = [tick.funding_rate for tick in funding_ticks]
+            config = ProbeConfig(
+                symbol=config.symbol,
+                timeframe=config.timeframe,
+                start=config.start,
+                end=config.end,
+                entry_threshold=entry_threshold_negative_tail(rates, entry_negative_tail_pct),
+                exit_threshold=config.exit_threshold,
+                forward_bars_12h=config.forward_bars_12h,
+                forward_bars_24h=config.forward_bars_24h,
+                min_events_for_pulse=config.min_events_for_pulse,
+                max_profit_concentration_pct=config.max_profit_concentration_pct,
+                long_only=config.long_only,
+            )
         reader = IndicatorReader(db_config)
         async with reader:
             price_rows = await reader.fetch_range(
@@ -490,8 +544,8 @@ def print_summary(summary: ProbeSummary, config: ProbeConfig) -> None:
 
 async def _main() -> int:
     configure_logger("WARNING")
-    config = parse_args()
-    summary = await run_probe(config)
+    config, tail_pct = parse_args()
+    summary = await run_probe(config, entry_negative_tail_pct=tail_pct)
     print_summary(summary, config)
     return 0
 

--- a/scripts/probe_relative_strength_rotation.py
+++ b/scripts/probe_relative_strength_rotation.py
@@ -1,0 +1,412 @@
+#!/usr/bin/env python3
+"""Cheap feasibility probe for the relative-strength rotation surface.
+
+This intentionally avoids strategy registration, BacktestEngine plumbing, and
+autoresearch candidate generation. It answers whether the ETH/BTC relative
+strength idea has enough signal frequency and crude forward edge to justify the
+full implementation described in:
+
+docs/specs/relative-strength-rotation-surface-v0.md
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import statistics
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass
+from datetime import datetime
+
+from src.db import close_pool, init_pool
+from src.features.reader import IndicatorReader
+from src.utils.logger import configure_logger
+
+
+@dataclass(frozen=True)
+class ProbeConfig:
+    target_symbol: str
+    anchor_symbol: str
+    timeframe: str
+    start: str
+    end: str
+    fast_lookback_bars: int
+    slow_lookback_bars: int
+    forward_bars: int
+    min_fast_rs_pct: float
+    min_slow_rs_pct: float
+    max_rs_deterioration_pct: float
+    max_pullback_distance_pct: float
+    rsi_reset_min: float
+    rsi_reset_max: float
+    anchor_max_fast_loss_pct: float
+    anchor_min_ema200_distance_pct: float
+
+
+@dataclass(frozen=True)
+class ProbeEvent:
+    time: datetime
+    target_close: float
+    anchor_close: float
+    rs_fast_pct: float
+    rs_slow_pct: float
+    rs_deterioration_pct: float
+    target_forward_return_pct: float
+    anchor_forward_return_pct: float
+    excess_forward_return_pct: float
+
+
+@dataclass(frozen=True)
+class ProbeSummary:
+    target_symbol: str
+    anchor_symbol: str
+    timeframe: str
+    target_rows: int
+    anchor_rows: int
+    aligned_rows: int
+    events: tuple[ProbeEvent, ...]
+
+    @property
+    def event_count(self) -> int:
+        return len(self.events)
+
+    @property
+    def event_rate_pct(self) -> float:
+        if self.aligned_rows == 0:
+            return 0.0
+        return self.event_count / self.aligned_rows * 100.0
+
+    @property
+    def mean_forward_return_pct(self) -> float:
+        return _mean(event.target_forward_return_pct for event in self.events)
+
+    @property
+    def median_forward_return_pct(self) -> float:
+        return _median(event.target_forward_return_pct for event in self.events)
+
+    @property
+    def mean_excess_forward_return_pct(self) -> float:
+        return _mean(event.excess_forward_return_pct for event in self.events)
+
+    @property
+    def median_excess_forward_return_pct(self) -> float:
+        return _median(event.excess_forward_return_pct for event in self.events)
+
+    @property
+    def win_rate_pct(self) -> float:
+        if not self.events:
+            return 0.0
+        wins = sum(1 for event in self.events if event.target_forward_return_pct > 0.0)
+        return wins / len(self.events) * 100.0
+
+    @property
+    def excess_win_rate_pct(self) -> float:
+        if not self.events:
+            return 0.0
+        wins = sum(1 for event in self.events if event.excess_forward_return_pct > 0.0)
+        return wins / len(self.events) * 100.0
+
+
+def build_db_config(env: Mapping[str, str] | None = None) -> dict[str, object]:
+    source = env or os.environ
+    return {
+        "host": source.get("DB_HOST", "localhost"),
+        "port": int(source.get("DB_PORT", 15432)),
+        "name": source.get("DB_NAME", "marketdata"),
+        "user": source.get("DB_USER", "trading"),
+        "password": source.get("DB_PASSWORD", source.get("POSTGRES_PASSWORD", "change_me")),
+    }
+
+
+def parse_args(argv: Sequence[str] | None = None) -> ProbeConfig:
+    parser = argparse.ArgumentParser(
+        description="Probe relative-strength rotation frequency and crude forward edge."
+    )
+    parser.add_argument("--target-symbol", default="ETHUSDT")
+    parser.add_argument("--anchor-symbol", default="BTCUSDT")
+    parser.add_argument("--timeframe", default="1h")
+    parser.add_argument("--start", default="2024-01-01T00:00:00")
+    parser.add_argument("--end", default="2026-06-01T00:00:00")
+    parser.add_argument("--fast-lookback-bars", type=int, default=6)
+    parser.add_argument("--slow-lookback-bars", type=int, default=24)
+    parser.add_argument("--forward-bars", type=int, default=12)
+    parser.add_argument("--min-fast-rs-pct", type=float, default=0.8)
+    parser.add_argument("--min-slow-rs-pct", type=float, default=2.0)
+    parser.add_argument("--max-rs-deterioration-pct", type=float, default=-1.5)
+    parser.add_argument("--max-pullback-distance-pct", type=float, default=2.0)
+    parser.add_argument("--rsi-reset-min", type=float, default=35.0)
+    parser.add_argument("--rsi-reset-max", type=float, default=60.0)
+    parser.add_argument("--anchor-max-fast-loss-pct", type=float, default=3.0)
+    parser.add_argument("--anchor-min-ema200-distance-pct", type=float, default=-2.0)
+    args = parser.parse_args(argv)
+
+    return ProbeConfig(
+        target_symbol=args.target_symbol.upper(),
+        anchor_symbol=args.anchor_symbol.upper(),
+        timeframe=args.timeframe,
+        start=args.start,
+        end=args.end,
+        fast_lookback_bars=args.fast_lookback_bars,
+        slow_lookback_bars=args.slow_lookback_bars,
+        forward_bars=args.forward_bars,
+        min_fast_rs_pct=args.min_fast_rs_pct,
+        min_slow_rs_pct=args.min_slow_rs_pct,
+        max_rs_deterioration_pct=args.max_rs_deterioration_pct,
+        max_pullback_distance_pct=args.max_pullback_distance_pct,
+        rsi_reset_min=args.rsi_reset_min,
+        rsi_reset_max=args.rsi_reset_max,
+        anchor_max_fast_loss_pct=args.anchor_max_fast_loss_pct,
+        anchor_min_ema200_distance_pct=args.anchor_min_ema200_distance_pct,
+    )
+
+
+def _mean(values: Iterable[float]) -> float:
+    materialized = list(values)
+    if not materialized:
+        return 0.0
+    return sum(materialized) / len(materialized)
+
+
+def _median(values: Iterable[float]) -> float:
+    materialized = list(values)
+    if not materialized:
+        return 0.0
+    return float(statistics.median(materialized))
+
+
+def _return_pct(rows: Sequence[Mapping[str, object]], index: int, lookback: int) -> float | None:
+    if index - lookback < 0:
+        return None
+    previous = float(rows[index - lookback]["close_price"])
+    current = float(rows[index]["close_price"])
+    if previous <= 0:
+        return None
+    return (current / previous - 1.0) * 100.0
+
+
+def _forward_return_pct(
+    rows: Sequence[Mapping[str, object]],
+    index: int,
+    forward_bars: int,
+) -> float | None:
+    if index + forward_bars >= len(rows):
+        return None
+    current = float(rows[index]["close_price"])
+    future = float(rows[index + forward_bars]["close_price"])
+    if current <= 0:
+        return None
+    return (future / current - 1.0) * 100.0
+
+
+def _distance_pct(price: float, reference: object) -> float | None:
+    if reference is None:
+        return None
+    reference_price = float(reference)
+    if reference_price <= 0:
+        return None
+    return (price / reference_price - 1.0) * 100.0
+
+
+def align_same_timestamp_rows(
+    target_rows: Sequence[Mapping[str, object]],
+    anchor_rows: Sequence[Mapping[str, object]],
+) -> tuple[list[Mapping[str, object]], list[Mapping[str, object]]]:
+    """Align same-timeframe rows by exact closed candle timestamp."""
+    anchor_by_time = {row["time"]: row for row in anchor_rows}
+    aligned_target: list[Mapping[str, object]] = []
+    aligned_anchor: list[Mapping[str, object]] = []
+
+    for target_row in target_rows:
+        anchor_row = anchor_by_time.get(target_row["time"])
+        if anchor_row is None:
+            continue
+        aligned_target.append(target_row)
+        aligned_anchor.append(anchor_row)
+
+    return aligned_target, aligned_anchor
+
+
+def is_rotation_probe_event(
+    target_rows: Sequence[Mapping[str, object]],
+    anchor_rows: Sequence[Mapping[str, object]],
+    index: int,
+    config: ProbeConfig,
+) -> tuple[bool, dict[str, float]]:
+    target_fast = _return_pct(target_rows, index, config.fast_lookback_bars)
+    anchor_fast = _return_pct(anchor_rows, index, config.fast_lookback_bars)
+    target_slow = _return_pct(target_rows, index, config.slow_lookback_bars)
+    anchor_slow = _return_pct(anchor_rows, index, config.slow_lookback_bars)
+    if None in {target_fast, anchor_fast, target_slow, anchor_slow}:
+        return False, {}
+
+    assert target_fast is not None
+    assert anchor_fast is not None
+    assert target_slow is not None
+    assert anchor_slow is not None
+
+    rs_fast = target_fast - anchor_fast
+    rs_slow = target_slow - anchor_slow
+    rs_deterioration = rs_fast - rs_slow
+
+    target_row = target_rows[index]
+    anchor_row = anchor_rows[index]
+    target_close = float(target_row["close_price"])
+    anchor_close = float(anchor_row["close_price"])
+
+    pullback_reference = target_row.get("vwap") or target_row.get("ema_50")
+    pullback_distance = _distance_pct(target_close, pullback_reference)
+    target_ema50_distance = _distance_pct(target_close, target_row.get("ema_50"))
+    anchor_ema200_distance = _distance_pct(anchor_close, anchor_row.get("ema_200"))
+    rsi_14 = target_row.get("rsi_14")
+
+    if pullback_distance is None or target_ema50_distance is None:
+        return False, {}
+    if anchor_ema200_distance is None or rsi_14 is None:
+        return False, {}
+
+    anchor_non_panic = (
+        anchor_fast >= -config.anchor_max_fast_loss_pct
+        and anchor_ema200_distance >= config.anchor_min_ema200_distance_pct
+    )
+    rs_persistent = rs_fast >= config.min_fast_rs_pct and rs_slow >= config.min_slow_rs_pct
+    rs_not_collapsing = rs_deterioration >= config.max_rs_deterioration_pct
+    controlled_pullback = abs(pullback_distance) <= config.max_pullback_distance_pct
+    rsi_reset = config.rsi_reset_min <= float(rsi_14) <= config.rsi_reset_max
+    pullback_resolution = target_close >= float(target_row["ema_50"])
+
+    passed = (
+        anchor_non_panic
+        and rs_persistent
+        and rs_not_collapsing
+        and controlled_pullback
+        and rsi_reset
+        and pullback_resolution
+    )
+    metrics = {
+        "target_fast_return_pct": target_fast,
+        "anchor_fast_return_pct": anchor_fast,
+        "target_slow_return_pct": target_slow,
+        "anchor_slow_return_pct": anchor_slow,
+        "rs_fast_pct": rs_fast,
+        "rs_slow_pct": rs_slow,
+        "rs_deterioration_pct": rs_deterioration,
+        "pullback_distance_pct": pullback_distance,
+        "target_ema50_distance_pct": target_ema50_distance,
+        "anchor_ema200_distance_pct": anchor_ema200_distance,
+    }
+    return passed, metrics
+
+
+def probe_rows(
+    target_rows: Sequence[Mapping[str, object]],
+    anchor_rows: Sequence[Mapping[str, object]],
+    config: ProbeConfig,
+) -> ProbeSummary:
+    aligned_target, aligned_anchor = align_same_timestamp_rows(target_rows, anchor_rows)
+    events: list[ProbeEvent] = []
+    start_index = max(config.fast_lookback_bars, config.slow_lookback_bars)
+    stop_index = len(aligned_target) - config.forward_bars
+
+    for index in range(start_index, max(start_index, stop_index)):
+        passed, metrics = is_rotation_probe_event(aligned_target, aligned_anchor, index, config)
+        if not passed:
+            continue
+
+        target_forward = _forward_return_pct(aligned_target, index, config.forward_bars)
+        anchor_forward = _forward_return_pct(aligned_anchor, index, config.forward_bars)
+        if target_forward is None or anchor_forward is None:
+            continue
+
+        events.append(
+            ProbeEvent(
+                time=aligned_target[index]["time"],
+                target_close=float(aligned_target[index]["close_price"]),
+                anchor_close=float(aligned_anchor[index]["close_price"]),
+                rs_fast_pct=metrics["rs_fast_pct"],
+                rs_slow_pct=metrics["rs_slow_pct"],
+                rs_deterioration_pct=metrics["rs_deterioration_pct"],
+                target_forward_return_pct=target_forward,
+                anchor_forward_return_pct=anchor_forward,
+                excess_forward_return_pct=target_forward - anchor_forward,
+            )
+        )
+
+    return ProbeSummary(
+        target_symbol=config.target_symbol,
+        anchor_symbol=config.anchor_symbol,
+        timeframe=config.timeframe,
+        target_rows=len(target_rows),
+        anchor_rows=len(anchor_rows),
+        aligned_rows=len(aligned_target),
+        events=tuple(events),
+    )
+
+
+async def run_probe(config: ProbeConfig) -> ProbeSummary:
+    db_config = build_db_config()
+    await init_pool(db_config)
+    try:
+        reader = IndicatorReader(db_config)
+        async with reader:
+            target_rows = await reader.fetch_range(
+                config.target_symbol,
+                config.timeframe,
+                config.start,
+                config.end,
+            )
+            anchor_rows = await reader.fetch_range(
+                config.anchor_symbol,
+                config.timeframe,
+                config.start,
+                config.end,
+            )
+    finally:
+        await close_pool()
+
+    return probe_rows(target_rows, anchor_rows, config)
+
+
+def print_summary(summary: ProbeSummary, config: ProbeConfig) -> None:
+    print("Relative Strength Rotation Feasibility Probe")
+    print("=" * 52)
+    print(f"Target / anchor: {summary.target_symbol} / {summary.anchor_symbol}")
+    print(f"Timeframe:        {summary.timeframe}")
+    print(f"Window:           {config.start} -> {config.end}")
+    print(f"Rows:             target={summary.target_rows} anchor={summary.anchor_rows}")
+    print(f"Aligned rows:     {summary.aligned_rows}")
+    print(f"Events:           {summary.event_count} ({summary.event_rate_pct:.2f}% of rows)")
+    print()
+    print("Forward edge after event")
+    print("-" * 52)
+    print(f"Forward bars:          {config.forward_bars}")
+    print(f"Mean target return:    {summary.mean_forward_return_pct:.2f}%")
+    print(f"Median target return:  {summary.median_forward_return_pct:.2f}%")
+    print(f"Target win rate:       {summary.win_rate_pct:.1f}%")
+    print(f"Mean excess vs anchor: {summary.mean_excess_forward_return_pct:.2f}%")
+    print(f"Median excess:         {summary.median_excess_forward_return_pct:.2f}%")
+    print(f"Excess win rate:       {summary.excess_win_rate_pct:.1f}%")
+    print()
+
+    if not summary.events:
+        print("Verdict: NO PULSE - preconditions produced zero events.")
+        return
+
+    if summary.event_count < 20:
+        print("Verdict: SPARSE - inspect thresholds before implementing the full surface.")
+    elif summary.mean_excess_forward_return_pct <= 0:
+        print("Verdict: WEAK EDGE - frequency exists, but crude forward excess is non-positive.")
+    else:
+        print("Verdict: HAS PULSE - frequency and crude forward excess justify deeper work.")
+
+
+async def _main() -> int:
+    configure_logger("WARNING")
+    config = parse_args()
+    summary = await run_probe(config)
+    print_summary(summary, config)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(_main()))

--- a/scripts/production_drift_sentinel.py
+++ b/scripts/production_drift_sentinel.py
@@ -32,6 +32,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--expected-branch", default="main", help="Expected deploy branch")
     parser.add_argument("--remote-host", default="crypto-agent", help="SSH host alias")
     parser.add_argument("--remote-dir", default="/opt/crypto-agent", help="Remote repo path")
+    parser.add_argument("--ssh-config", help="Optional OpenSSH config file passed with ssh -F")
     parser.add_argument("--signal-stale-hours", type=int, default=24)
     parser.add_argument("--log-tail", type=int, default=500)
     parser.add_argument(
@@ -180,14 +181,21 @@ def main() -> int:
 
     if not args.local_only:
         try:
-            remote_repo = collect_remote_repo_snapshot(args.remote_host, args.remote_dir)
-            remote_config_hashes = collect_remote_config_hashes(args.remote_host, args.remote_dir)
-            service_snapshot = collect_remote_service_snapshot(args.remote_host, args.remote_dir)
+            remote_repo = collect_remote_repo_snapshot(
+                args.remote_host, args.remote_dir, ssh_config=args.ssh_config
+            )
+            remote_config_hashes = collect_remote_config_hashes(
+                args.remote_host, args.remote_dir, ssh_config=args.ssh_config
+            )
+            service_snapshot = collect_remote_service_snapshot(
+                args.remote_host, args.remote_dir, ssh_config=args.ssh_config
+            )
             signal_snapshot = collect_remote_signal_snapshot(
                 args.remote_host,
                 args.remote_dir,
                 service_snapshot,
                 tail_lines=args.log_tail,
+                ssh_config=args.ssh_config,
             )
             if args.watch_service:
                 watched_service_snapshot = collect_remote_watched_service_snapshot(
@@ -196,6 +204,7 @@ def main() -> int:
                     service_snapshot,
                     args.watch_service,
                     tail_lines=args.log_tail,
+                    ssh_config=args.ssh_config,
                 )
         except Exception as exc:  # noqa: BLE001
             remote_error = str(exc)

--- a/scripts/production_drift_sentinel.py
+++ b/scripts/production_drift_sentinel.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
 from datetime import datetime
 from pathlib import Path
@@ -30,7 +31,11 @@ from src.utils.production_drift_sentinel import (  # noqa: E402
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Production drift sentinel")
-    parser.add_argument("--expected-branch", default="main", help="Expected deploy branch")
+    parser.add_argument(
+        "--expected-branch",
+        default=os.getenv("EXPECTED_DEPLOY_BRANCH", "main"),
+        help="Expected deploy branch (default: EXPECTED_DEPLOY_BRANCH or main)",
+    )
     parser.add_argument("--remote-host", default="crypto-agent", help="SSH host alias")
     parser.add_argument("--remote-dir", default="/opt/crypto-agent", help="Remote repo path")
     parser.add_argument("--ssh-config", help="Optional OpenSSH config file passed with ssh -F")
@@ -41,6 +46,11 @@ def parse_args() -> argparse.Namespace:
         help="Optional docker compose service to inspect separately (for example: agent_sol_sparse)",
     )
     parser.add_argument("--local-only", action="store_true", help="Skip remote checks")
+    parser.add_argument(
+        "--production-local",
+        action="store_true",
+        help="Inspect the production host directly without SSH (for server-side scheduling)",
+    )
     parser.add_argument("--json", action="store_true", help="Print JSON output")
     parser.add_argument(
         "--fail-on",
@@ -174,6 +184,8 @@ def _render_markdown(report: DriftReport, expected_branch: str) -> str:
 
 def main() -> int:
     args = parse_args()
+    if args.local_only and args.production_local:
+        raise SystemExit("--local-only and --production-local cannot be used together")
 
     local_repo = None
     local_config_hashes: dict[str, str] = {}
@@ -196,21 +208,22 @@ def main() -> int:
     remote_error = None
 
     if not args.local_only:
+        inspection_host = None if args.production_local else args.remote_host
         try:
             remote_repo = collect_remote_repo_snapshot(
-                args.remote_host, args.remote_dir, ssh_config=args.ssh_config
+                inspection_host, args.remote_dir, ssh_config=args.ssh_config
             )
             remote_config_hashes = collect_remote_config_hashes(
-                args.remote_host, args.remote_dir, ssh_config=args.ssh_config
+                inspection_host, args.remote_dir, ssh_config=args.ssh_config
             )
             service_snapshot = collect_remote_service_snapshot(
-                args.remote_host, args.remote_dir, ssh_config=args.ssh_config
+                inspection_host, args.remote_dir, ssh_config=args.ssh_config
             )
             timer_snapshot = collect_remote_timer_snapshot(
-                args.remote_host, args.remote_dir, ssh_config=args.ssh_config
+                inspection_host, args.remote_dir, ssh_config=args.ssh_config
             )
             signal_snapshot = collect_remote_signal_snapshot(
-                args.remote_host,
+                inspection_host,
                 args.remote_dir,
                 service_snapshot,
                 tail_lines=args.log_tail,
@@ -218,7 +231,7 @@ def main() -> int:
             )
             if args.watch_service:
                 watched_service_snapshot = collect_remote_watched_service_snapshot(
-                    args.remote_host,
+                    inspection_host,
                     args.remote_dir,
                     service_snapshot,
                     args.watch_service,

--- a/scripts/production_drift_sentinel.py
+++ b/scripts/production_drift_sentinel.py
@@ -21,6 +21,7 @@ from src.utils.production_drift_sentinel import (  # noqa: E402
     collect_remote_repo_snapshot,
     collect_remote_service_snapshot,
     collect_remote_signal_snapshot,
+    collect_remote_timer_snapshot,
     collect_remote_watched_service_snapshot,
     collect_repo_snapshot,
     report_to_json,
@@ -111,6 +112,15 @@ def _render_markdown(report: DriftReport, expected_branch: str) -> str:
         lines.append("- Service snapshot unavailable")
 
     lines.append("")
+    lines.append("## Required Timers")
+    lines.append("")
+    if report.timer_snapshot is not None:
+        for timer in report.timer_snapshot.timers:
+            lines.append(f"- {timer.timer}: enabled={timer.enabled}, active={timer.active}")
+    else:
+        lines.append("- Timer snapshot unavailable")
+
+    lines.append("")
     lines.append("## Signal Activity")
     lines.append("")
     if report.signal_snapshot is not None:
@@ -175,6 +185,7 @@ def main() -> int:
     remote_repo = None
     remote_config_hashes: dict[str, str] = {}
     service_snapshot = None
+    timer_snapshot = None
     signal_snapshot = None
     watched_service_snapshot = None
     remote_error = None
@@ -188,6 +199,9 @@ def main() -> int:
                 args.remote_host, args.remote_dir, ssh_config=args.ssh_config
             )
             service_snapshot = collect_remote_service_snapshot(
+                args.remote_host, args.remote_dir, ssh_config=args.ssh_config
+            )
+            timer_snapshot = collect_remote_timer_snapshot(
                 args.remote_host, args.remote_dir, ssh_config=args.ssh_config
             )
             signal_snapshot = collect_remote_signal_snapshot(
@@ -216,6 +230,7 @@ def main() -> int:
         local_config_hashes=local_config_hashes,
         remote_config_hashes=remote_config_hashes,
         service_snapshot=service_snapshot,
+        timer_snapshot=timer_snapshot,
         signal_snapshot=signal_snapshot,
         watched_service_snapshot=watched_service_snapshot,
         remote_error=remote_error,
@@ -242,6 +257,7 @@ def main() -> int:
         local_config_hashes=local_config_hashes,
         remote_config_hashes=remote_config_hashes,
         service_snapshot=service_snapshot,
+        timer_snapshot=timer_snapshot,
         signal_snapshot=signal_snapshot,
         watched_service_snapshot=watched_service_snapshot,
         findings=findings,

--- a/scripts/production_drift_sentinel.py
+++ b/scripts/production_drift_sentinel.py
@@ -116,7 +116,12 @@ def _render_markdown(report: DriftReport, expected_branch: str) -> str:
     lines.append("")
     if report.timer_snapshot is not None:
         for timer in report.timer_snapshot.timers:
-            lines.append(f"- {timer.timer}: enabled={timer.enabled}, active={timer.active}")
+            lines.append(
+                f"- {timer.timer}: enabled={timer.enabled}, active={timer.active}, "
+                f"service_result={timer.service_result}, "
+                f"exec_status={timer.exec_main_status}, "
+                f"latest_report={timer.latest_report_at or 'none'}"
+            )
     else:
         lines.append("- Timer snapshot unavailable")
 

--- a/scripts/profit_report.py
+++ b/scripts/profit_report.py
@@ -182,11 +182,9 @@ async def generate_report(
     )
     try:
         async with pool.acquire() as conn:
-            overall, by_agent, by_symbol = await asyncio.gather(
-                _fetch_overall(conn),
-                _fetch_by_agent(conn),
-                _fetch_by_symbol(conn),
-            )
+            overall = await _fetch_overall(conn)
+            by_agent = await _fetch_by_agent(conn)
+            by_symbol = await _fetch_by_symbol(conn)
     finally:
         await pool.close()
 

--- a/scripts/run_autoresearch.py
+++ b/scripts/run_autoresearch.py
@@ -17,6 +17,8 @@ from typing import Any
 
 import yaml
 
+from src.backtest.experiment_autopilot import ExperimentSummary, GateConfig, evaluate_gates
+
 GATE_PROFILES: dict[str, dict[str, float | int]] = {
     "standard": {
         "min_trades": 0,
@@ -44,6 +46,15 @@ GATE_PROFILES: dict[str, dict[str, float | int]] = {
         "max_bootstrap_p_loss_pct": 25.0,
         "min_oos_return_pct": 0.0,
         "max_profit_concentration_pct": 50.0,
+    },
+    "promotion_candidate": {
+        "min_trades": 0,
+        "min_wfo_trades": 20,
+        "min_wfo_sharpe": 0.5,
+        "max_drawdown_pct": 8.0,
+        "max_bootstrap_p_loss_pct": 20.0,
+        "min_oos_return_pct": 1.0,
+        "max_profit_concentration_pct": 40.0,
     },
 }
 
@@ -248,6 +259,52 @@ def _build_autopilot_command(args: argparse.Namespace, artifacts: RunArtifacts) 
     if args.replay_sentiment_max_age_hours is not None:
         cmd.extend(["--replay-sentiment-max-age-hours", str(args.replay_sentiment_max_age_hours)])
     return cmd
+
+
+def _gate_config_from_profile(profile_name: str) -> GateConfig:
+    profile = GATE_PROFILES[profile_name]
+    return GateConfig(
+        min_trades=int(profile["min_trades"]),
+        min_wfo_trades=int(profile["min_wfo_trades"]),
+        min_wfo_sharpe=float(profile["min_wfo_sharpe"]),
+        max_drawdown_pct=float(profile["max_drawdown_pct"]),
+        max_bootstrap_p_loss_pct=float(profile["max_bootstrap_p_loss_pct"]),
+        min_oos_return_pct=float(profile["min_oos_return_pct"]),
+        max_profit_concentration_pct=float(profile["max_profit_concentration_pct"]),
+    )
+
+
+def _summary_from_payload(summary: dict[str, Any]) -> ExperimentSummary:
+    return ExperimentSummary(
+        symbol=str(summary.get("symbol", "")),
+        timeframe=str(summary.get("timeframe", "")),
+        start=str(summary.get("start", "")),
+        end=str(summary.get("end", "")),
+        total_trades=int(summary.get("total_trades", 0)),
+        win_rate=float(summary.get("win_rate", 0.0)),
+        total_return_pct=float(summary.get("total_return_pct", 0.0)),
+        max_drawdown_pct=float(summary.get("max_drawdown_pct", 0.0)),
+        sharpe_ratio=float(summary.get("sharpe_ratio", 0.0)),
+        wfo_windows=int(summary.get("wfo_windows", 0)),
+        wfo_total_trades=int(summary.get("wfo_total_trades", 0)),
+        wfo_mean_sharpe=float(summary.get("wfo_mean_sharpe", 0.0)),
+        wfo_total_return_pct=float(summary.get("wfo_total_return_pct", 0.0)),
+        bootstrap_p_loss_pct=float(summary.get("bootstrap_p_loss_pct", 0.0)),
+        profit_concentration_pct=float(summary.get("profit_concentration_pct", 0.0)),
+        passes_gates=bool(summary.get("passes_gates", False)),
+        failure_reasons=list(summary.get("failure_reasons", [])),
+    )
+
+
+def _eligible_for_bootstrap_1000(
+    summary: dict[str, Any], *, bootstrap: int
+) -> tuple[bool, list[str]]:
+    """Stricter pre-filter before scheduling bootstrap=1000 revalidation."""
+    if bootstrap > 100:
+        return False, ["bootstrap_gt_100"]
+    promotion_gates = _gate_config_from_profile("promotion_candidate")
+    failures = evaluate_gates(_summary_from_payload(summary), promotion_gates)
+    return len(failures) == 0, failures
 
 
 def _resolve_gates(args: argparse.Namespace) -> dict[str, float | int]:
@@ -694,12 +751,17 @@ def main() -> None:
         stdout=stdout,
         stderr=stderr,
     )
+    eligible_b1000, promotion_failures = _eligible_for_bootstrap_1000(
+        summary, bootstrap=args.bootstrap
+    )
     last_result.update(
         {
             "score": round(score, 6),
             "previous_best_score": previous_best,
             "summary": summary,
             "gates": gates,
+            "eligible_for_bootstrap_1000": eligible_b1000,
+            "promotion_candidate_failures": promotion_failures,
             "results_row": row,
             "json_artifact_path": str(json_path.resolve()),
             "markdown_artifact_path": str(markdown_path.resolve()) if markdown_path else None,

--- a/scripts/run_autoresearch.py
+++ b/scripts/run_autoresearch.py
@@ -466,12 +466,15 @@ def _append_results_row(results_path: Path, row: dict[str, str]) -> None:
 
 
 def _git_commit_short() -> str:
-    result = subprocess.run(
-        ["git", "rev-parse", "--short", "HEAD"],
-        capture_output=True,
-        text=True,
-        check=False,
-    )
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--short", "HEAD"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except (FileNotFoundError, OSError):
+        return "unknown"
     if result.returncode != 0:
         return "unknown"
     return result.stdout.strip() or "unknown"

--- a/scripts/run_autoresearch.py
+++ b/scripts/run_autoresearch.py
@@ -15,6 +15,8 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
 import yaml
 
 from src.backtest.experiment_autopilot import ExperimentSummary, GateConfig, evaluate_gates

--- a/scripts/run_autoresearch.py
+++ b/scripts/run_autoresearch.py
@@ -36,6 +36,15 @@ GATE_PROFILES: dict[str, dict[str, float | int]] = {
         "min_oos_return_pct": 0.0,
         "max_profit_concentration_pct": 65.0,
     },
+    "probe_1h": {
+        "min_trades": 0,
+        "min_wfo_trades": 15,
+        "min_wfo_sharpe": 0.5,
+        "max_drawdown_pct": 10.0,
+        "max_bootstrap_p_loss_pct": 25.0,
+        "min_oos_return_pct": 0.0,
+        "max_profit_concentration_pct": 50.0,
+    },
 }
 
 RESULTS_FIELDNAMES = [
@@ -299,6 +308,15 @@ def _write_run_log(
         handle.write("\n".join(lines))
 
 
+def _normalize_subprocess_output(value: str | bytes | None) -> str:
+    """Return subprocess output as text for both completed and timed-out runs."""
+    if value is None:
+        return ""
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    return value
+
+
 def _run_autopilot(
     cmd: list[str],
     *,
@@ -332,8 +350,8 @@ def _run_autopilot(
     except subprocess.TimeoutExpired as exc:
         duration = time.monotonic() - start_time
         finished = datetime.now(UTC)
-        stdout = exc.stdout or ""
-        stderr = exc.stderr or ""
+        stdout = _normalize_subprocess_output(exc.stdout)
+        stderr = _normalize_subprocess_output(exc.stderr)
         _write_run_log(
             run_log_path,
             cmd=cmd,

--- a/scripts/run_autoresearch_campaign_remote.sh
+++ b/scripts/run_autoresearch_campaign_remote.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# Run a bounded autoresearch_loop on Hetzner via one-off Docker on the DB network.
+set -euo pipefail
+
+SYMBOL="${1:?symbol required, e.g. ETHUSDT}"
+TIMEFRAME="${2:?timeframe required, e.g. 1h}"
+OUTPUT_SUFFIX="${3:-pass1}"
+FAMILIES="${FAMILIES:-trend_pullback_overlay,combined_focus}"
+MAX_RUNS="${MAX_RUNS:-50}"
+BOOTSTRAP="${BOOTSTRAP:-100}"
+GATE_PROFILE="${GATE_PROFILE:-standard}"
+TRAIN_MONTHS="${TRAIN_MONTHS:-3}"
+TEST_MONTHS="${TEST_MONTHS:-2}"
+REMOTE_HOST="${REMOTE_HOST:-crypto-agent}"
+REMOTE_DIR="${REMOTE_DIR:-/opt/crypto-agent}"
+IMAGE="${IMAGE:-crypto-agent-agent_sentiment_macro:latest}"
+
+OUTPUT_DIR="research/$(echo "${SYMBOL}" | tr '[:upper:]' '[:lower:]')-${TIMEFRAME}-${OUTPUT_SUFFIX}"
+
+echo "Remote campaign: ${SYMBOL} ${TIMEFRAME} -> ${OUTPUT_DIR} (${MAX_RUNS} runs)"
+
+ssh "${REMOTE_HOST}" "mkdir -p ${REMOTE_DIR}/${OUTPUT_DIR} && sudo chown -R 999:999 ${REMOTE_DIR}/${OUTPUT_DIR} && nohup bash -c '
+cd ${REMOTE_DIR} && docker run --rm \
+  --network crypto-agent_crypto-net \
+  -v ${REMOTE_DIR}:/app \
+  -w /app \
+  --env-file .env \
+  -e POSTGRES_HOST=timescaledb \
+  -e POSTGRES_PORT=5432 \
+  ${IMAGE} \
+  python scripts/autoresearch_loop.py \
+    --config config/settings.autoresearch.yaml \
+    --symbol ${SYMBOL} \
+    --timeframe ${TIMEFRAME} \
+    --train-months ${TRAIN_MONTHS} \
+    --test-months ${TEST_MONTHS} \
+    --gate-profile ${GATE_PROFILE} \
+    --families ${FAMILIES} \
+    --bootstrap ${BOOTSTRAP} \
+    --max-runs ${MAX_RUNS} \
+    --output-dir /app/${OUTPUT_DIR} \
+    --timeout-seconds 900
+' >> ${REMOTE_DIR}/${OUTPUT_DIR}/campaign.log 2>&1 &
+echo Campaign started. Log: ${REMOTE_DIR}/${OUTPUT_DIR}/campaign.log
+"

--- a/scripts/run_autoresearch_tunnel.sh
+++ b/scripts/run_autoresearch_tunnel.sh
@@ -13,6 +13,15 @@ TEST_MONTHS="2"
 GATE_PROFILE="standard"
 LOCAL_PORT="15433"
 OVERLAY=""
+CONFIG="config/settings.sentiment_macro.yaml"
+OUTPUT_DIR="research"
+BOOTSTRAP="500"
+SEED="42"
+TIMEOUT_SECONDS="1800"
+MODE="single"
+FAMILIES=""
+MAX_RUNS="10"
+SSH_CONFIG="${SSH_CONFIG:-}"
 
 # Parse named args
 while [[ $# -gt 0 ]]; do
@@ -25,9 +34,23 @@ while [[ $# -gt 0 ]]; do
         --gate-profile) GATE_PROFILE="$2"; shift 2 ;;
         --local-port) LOCAL_PORT="$2"; shift 2 ;;
         --overlay) OVERLAY="$2"; shift 2 ;;
+        --config) CONFIG="$2"; shift 2 ;;
+        --output-dir) OUTPUT_DIR="$2"; shift 2 ;;
+        --bootstrap) BOOTSTRAP="$2"; shift 2 ;;
+        --seed) SEED="$2"; shift 2 ;;
+        --timeout-seconds) TIMEOUT_SECONDS="$2"; shift 2 ;;
+        --mode) MODE="$2"; shift 2 ;;
+        --families) FAMILIES="$2"; shift 2 ;;
+        --max-runs) MAX_RUNS="$2"; shift 2 ;;
+        --ssh-config) SSH_CONFIG="$2"; shift 2 ;;
         *) echo "Unknown arg: $1"; shift ;;
     esac
 done
+
+if [[ "$MODE" != "single" && "$MODE" != "loop" ]]; then
+    echo "ERROR: --mode must be 'single' or 'loop'" >&2
+    exit 1
+fi
 
 REMOTE_HOST="crypto-agent"
 REMOTE_DB_PORT="5432"
@@ -37,11 +60,23 @@ echo "=========================================="
 echo "Autoresearch via SSH Tunnel"
 echo "Symbol: ${SYMBOL} | Timeframe: ${TIMEFRAME}"
 echo "Description: ${DESCRIPTION}"
+echo "Mode: ${MODE}"
+echo "Config: ${CONFIG}"
+echo "Output Dir: ${OUTPUT_DIR}"
 echo "Gate Profile: ${GATE_PROFILE}"
 echo "Train/Test: ${TRAIN_MONTHS}mo / ${TEST_MONTHS}mo"
+echo "Bootstrap: ${BOOTSTRAP} | Seed: ${SEED}"
+echo "Timeout: ${TIMEOUT_SECONDS}s"
 echo "Local Port: ${LOCAL_PORT}"
+[[ -n "$SSH_CONFIG" ]] && echo "SSH Config: ${SSH_CONFIG}"
 [[ -n "$OVERLAY" ]] && echo "Overlay: ${OVERLAY}"
+[[ -n "$FAMILIES" ]] && echo "Families: ${FAMILIES} | Max Runs: ${MAX_RUNS}"
 echo "=========================================="
+
+SSH_CMD=(ssh)
+if [[ -n "$SSH_CONFIG" ]]; then
+    SSH_CMD+=( -F "$SSH_CONFIG" )
+fi
 
 # Kill any existing tunnel on this port
 pkill -f "ssh.*${LOCAL_PORT}.*${REMOTE_HOST}" 2>/dev/null || true
@@ -49,7 +84,7 @@ sleep 1
 
 # Establish SSH tunnel to remote TimescaleDB
 echo "Establishing SSH tunnel to ${REMOTE_HOST}:${REMOTE_DB_PORT}..."
-ssh -fNL ${LOCAL_PORT}:localhost:${REMOTE_DB_PORT} ${REMOTE_HOST}
+"${SSH_CMD[@]}" -fNL ${LOCAL_PORT}:localhost:${REMOTE_DB_PORT} ${REMOTE_HOST}
 
 # Wait for tunnel
 sleep 2
@@ -67,30 +102,51 @@ cd "$SCRIPT_DIR"
 
 # Activate venv and set environment
 source .venv/bin/activate
+PYTHON_BIN="${SCRIPT_DIR}/.venv/bin/python"
 
-export DB_HOST=127.0.0.1
-export DB_PORT=${LOCAL_PORT}
 source .env
-export DB_PASSWORD="${POSTGRES_PASSWORD}"
+export POSTGRES_HOST=127.0.0.1
+export POSTGRES_PORT=${LOCAL_PORT}
+export POSTGRES_PASSWORD="${POSTGRES_PASSWORD}"
 
 echo ""
 echo "Running autoresearch..."
 echo ""
 
-# Build command
-CMD="python scripts/run_autoresearch.py \
-    --config config/settings.sentiment_macro.yaml \
-    --symbol ${SYMBOL} \
-    --timeframe ${TIMEFRAME} \
-    --train-months ${TRAIN_MONTHS} \
-    --test-months ${TEST_MONTHS} \
-    --gate-profile ${GATE_PROFILE} \
-    --description \"${SYMBOL}_${DESCRIPTION}\" \
-    --timeout-seconds 1800"
+if [[ "$MODE" == "loop" ]]; then
+    CMD="${PYTHON_BIN} scripts/autoresearch_loop.py \
+        --config ${CONFIG} \
+        --symbol ${SYMBOL} \
+        --timeframe ${TIMEFRAME} \
+        --train-months ${TRAIN_MONTHS} \
+        --test-months ${TEST_MONTHS} \
+        --bootstrap ${BOOTSTRAP} \
+        --seed ${SEED} \
+        --gate-profile ${GATE_PROFILE} \
+        --output-dir ${OUTPUT_DIR} \
+        --timeout-seconds ${TIMEOUT_SECONDS} \
+        --max-runs ${MAX_RUNS}"
 
-# Add overlay if specified
-if [[ -n "$OVERLAY" ]]; then
-    CMD="$CMD --overlay ${OVERLAY}"
+    if [[ -n "$FAMILIES" ]]; then
+        CMD="$CMD --families ${FAMILIES}"
+    fi
+else
+    CMD="${PYTHON_BIN} scripts/run_autoresearch.py \
+        --config ${CONFIG} \
+        --symbol ${SYMBOL} \
+        --timeframe ${TIMEFRAME} \
+        --train-months ${TRAIN_MONTHS} \
+        --test-months ${TEST_MONTHS} \
+        --bootstrap ${BOOTSTRAP} \
+        --seed ${SEED} \
+        --gate-profile ${GATE_PROFILE} \
+        --description \"${SYMBOL}_${DESCRIPTION}\" \
+        --output-dir ${OUTPUT_DIR} \
+        --timeout-seconds ${TIMEOUT_SECONDS}"
+
+    if [[ -n "$OVERLAY" ]]; then
+        CMD="$CMD --overlay ${OVERLAY}"
+    fi
 fi
 
 # Run

--- a/scripts/run_autoresearch_validation_remote.sh
+++ b/scripts/run_autoresearch_validation_remote.sh
@@ -5,12 +5,12 @@ set -euo pipefail
 SYMBOL="${1:?SYMBOL required}"
 TIMEFRAME="${2:?TIMEFRAME required}"
 OVERLAY="${3:?OVERLAY path required}"
-LABEL="${4:-validation}"
+LABEL="${4:-validation-b1000}"
 REMOTE_HOST="${REMOTE_HOST:-crypto-agent}"
 REMOTE_DIR="${REMOTE_DIR:-/opt/crypto-agent}"
 IMAGE="${IMAGE:-crypto-agent-agent_sentiment_macro:latest}"
 
-OUTPUT_DIR="research/$(echo "${SYMBOL}" | tr '[:upper:]' '[:lower:]')-${TIMEFRAME}-${LABEL}-b1000"
+OUTPUT_DIR="research/$(echo "${SYMBOL}" | tr '[:upper:]' '[:lower:]')-${TIMEFRAME}-${LABEL}"
 
 echo "Validation: ${SYMBOL} ${TIMEFRAME} overlay=${OVERLAY} -> ${OUTPUT_DIR}"
 

--- a/scripts/run_autoresearch_validation_remote.sh
+++ b/scripts/run_autoresearch_validation_remote.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Revalidate a tracked overlay with bootstrap=1000 on the production DB host.
+set -euo pipefail
+
+SYMBOL="${1:?SYMBOL required}"
+TIMEFRAME="${2:?TIMEFRAME required}"
+OVERLAY="${3:?OVERLAY path required}"
+LABEL="${4:-validation}"
+REMOTE_HOST="${REMOTE_HOST:-crypto-agent}"
+REMOTE_DIR="${REMOTE_DIR:-/opt/crypto-agent}"
+IMAGE="${IMAGE:-crypto-agent-agent_sentiment_macro:latest}"
+
+OUTPUT_DIR="research/$(echo "${SYMBOL}" | tr '[:upper:]' '[:lower:]')-${TIMEFRAME}-${LABEL}-b1000"
+
+echo "Validation: ${SYMBOL} ${TIMEFRAME} overlay=${OVERLAY} -> ${OUTPUT_DIR}"
+
+ssh "${REMOTE_HOST}" "mkdir -p ${REMOTE_DIR}/${OUTPUT_DIR} && sudo chown -R 999:999 ${REMOTE_DIR}/${OUTPUT_DIR} && nohup bash -c '
+cd ${REMOTE_DIR} && docker run --rm \
+  --network crypto-agent_crypto-net \
+  -v ${REMOTE_DIR}:/app -w /app \
+  --env-file .env \
+  -e POSTGRES_HOST=timescaledb \
+  -e POSTGRES_PORT=5432 \
+  ${IMAGE} \
+  python scripts/run_autoresearch.py \
+    --config config/settings.autoresearch.yaml \
+    --overlay ${OVERLAY} \
+    --description ${SYMBOL}_${LABEL}_bootstrap1000 \
+    --output-dir /app/${OUTPUT_DIR} \
+    --symbol ${SYMBOL} \
+    --timeframe ${TIMEFRAME} \
+    --train-months 3 \
+    --test-months 2 \
+    --bootstrap 1000 \
+    --seed 317 \
+    --gate-profile standard \
+    --timeout-seconds 3600
+' >> ${REMOTE_DIR}/${OUTPUT_DIR}/campaign.log 2>&1 &
+echo started ${OUTPUT_DIR}
+"

--- a/scripts/run_backtest.py
+++ b/scripts/run_backtest.py
@@ -33,6 +33,18 @@ async def main():
         help="Trading fee rate override (defaults to 0.0004 futures / 0.001 spot)",
     )
     parser.add_argument(
+        "--quantity-step-size",
+        type=float,
+        default=0.0,
+        help="LOT_SIZE step override for exchange-parity sizing (e.g. 0.01 for SOLUSDT)",
+    )
+    parser.add_argument(
+        "--min-notional",
+        type=float,
+        default=None,
+        help="Minimum order notional override (defaults to $20 for configured futures symbols)",
+    )
+    parser.add_argument(
         "--sl", type=float, default=None, help="Stop loss percentage (e.g. 0.01 for 1%%)"
     )
     parser.add_argument(
@@ -96,6 +108,9 @@ async def main():
         settings.futures and settings.futures.enabled and args.symbol in settings.futures.symbols
     )
     fee_rate = args.fee if args.fee is not None else (0.0004 if futures_mode else 0.001)
+    min_notional_usdt = (
+        args.min_notional if args.min_notional is not None else (20.0 if futures_mode else 0.0)
+    )
 
     config = BacktestConfig(
         symbol=args.symbol,
@@ -133,6 +148,8 @@ async def main():
         futures_mode=futures_mode,
         futures_leverage=settings.futures.default_leverage if futures_mode else 1,
         fixed_notional_usdt=settings.trading_execution.order_size_usdt,
+        quantity_step_size=args.quantity_step_size,
+        min_notional_usdt=min_notional_usdt,
     )
 
     print(f"Starting backtest for {args.symbol} from {args.start} to {args.end}...")
@@ -156,7 +173,9 @@ async def main():
     print(f"Trend Filter: {not args.disable_trend_filter}")
     print(
         f"Execution: futures={config.futures_mode}, leverage={config.futures_leverage}x, "
-        f"fixed_notional=${config.fixed_notional_usdt:.2f}, fee={config.fee_rate:.4f}"
+        f"fixed_notional=${config.fixed_notional_usdt:.2f}, fee={config.fee_rate:.4f}, "
+        f"quantity_step={config.quantity_step_size:g}, "
+        f"min_notional=${config.min_notional_usdt:.2f}"
     )
     print(f"Allow Short: {args.allow_short}")
     print(f"Replay Sentiment Log: {args.replay_sentiment_log or 'disabled'}")

--- a/scripts/run_backtest.py
+++ b/scripts/run_backtest.py
@@ -26,7 +26,12 @@ async def main():
     parser.add_argument("--start", type=str, required=True, help="Start date (ISO 8601)")
     parser.add_argument("--end", type=str, required=True, help="End date (ISO 8601)")
     parser.add_argument("--capital", type=float, default=10000.0, help="Initial capital")
-    parser.add_argument("--fee", type=float, default=0.001, help="Trading fee rate (0.001 = 0.1%%)")
+    parser.add_argument(
+        "--fee",
+        type=float,
+        default=None,
+        help="Trading fee rate override (defaults to 0.0004 futures / 0.001 spot)",
+    )
     parser.add_argument(
         "--sl", type=float, default=None, help="Stop loss percentage (e.g. 0.01 for 1%%)"
     )
@@ -87,6 +92,10 @@ async def main():
         raw_config = yaml.safe_load(file_handle) or {}
     trading_exec = raw_config.get("trading_execution", {})
     exit_rules = trading_exec.get("exit_rules", {}) or {}
+    futures_mode = bool(
+        settings.futures and settings.futures.enabled and args.symbol in settings.futures.symbols
+    )
+    fee_rate = args.fee if args.fee is not None else (0.0004 if futures_mode else 0.001)
 
     config = BacktestConfig(
         symbol=args.symbol,
@@ -94,7 +103,7 @@ async def main():
         start_date=datetime.fromisoformat(args.start),
         end_date=datetime.fromisoformat(args.end),
         initial_capital=args.capital,
-        fee_rate=args.fee,
+        fee_rate=fee_rate,
         stop_loss_pct=stop_loss_pct,
         take_profit_pct=take_profit_pct,
         sl_atr_multiplier=float(trading_exec.get("sl_atr_multiplier", 2.0)),
@@ -121,6 +130,9 @@ async def main():
             if args.replay_sentiment_max_age_hours is not None
             else None
         ),
+        futures_mode=futures_mode,
+        futures_leverage=settings.futures.default_leverage if futures_mode else 1,
+        fixed_notional_usdt=settings.trading_execution.order_size_usdt,
     )
 
     print(f"Starting backtest for {args.symbol} from {args.start} to {args.end}...")
@@ -142,6 +154,10 @@ async def main():
         f"trail_offset={config.trailing_offset_atr:.2f}"
     )
     print(f"Trend Filter: {not args.disable_trend_filter}")
+    print(
+        f"Execution: futures={config.futures_mode}, leverage={config.futures_leverage}x, "
+        f"fixed_notional=${config.fixed_notional_usdt:.2f}, fee={config.fee_rate:.4f}"
+    )
     print(f"Allow Short: {args.allow_short}")
     print(f"Replay Sentiment Log: {args.replay_sentiment_log or 'disabled'}")
     print(

--- a/scripts/run_entry_overlap_remote.sh
+++ b/scripts/run_entry_overlap_remote.sh
@@ -5,9 +5,9 @@ set -euo pipefail
 REMOTE_HOST="${REMOTE_HOST:-crypto-agent}"
 REMOTE_DIR="${REMOTE_DIR:-/opt/crypto-agent}"
 IMAGE="${IMAGE:-crypto-agent-agent_sentiment_macro:latest}"
-OUTPUT_JSON="${OUTPUT_JSON:-docs/reports/entry-overlap-sol-1h.json}"
+OUTPUT_JSON="${OUTPUT_JSON:-research/entry-overlap-sol-1h.json}"
 
-ssh "${REMOTE_HOST}" "mkdir -p ${REMOTE_DIR}/docs/reports ${REMOTE_DIR}/research/overlap-resolved && sudo chown -R 999:999 ${REMOTE_DIR}/docs/reports ${REMOTE_DIR}/research/overlap-resolved && docker run --rm \
+ssh "${REMOTE_HOST}" "mkdir -p ${REMOTE_DIR}/research/overlap-resolved && sudo chown -R 999:999 ${REMOTE_DIR}/research && docker run --rm \
   --network crypto-agent_crypto-net \
   -v ${REMOTE_DIR}:/app -w /app \
   --env-file .env \

--- a/scripts/run_entry_overlap_remote.sh
+++ b/scripts/run_entry_overlap_remote.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Run SOL 1h entry-overlap analysis on Hetzner (production TimescaleDB).
+set -euo pipefail
+
+REMOTE_HOST="${REMOTE_HOST:-crypto-agent}"
+REMOTE_DIR="${REMOTE_DIR:-/opt/crypto-agent}"
+IMAGE="${IMAGE:-crypto-agent-agent_sentiment_macro:latest}"
+OUTPUT_JSON="${OUTPUT_JSON:-docs/reports/entry-overlap-sol-1h.json}"
+
+ssh "${REMOTE_HOST}" "mkdir -p ${REMOTE_DIR}/docs/reports ${REMOTE_DIR}/research/overlap-resolved && sudo chown -R 999:999 ${REMOTE_DIR}/docs/reports ${REMOTE_DIR}/research/overlap-resolved && docker run --rm \
+  --network crypto-agent_crypto-net \
+  -v ${REMOTE_DIR}:/app -w /app \
+  --env-file .env \
+  -e POSTGRES_HOST=timescaledb \
+  -e POSTGRES_PORT=5432 \
+  ${IMAGE} \
+  python scripts/analyze_entry_overlap.py \
+    --manifest config/autoresearch/overlap_manifest_sol_1h.yaml \
+    --output /app/${OUTPUT_JSON} \
+    --include-live-db \
+    --agent-ids sol-1h-trend-pullback-overlay-live sentiment-macro-bot"

--- a/scripts/run_entry_overlap_remote.sh
+++ b/scripts/run_entry_overlap_remote.sh
@@ -7,10 +7,10 @@ REMOTE_DIR="${REMOTE_DIR:-/opt/crypto-agent}"
 IMAGE="${IMAGE:-crypto-agent-agent_sentiment_macro:latest}"
 OUTPUT_JSON="${OUTPUT_JSON:-research/entry-overlap-sol-1h.json}"
 
-ssh "${REMOTE_HOST}" "mkdir -p ${REMOTE_DIR}/research/overlap-resolved && sudo chown -R 999:999 ${REMOTE_DIR}/research && docker run --rm \
+ssh "${REMOTE_HOST}" "cd ${REMOTE_DIR} && mkdir -p research/overlap-resolved && sudo chown -R 999:999 research && docker run --rm \
   --network crypto-agent_crypto-net \
   -v ${REMOTE_DIR}:/app -w /app \
-  --env-file .env \
+  --env-file ${REMOTE_DIR}/.env \
   -e POSTGRES_HOST=timescaledb \
   -e POSTGRES_PORT=5432 \
   ${IMAGE} \

--- a/scripts/run_funding_probe_reshape.py
+++ b/scripts/run_funding_probe_reshape.py
@@ -11,8 +11,12 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import sys
 from collections.abc import Sequence
 from dataclasses import dataclass
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 from scripts.probe_funding_normalization import (
     ProbeConfig,

--- a/scripts/run_funding_probe_reshape.py
+++ b/scripts/run_funding_probe_reshape.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""Run funding-normalization probe scenarios (reshape study).
+
+Compares fixed thresholds, per-symbol quantile tails, and short-side normalization
+(probe-only). Does not implement the full surface.
+
+See docs/reports/candidate-search-options-2026-06-04.md
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+from scripts.probe_funding_normalization import (
+    ProbeConfig,
+    _fetch_funding_ticks,
+    build_db_config,
+    entry_threshold_negative_tail,
+    evaluate_pulse,
+    probe_funding_series,
+)
+from src.db import close_pool, init_pool
+from src.features.reader import IndicatorReader
+from src.utils.logger import configure_logger
+
+
+@dataclass(frozen=True)
+class Scenario:
+    name: str
+    entry_threshold: float | None
+    negative_tail_pct: float | None
+    positive_tail_pct: float | None
+    long_only: bool
+
+
+@dataclass(frozen=True)
+class ScenarioResult:
+    scenario: str
+    symbol: str
+    entry_used: float
+    long_events: int
+    short_events: int
+    mean_net_12h: float
+    mean_net_24h: float
+    verdict_long: str
+
+
+DEFAULT_SCENARIOS: tuple[Scenario, ...] = (
+    Scenario("fixed_0.05pct", 0.0005, None, None, True),
+    Scenario("fixed_0.015pct", 0.00015, None, None, True),
+    Scenario("neg_tail_5pct", None, 5.0, None, True),
+    Scenario("neg_tail_10pct", None, 10.0, None, True),
+    Scenario("both_norm_probe", None, 5.0, 5.0, False),
+)
+
+
+def resolve_entry_threshold(
+    funding_rates: Sequence[float],
+    scenario: Scenario,
+    fallback: float = 0.0005,
+) -> float:
+    if scenario.entry_threshold is not None:
+        return scenario.entry_threshold
+    if scenario.negative_tail_pct is not None:
+        return entry_threshold_negative_tail(funding_rates, scenario.negative_tail_pct)
+    return fallback
+
+
+async def run_scenario(
+    symbol: str,
+    scenario: Scenario,
+    base: ProbeConfig,
+    funding_ticks: list,
+    price_rows: list,
+) -> ScenarioResult:
+    rates = [tick.funding_rate for tick in funding_ticks]
+    entry = resolve_entry_threshold(rates, scenario)
+    config = ProbeConfig(
+        symbol=symbol,
+        timeframe=base.timeframe,
+        start=base.start,
+        end=base.end,
+        entry_threshold=entry,
+        exit_threshold=base.exit_threshold,
+        forward_bars_12h=base.forward_bars_12h,
+        forward_bars_24h=base.forward_bars_24h,
+        min_events_for_pulse=base.min_events_for_pulse,
+        max_profit_concentration_pct=base.max_profit_concentration_pct,
+        long_only=scenario.long_only,
+    )
+    summary = probe_funding_series(funding_ticks, price_rows, config)
+    short_count = len(summary.events) - len(summary.long_events)
+    stats_12 = summary.stats_for("12h")
+    stats_24 = summary.stats_for("24h")
+    return ScenarioResult(
+        scenario=scenario.name,
+        symbol=symbol,
+        entry_used=entry,
+        long_events=len(summary.long_events),
+        short_events=short_count,
+        mean_net_12h=stats_12.mean_net_pct,
+        mean_net_24h=stats_24.mean_net_pct,
+        verdict_long=evaluate_pulse(summary, config),
+    )
+
+
+async def run_reshape(symbols: Sequence[str], base: ProbeConfig) -> list[ScenarioResult]:
+    db_config = build_db_config()
+    await init_pool(db_config)
+    results: list[ScenarioResult] = []
+    try:
+        reader = IndicatorReader(db_config)
+        async with reader:
+            for symbol in symbols:
+                funding_ticks = await _fetch_funding_ticks(symbol, base.start, base.end)
+                price_rows = await reader.fetch_range(
+                    symbol,
+                    base.timeframe,
+                    base.start,
+                    base.end,
+                )
+                for scenario in DEFAULT_SCENARIOS:
+                    results.append(
+                        await run_scenario(symbol, scenario, base, funding_ticks, price_rows)
+                    )
+    finally:
+        await close_pool()
+    return results
+
+
+def print_results(results: Sequence[ScenarioResult]) -> None:
+    print("Funding probe reshape matrix")
+    print("=" * 88)
+    print(
+        f"{'scenario':<20} {'symbol':<10} {'entry':>9} {'long':>5} {'short':>5} "
+        f"{'net12h':>8} {'net24h':>8} {'verdict':<12}"
+    )
+    print("-" * 88)
+    for row in results:
+        print(
+            f"{row.scenario:<20} {row.symbol:<10} {row.entry_used:>9.5f} "
+            f"{row.long_events:>5} {row.short_events:>5} {row.mean_net_12h:>7.2f}% "
+            f"{row.mean_net_24h:>7.2f}% {row.verdict_long:<12}"
+        )
+    print()
+    pulses = [r for r in results if r.verdict_long == "HAS_PULSE"]
+    if pulses:
+        print("HAS_PULSE scenarios:")
+        for row in pulses:
+            print(f"  {row.scenario} {row.symbol} entry={row.entry_used:.5f}")
+    else:
+        print("No HAS_PULSE scenario in this matrix — pick another surface or redesign trigger.")
+
+
+async def _main() -> int:
+    configure_logger("WARNING")
+    parser = argparse.ArgumentParser(description="Funding normalization reshape sweep")
+    parser.add_argument("--symbols", default="BTCUSDT,ETHUSDT,SOLUSDT")
+    parser.add_argument("--start", default="2024-01-01T00:00:00")
+    parser.add_argument("--end", default="2026-06-01T00:00:00")
+    parser.add_argument("--min-events", type=int, default=20)
+    args = parser.parse_args()
+    symbols = [s.strip().upper() for s in args.symbols.split(",") if s.strip()]
+    base = ProbeConfig(
+        symbol=symbols[0],
+        timeframe="1h",
+        start=args.start,
+        end=args.end,
+        entry_threshold=0.0005,
+        exit_threshold=0.00015,
+        forward_bars_12h=12,
+        forward_bars_24h=24,
+        min_events_for_pulse=args.min_events,
+        max_profit_concentration_pct=30.0,
+        long_only=True,
+    )
+    results = await run_reshape(symbols, base)
+    print_results(results)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(_main()))

--- a/scripts/run_paper_validation_report.sh
+++ b/scripts/run_paper_validation_report.sh
@@ -8,6 +8,9 @@ PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
 REPORT_OUTPUT_DIR="${REPORT_OUTPUT_DIR:-data/reports}"
 REPORT_DAY="${1:-$(date -u -d 'yesterday' +%F)}"
 REPORT_PREFIX="${REPORT_OUTPUT_DIR%/}/paper-validation-report-${REPORT_DAY}"
+CONTAINER_REPORT_PREFIX="/tmp/paper-validation-report-${REPORT_DAY}"
+REPORT_SERVICE="agent_sol_sparse"
+PRODUCTION_COMPOSE=(docker compose -f docker-compose.prod.yml)
 
 cd "$PROJECT_DIR"
 
@@ -28,23 +31,32 @@ done
 
 mkdir -p "$REPORT_OUTPUT_DIR"
 
-if ! docker compose ps --status running --services | grep -qx "agent_avax"; then
-    echo "ERROR: agent_avax service is not running" >&2
+if ! "${PRODUCTION_COMPOSE[@]}" ps --status running --services | grep -qx "$REPORT_SERVICE"; then
+    echo "ERROR: ${REPORT_SERVICE} service is not running" >&2
     exit 1
 fi
 
 echo "[$(date -Iseconds)] Generating paper validation report for ${REPORT_DAY}"
 
-docker compose exec -T \
+"${PRODUCTION_COMPOSE[@]}" exec -T \
     -e POSTGRES_HOST=timescaledb \
     -e POSTGRES_PORT=5432 \
     -e POSTGRES_DB="$POSTGRES_DB" \
     -e POSTGRES_USER="$POSTGRES_USER" \
     -e POSTGRES_PASSWORD="$POSTGRES_PASSWORD" \
-    agent_avax \
+    "$REPORT_SERVICE" \
     python scripts/paper_validation_report.py \
     --day "$REPORT_DAY" \
-    --output-prefix "$REPORT_PREFIX"
+    --output-prefix "$CONTAINER_REPORT_PREFIX"
+
+"${PRODUCTION_COMPOSE[@]}" cp \
+    "${REPORT_SERVICE}:${CONTAINER_REPORT_PREFIX}.md" \
+    "${REPORT_PREFIX}.md"
+"${PRODUCTION_COMPOSE[@]}" cp \
+    "${REPORT_SERVICE}:${CONTAINER_REPORT_PREFIX}.json" \
+    "${REPORT_PREFIX}.json"
+"${PRODUCTION_COMPOSE[@]}" exec -T "$REPORT_SERVICE" \
+    rm -f "${CONTAINER_REPORT_PREFIX}.md" "${CONTAINER_REPORT_PREFIX}.json"
 
 echo "[$(date -Iseconds)] Report written:"
 echo "  ${PROJECT_DIR}/${REPORT_PREFIX}.md"

--- a/scripts/run_phase0_weekly.sh
+++ b/scripts/run_phase0_weekly.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Phase 0 weekly forward-validation checklist (production).
+set -euo pipefail
+
+REMOTE_HOST="${REMOTE_HOST:-crypto-agent}"
+DATE_TAG="$(date -u +%Y%m%d)"
+OUTPUT_DIR="docs/reports/phase0"
+
+mkdir -p "${OUTPUT_DIR}"
+
+echo "== Phase 0: entry overlap (WFO + live DB) =="
+./scripts/run_entry_overlap_remote.sh
+
+echo ""
+echo "== Phase 0: copy remote overlap artifact =="
+scp "${REMOTE_HOST}:/opt/crypto-agent/research/entry-overlap-sol-1h.json" \
+  "${OUTPUT_DIR}/entry-overlap-${DATE_TAG}.json" 2>/dev/null || true
+
+echo ""
+echo "== Phase 0: PnL by agent (requires profit_report fix on server image or mount) =="
+ssh "${REMOTE_HOST}" "cd /opt/crypto-agent && docker run --rm \
+  --network crypto-agent_crypto-net -v /opt/crypto-agent:/app -w /app \
+  --env-file /opt/crypto-agent/.env -e POSTGRES_HOST=timescaledb \
+  crypto-agent-agent_sentiment_macro:latest \
+  python scripts/profit_report.py --format json --quiet" \
+  > "${OUTPUT_DIR}/pnl-${DATE_TAG}.json" 2>/dev/null || echo "PnL skipped (run after deploy includes profit_report fix)"
+
+echo ""
+echo "Wrote ${OUTPUT_DIR}/entry-overlap-${DATE_TAG}.json (if scp succeeded)"
+echo "Review: live entry counts, pairwise_live overlap, closed trades per agent_id"

--- a/scripts/run_phase3_sentiment_validation.sh
+++ b/scripts/run_phase3_sentiment_validation.sh
@@ -3,7 +3,7 @@
 #
 # Prerequisites:
 #   1. Sync event log from server:
-#      scp crypto-agent:/opt/crypto-agent/data/event_log_sentiment-macro-bot.jsonl data/
+#      ./scripts/export_sentiment_replay.sh
 #   2. Ensure DB has historical OHLCV data for the replay period
 #
 # Gate criteria (from RESEARCH_FRAMEWORK.md):
@@ -15,13 +15,11 @@
 
 set -euo pipefail
 
-CONFIG="config/settings.sentiment_macro.yaml"
-REPLAY_LOG="data/event_log_sentiment-macro-bot.jsonl"
-REPLAY_MAX_AGE=24  # hours
+CONFIG="${CONFIG:-config/settings.sentiment_macro.yaml}"
+REPLAY_LOG="${REPLAY_LOG:-data/event_log_sentiment-macro-bot.jsonl}"
+REPLAY_MAX_AGE="${REPLAY_MAX_AGE:-24}"  # hours
 SYMBOLS=("BTCUSDT" "ETHUSDT" "SOLUSDT")
 TIMEFRAME="1h"
-START="2026-03-26"  # adjust to match replay data start
-END="2026-04-15"    # adjust to match replay data end
 
 echo "============================================"
 echo "Phase 3: Sentiment Mean Reversion Validation"
@@ -31,7 +29,7 @@ echo ""
 # Check replay log exists
 if [ ! -f "$REPLAY_LOG" ]; then
     echo "ERROR: Replay log not found at $REPLAY_LOG"
-    echo "Sync from server: scp crypto-agent:/opt/crypto-agent/data/event_log_sentiment-macro-bot.jsonl data/"
+    echo "Sync from production Docker volume: ./scripts/export_sentiment_replay.sh"
     exit 1
 fi
 
@@ -39,11 +37,39 @@ OBSERVATIONS=$(grep -c sentiment_score "$REPLAY_LOG" || true)
 echo "Replay log: $OBSERVATIONS sentiment observations"
 echo ""
 
+read -r REPLAY_START REPLAY_END < <(
+    uv run python - "$REPLAY_LOG" <<'PY'
+from __future__ import annotations
+
+import json
+import sys
+from datetime import datetime, timedelta
+from pathlib import Path
+
+timestamps = []
+for line in Path(sys.argv[1]).read_text().splitlines():
+    event = json.loads(line)
+    if event.get("type") == "sentiment_score":
+        timestamps.append(datetime.fromisoformat(event["ts"]))
+
+if not timestamps:
+    raise SystemExit("Replay log contains no sentiment_score observations")
+
+print(min(timestamps).date(), (max(timestamps).date() + timedelta(days=1)))
+PY
+)
+
+START="${START:-$REPLAY_START}"
+END="${END:-$REPLAY_END}"
+
+echo "Validation window: $START to $END (END is exclusive)"
+echo ""
+
 # --- Test 1: Multi-symbol backtests with replay ---
 echo "=== Test 1: Multi-Symbol Backtests (with replay) ==="
 for sym in "${SYMBOLS[@]}"; do
     echo "--- $sym ---"
-    python scripts/run_backtest.py \
+    uv run python scripts/run_backtest.py \
         --config "$CONFIG" \
         --symbol "$sym" \
         --timeframe "$TIMEFRAME" \
@@ -58,7 +84,7 @@ done
 echo "=== Test 2: Control Backtests (neutral sentiment baseline) ==="
 for sym in "${SYMBOLS[@]}"; do
     echo "--- $sym (no replay) ---"
-    python scripts/run_backtest.py \
+    uv run python scripts/run_backtest.py \
         --config "$CONFIG" \
         --symbol "$sym" \
         --timeframe "$TIMEFRAME" \
@@ -71,7 +97,7 @@ done
 echo "=== Test 3: Walk-Forward Optimization ==="
 for sym in "${SYMBOLS[@]}"; do
     echo "--- WFO: $sym ---"
-    python scripts/run_wfo.py \
+    uv run python scripts/run_wfo.py \
         "$sym" "$TIMEFRAME" "$START" "$END" \
         --train-months 2 \
         --test-months 1 \
@@ -86,7 +112,7 @@ done
 echo "=== Test 4: Monte Carlo Stress Test ==="
 for sym in "${SYMBOLS[@]}"; do
     echo "--- Monte Carlo: $sym ---"
-    python scripts/run_monte_carlo.py \
+    uv run python scripts/run_monte_carlo.py \
         --config "$CONFIG" \
         --symbol "$sym" \
         --timeframe "$TIMEFRAME" \

--- a/scripts/run_phase7_4h_campaigns.sh
+++ b/scripts/run_phase7_4h_campaigns.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# Phase 1 + Phase 2 discovery from autoresearch-next-candidate-path (June 2026).
+set -euo pipefail
+
+REMOTE_HOST="${REMOTE_HOST:-crypto-agent}"
+export GATE_PROFILE=standard
+export BOOTSTRAP=100
+export MAX_RUNS="${MAX_RUNS:-80}"
+
+run_lane() {
+  local symbol="$1"
+  local tf="$2"
+  local suffix="$3"
+  local families="$4"
+  FAMILIES="${families}" MAX_RUNS="${MAX_RUNS}" GATE_PROFILE="${GATE_PROFILE}" BOOTSTRAP="${BOOTSTRAP}" \
+    ./scripts/run_autoresearch_campaign_remote.sh "${symbol}" "${tf}" "${suffix}"
+}
+
+echo "Phase 1: ETH 4h regime overlay"
+run_lane ETHUSDT 4h w7-eth-4h-regime "regime_gated_pullback_overlay,breakout_retest_overlay"
+
+echo "Phase 1: BTC 4h regime overlay"
+run_lane BTCUSDT 4h w7-btc-4h-regime "regime_gated_pullback_overlay,breakout_retest_overlay"
+
+if [[ "${RUN_PHASE2:-1}" == "1" ]]; then
+  export MAX_RUNS="${BOUNDED_RUNS:-50}"
+  echo "Phase 2: ETH 4h range_reversion_bounded"
+  run_lane ETHUSDT 4h w8-eth-4h-bounded "range_reversion_bounded"
+
+  echo "Phase 2: BTC 4h range_reversion_bounded"
+  run_lane BTCUSDT 4h w8-btc-4h-bounded "range_reversion_bounded"
+
+  echo "Phase 3 probe: BTC 4h funding_primary_standalone"
+  run_lane BTCUSDT 4h w8-btc-4h-funding-primary "funding_primary_standalone"
+fi
+
+echo "All lanes queued on ${REMOTE_HOST}"

--- a/scripts/run_wfo.py
+++ b/scripts/run_wfo.py
@@ -6,6 +6,7 @@ import asyncio
 import csv
 import os
 import subprocess
+import sys
 from datetime import datetime, timedelta
 from pathlib import Path
 from statistics import mean
@@ -21,7 +22,7 @@ def run_backtest(
     replay_sentiment_max_age_hours: float | None = None,
 ) -> dict[str, float] | None:
     cmd = [
-        "python",
+        sys.executable,
         "scripts/run_backtest.py",
         "--symbol",
         symbol,

--- a/src/backtest/engine.py
+++ b/src/backtest/engine.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import math
 from collections.abc import Mapping
 from dataclasses import dataclass, field
 from datetime import datetime
@@ -48,6 +49,8 @@ class BacktestConfig:
     futures_leverage: int = 5
     futures_funding_rate: float = 0.0001
     fixed_notional_usdt: float = 0.0  # 0 = size from available capital
+    quantity_step_size: float = 0.0  # 0 = ideal fractional quantity
+    min_notional_usdt: float = 0.0  # 0 = disabled
 
 
 @dataclass
@@ -368,8 +371,19 @@ class BacktestEngine:
 
     def _cap_fixed_notional(self, quantity: float, entry_price: float) -> float:
         if self._config.fixed_notional_usdt <= 0:
+            capped_quantity = quantity
+        else:
+            capped_quantity = min(quantity, self._config.fixed_notional_usdt / entry_price)
+        return self._apply_quantity_step(capped_quantity, entry_price)
+
+    def _apply_quantity_step(self, quantity: float, entry_price: float) -> float:
+        step = self._config.quantity_step_size
+        if step <= 0:
             return quantity
-        return min(quantity, self._config.fixed_notional_usdt / entry_price)
+        truncated = math.floor(quantity / step) * step
+        if truncated * entry_price < self._config.min_notional_usdt:
+            return truncated + step
+        return truncated
 
     def _open_long(self, timestamp: str, price: float, atr: float) -> None:
         entry_price = price * (1 + self._config.slippage_pct)

--- a/src/backtest/engine.py
+++ b/src/backtest/engine.py
@@ -47,6 +47,7 @@ class BacktestConfig:
     futures_mode: bool = False
     futures_leverage: int = 5
     futures_funding_rate: float = 0.0001
+    fixed_notional_usdt: float = 0.0  # 0 = size from available capital
 
 
 @dataclass
@@ -350,17 +351,25 @@ class BacktestEngine:
                 risk_amount = self._cash * self._config.risk_per_trade
                 stop_distance = atr * self._config.atr_multiplier
                 target_qty = risk_amount / stop_distance if stop_distance > 0 else 0.0
-                return min(target_qty, max_qty)
-            return max_qty
+                quantity = min(target_qty, max_qty)
+            else:
+                quantity = max_qty
+            return self._cap_fixed_notional(quantity, entry_price)
 
         if self._config.use_atr_sizing and atr > 0:
             risk_amount = self._cash * self._config.risk_per_trade
             stop_distance = atr * self._config.atr_multiplier
             target_qty = risk_amount / stop_distance if stop_distance > 0 else 0.0
             max_qty = (self._cash * (1 - self._config.fee_rate)) / entry_price
-            return min(target_qty, max_qty)
+            return self._cap_fixed_notional(min(target_qty, max_qty), entry_price)
 
-        return (self._cash * (1 - self._config.fee_rate)) / entry_price
+        quantity = (self._cash * (1 - self._config.fee_rate)) / entry_price
+        return self._cap_fixed_notional(quantity, entry_price)
+
+    def _cap_fixed_notional(self, quantity: float, entry_price: float) -> float:
+        if self._config.fixed_notional_usdt <= 0:
+            return quantity
+        return min(quantity, self._config.fixed_notional_usdt / entry_price)
 
     def _open_long(self, timestamp: str, price: float, atr: float) -> None:
         entry_price = price * (1 + self._config.slippage_pct)

--- a/src/execution/futures_executor.py
+++ b/src/execution/futures_executor.py
@@ -412,6 +412,7 @@ class FuturesTradingExecutor:
                     close_price = (
                         close_details.fill_price if close_details.fill_price else last_mark
                     )
+                    pnl: float | None = None
                     if close_details.reason == "stop_loss" and self._config.sl_cooldown_minutes > 0:
                         self._sl_cooldown_timestamps[symbol] = time.time()
                         self._logger.info(
@@ -465,6 +466,7 @@ class FuturesTradingExecutor:
                     self._sl_tp_orders.pop(symbol, None)
                     self._sl_tp_prices.pop(symbol, None)
                     self._positions.pop(symbol, None)
+                    self._record_risk_close(symbol, pnl, self._account_balance)
 
                 # Software SL/TP: trigger MARKET close when mark_price crosses stored levels
                 sw = self._sl_tp_prices.get(symbol)
@@ -536,6 +538,7 @@ class FuturesTradingExecutor:
                                 pnl = sw_realized_pnl
                             else:
                                 pnl = (mark - sw_entry_px) * qty if sw_entry_px > 0 else None
+                            self._record_risk_close(symbol, pnl, self._account_balance)
                             await self._notifier.send_trade_alert(
                                 symbol=symbol,
                                 side="SELL",
@@ -559,6 +562,18 @@ class FuturesTradingExecutor:
             except Exception as exc:
                 self._logger.error("Failed to get position risk for %s: %s", symbol, exc)
 
+    def _record_risk_close(
+        self,
+        symbol: str,
+        pnl: float | None,
+        portfolio_value: float,
+    ) -> None:
+        """Release futures risk state and feed realized P&L into circuit breakers."""
+        if pnl is not None and portfolio_value > 0:
+            self._risk_manager.record_trade(symbol, pnl, portfolio_value)
+            self._metrics.record_realized_pnl(symbol, pnl)
+        self._risk_manager.register_close_position(symbol)
+
     async def place_futures_order(
         self,
         symbol: str,
@@ -566,6 +581,7 @@ class FuturesTradingExecutor:
         quantity: float,
         position_side: str = "LONG",
         reduce_only: bool = False,
+        reference_price: float | None = None,
     ) -> FuturesOrderInfo:
         """Place a futures order with risk checks.
 
@@ -575,6 +591,7 @@ class FuturesTradingExecutor:
             quantity: Order quantity (in base asset units)
             position_side: "LONG" or "SHORT"
             reduce_only: If True, order will only reduce position
+            reference_price: Current market price used to enforce opening notional limits
 
         Returns:
             FuturesOrderInfo: Information about placed order
@@ -615,6 +632,19 @@ class FuturesTradingExecutor:
 
         # Check margin usage — skip for reduce-only orders (closing frees margin, never consumes it)
         if not reduce_only:
+            if reference_price is None or reference_price <= 0:
+                raise ValueError("reference_price must be positive for opening futures orders")
+
+            notional_value = quantity * reference_price
+            position_allowed, position_reason = self._risk_manager.check_position_limit(
+                symbol,
+                notional_value,
+                account_info.total_margin_balance,
+            )
+            if not position_allowed:
+                self._metrics.record_risk_block(symbol, position_reason)
+                raise RuntimeError(f"Position limit check failed: {position_reason}")
+
             current_positions = self._positions.get(symbol, {})
             used_margin = (
                 abs(current_positions.get("amount", 0))
@@ -690,15 +720,21 @@ class FuturesTradingExecutor:
 
                 if reduce_only:
                     # Position was reduced/closed
+                    close_pnl: float | None = None
                     if self._portfolio_manager is not None:
-                        _, _close_pnl = await self._portfolio_manager.close_position(
+                        _, close_pnl = await self._portfolio_manager.close_position(
                             symbol=symbol,
                             price=float(order.price) if order.price else 0.0,
                             order_id=str(order.order_id),
                             market="futures",
                             closing_side=side,
                         )
-                        self._recent_close_pnl[symbol] = _close_pnl
+                        self._recent_close_pnl[symbol] = close_pnl
+                    self._record_risk_close(
+                        symbol,
+                        close_pnl,
+                        account_info.total_margin_balance,
+                    )
                     # Clear in-memory tracker so max_concurrent_longs frees the slot.
                     # The monitor-loop cleanup at line ~313 only fires when _sl_tp_orders
                     # still has the symbol, but signal-driven closes pop it beforehand.
@@ -738,6 +774,12 @@ class FuturesTradingExecutor:
                     # works within the same evaluation cycle (before next monitoring tick).
                     self._positions[symbol]["amount"] = recorded_qty
                     self._positions[symbol]["side"] = "LONG"
+                    executed_price = float(order.price) if order.price else reference_price
+                    self._risk_manager.register_open_position(
+                        symbol,
+                        recorded_qty * executed_price,
+                        executed_price,
+                    )
 
             return order
 
@@ -876,6 +918,7 @@ class FuturesTradingExecutor:
                         quantity=order_size,
                         position_side="LONG",
                         reduce_only=False,
+                        reference_price=signal.price,
                     )
                     if order.status == "FILLED":
                         entry_price = (
@@ -1273,6 +1316,11 @@ class FuturesTradingExecutor:
                     )
                     await self._place_sl_tp_orders(
                         symbol, pos.entry_price, abs(pos.position_amt), atr_14
+                    )
+                    self._risk_manager.register_open_position(
+                        symbol,
+                        abs(pos.position_amt) * pos.entry_price,
+                        pos.entry_price,
                     )
             except Exception as exc:
                 self._logger.error("Failed to recover SL/TP for open %s position: %s", symbol, exc)

--- a/src/execution/futures_executor.py
+++ b/src/execution/futures_executor.py
@@ -45,6 +45,9 @@ class FuturesTradingConfig:
     # SL/TP — ATR-based (primary) with fixed-pct fallback
     sl_atr_multiplier: float = 2.0  # SL = entry - mult * ATR(14)
     tp_atr_multiplier: float = 4.5  # TP = entry + mult * ATR(14)
+    trailing_activate_atr: float = 1.5
+    trailing_offset_atr: float = 1.0
+    time_stop_minutes: float = 0.0  # 0 = disabled
     stop_loss_pct: float = 0.03  # fallback if ATR unavailable
     take_profit_pct: float = 0.06  # fallback if ATR unavailable
     max_concurrent_longs: int = 0  # 0 = disabled; cap on simultaneous LONG positions
@@ -468,17 +471,47 @@ class FuturesTradingExecutor:
                     self._positions.pop(symbol, None)
                     self._record_risk_close(symbol, pnl, self._account_balance)
 
-                # Software SL/TP: trigger MARKET close when mark_price crosses stored levels
+                # Software exits: enforce SL/TP, ATR trailing, and time stops.
                 sw = self._sl_tp_prices.get(symbol)
                 if sw and positions:
                     mark = positions[0].mark_price
                     sl = sw.get("sl_price", 0.0)
                     tp = sw.get("tp_price", 0.0)
-                    triggered = (sl > 0 and mark <= sl) or (tp > 0 and mark >= tp)
-                    if triggered:
-                        sw_close_reason = "stop_loss" if (sl > 0 and mark <= sl) else "take_profit"
+                    entry_price = sw.get("entry_price", 0.0)
+                    atr_14 = sw.get("atr_14", 0.0)
+                    high_water_mark = max(sw.get("high_water_mark", entry_price), mark)
+                    sw["high_water_mark"] = high_water_mark
+                    if atr_14 > 0 and high_water_mark >= (
+                        entry_price + self._config.trailing_activate_atr * atr_14
+                    ):
+                        trailing_sl = high_water_mark - self._config.trailing_offset_atr * atr_14
+                        if trailing_sl > sl:
+                            sl = trailing_sl
+                            sw["sl_price"] = trailing_sl
+
+                    opened_at = sw.get("opened_at", 0.0)
+                    time_stop = (
+                        self._config.time_stop_minutes > 0
+                        and opened_at > 0
+                        and (time.time() - opened_at) / 60 >= self._config.time_stop_minutes
+                    )
+                    sw_close_reason: str | None = None
+                    if sl > 0 and mark <= sl:
+                        sw_close_reason = "stop_loss"
+                    elif tp > 0 and mark >= tp:
+                        sw_close_reason = "take_profit"
+                    elif time_stop:
+                        sw_close_reason = "time_stop"
+
+                    if sw_close_reason is not None:
                         reason_str = (
-                            f"SL {sl:.4f}" if sw_close_reason == "stop_loss" else f"TP {tp:.4f}"
+                            f"SL {sl:.4f}"
+                            if sw_close_reason == "stop_loss"
+                            else (
+                                f"TP {tp:.4f}"
+                                if sw_close_reason == "take_profit"
+                                else f"time stop {self._config.time_stop_minutes:.0f}m"
+                            )
                         )
                         self._logger.warning(
                             "Software %s triggered for %s: mark=%.4f — closing position",
@@ -498,6 +531,7 @@ class FuturesTradingExecutor:
                         self._sl_tp_prices.pop(symbol, None)
                         try:
                             qty = abs(positions[0].position_amt)
+                            await self._cancel_sl_tp_orders(symbol)
                             request_position_side = (
                                 "BOTH" if self._active_position_mode == "one-way" else "LONG"
                             )
@@ -1180,6 +1214,7 @@ class FuturesTradingExecutor:
         entry_price: float,
         quantity: float,
         atr_14: float,
+        opened_at: float | None = None,
     ) -> tuple[float, float]:
         """Place exchange-side SL and TP orders, with software-monitor fallback.
 
@@ -1206,7 +1241,14 @@ class FuturesTradingExecutor:
         tp_order_id = ""
 
         # Software monitor always active as final fallback.
-        self._sl_tp_prices[symbol] = {"sl_price": sl_price, "tp_price": tp_price}
+        self._sl_tp_prices[symbol] = {
+            "sl_price": sl_price,
+            "tp_price": tp_price,
+            "entry_price": entry_price,
+            "atr_14": atr_14,
+            "high_water_mark": entry_price,
+            "opened_at": opened_at if opened_at is not None else time.time(),
+        }
 
         order_position_side = "BOTH" if self._active_position_mode == "one-way" else "LONG"
 
@@ -1314,8 +1356,19 @@ class FuturesTradingExecutor:
                         abs(pos.position_amt),
                         atr_14,
                     )
+                    opened_at: float | None = None
+                    if self._portfolio_manager is not None:
+                        tracked_position = self._portfolio_manager.get_position(
+                            symbol, market="futures"
+                        )
+                        if tracked_position is not None and tracked_position.entry_time is not None:
+                            opened_at = tracked_position.entry_time.timestamp()
                     await self._place_sl_tp_orders(
-                        symbol, pos.entry_price, abs(pos.position_amt), atr_14
+                        symbol,
+                        pos.entry_price,
+                        abs(pos.position_amt),
+                        atr_14,
+                        opened_at=opened_at,
                     )
                     self._risk_manager.register_open_position(
                         symbol,

--- a/src/execution/paper_executor.py
+++ b/src/execution/paper_executor.py
@@ -696,11 +696,6 @@ class PaperExecutor:
                     "risk_check_failed",
                     {"symbol": signal.symbol, "reason": reason, "stage": "paper_buy"},
                 )
-            if self._event_log:
-                await self._event_log.log(
-                    "risk_check_failed",
-                    {"symbol": signal.symbol, "reason": reason, "stage": "paper_buy"},
-                )
             await self._notifier.send_alert(
                 f"🛑 <b>Signal Blocked</b> [{market_tag}]\n{signal.symbol} BUY — {reason}"
             )

--- a/src/execution/paper_executor.py
+++ b/src/execution/paper_executor.py
@@ -109,7 +109,6 @@ class PaperExecutor:
         self._guard_pipeline = guard_pipeline
         self._staged_manager = staged_manager
         self._agent_id = self._normalize_agent_id(agent_id)
-        self._agent_id = self._normalize_agent_id(agent_id)
         self._position_prefix = "" if self._agent_id == "default" else f"{self._agent_id}::"
         self._logger = get_logger("PaperExecutor")
 

--- a/src/main.py
+++ b/src/main.py
@@ -1050,6 +1050,13 @@ async def run() -> None:
                 sl_cooldown_minutes=settings.futures.sl_cooldown_minutes,
                 sl_atr_multiplier=settings.trading_execution.sl_atr_multiplier,
                 tp_atr_multiplier=settings.trading_execution.tp_atr_multiplier,
+                trailing_activate_atr=settings.trading_execution.trailing_activate_atr,
+                trailing_offset_atr=settings.trading_execution.trailing_offset_atr,
+                time_stop_minutes=_as_float(
+                    settings.exit_rules.get("time_stop_minutes"),
+                    "trading_execution.exit_rules.time_stop_minutes",
+                    default=0.0,
+                ),
                 stop_loss_pct=settings.trading_execution.stop_loss_pct,
                 take_profit_pct=settings.trading_execution.take_profit_pct,
                 timeframe=settings.timeframe,

--- a/src/main.py
+++ b/src/main.py
@@ -430,9 +430,14 @@ def load_settings(config_path: Path) -> Settings:
         futures_enabled = _as_bool(futures.get("enabled"), "futures.enabled", default=False)
         if futures_enabled:
             # Validate leverage limits (hard cap at 20x)
-            leverage = _as_int(futures.get("max_leverage"), "futures.max_leverage", default=10)
-            if leverage > 20:
-                raise ValueError(f"futures.max_leverage={leverage} exceeds hard safety cap of 20x")
+            max_leverage = _as_int(futures.get("max_leverage"), "futures.max_leverage", default=10)
+            if max_leverage > 20:
+                raise ValueError(
+                    f"futures.max_leverage={max_leverage} exceeds hard safety cap of 20x"
+                )
+            default_leverage = _as_int(
+                futures.get("default_leverage"), "futures.default_leverage", default=5
+            )
 
             # Validate margin mode (isolated only for MVP)
             margin_mode = _as_str(
@@ -456,7 +461,8 @@ def load_settings(config_path: Path) -> Settings:
             _logger = get_logger("load_settings")
             _logger.info(
                 f"Futures trading enabled: symbols={_as_str_list(futures.get('symbols'), 'futures.symbols')}, "
-                f"leverage={leverage}x, margin={margin_mode}, mode={position_mode}"
+                f"leverage={default_leverage}x, max_leverage={max_leverage}x, "
+                f"margin={margin_mode}, mode={position_mode}"
             )
 
     # BLOCKER R-1 FIX: Enforce mode: paper safety

--- a/src/portfolio/manager.py
+++ b/src/portfolio/manager.py
@@ -98,6 +98,14 @@ class PortfolioManager:
             await conn.execute(
                 "ALTER TABLE trades ADD COLUMN IF NOT EXISTS market TEXT NOT NULL DEFAULT 'spot'"
             )
+            await conn.execute(
+                "ALTER TABLE positions ADD COLUMN IF NOT EXISTS agent_id TEXT DEFAULT 'default'"
+            )
+            await conn.execute(
+                "ALTER TABLE trades ADD COLUMN IF NOT EXISTS agent_id TEXT DEFAULT 'default'"
+            )
+            await conn.execute("UPDATE positions SET agent_id = 'default' WHERE agent_id IS NULL")
+            await conn.execute("UPDATE trades SET agent_id = 'default' WHERE agent_id IS NULL")
 
     async def _load_open_positions(self) -> None:
         """Load open positions from database into cache."""

--- a/src/portfolio/manager.py
+++ b/src/portfolio/manager.py
@@ -447,6 +447,31 @@ class PortfolioManager:
         details = await self.get_daily_summary_details(day)
         return details["total_pnl"], details["trades_count"], details["win_rate"]
 
+    async def get_closed_stats_since(self, started_at: datetime) -> tuple[float, int, float]:
+        """Return realized PnL, closed trades, and win rate since a UTC timestamp."""
+        async with self._db_lock:
+            pool = get_pool()
+            async with pool.acquire() as conn:
+                row = await conn.fetchrow(
+                    """
+                    SELECT
+                        COALESCE(SUM(realized_pnl), 0) AS total_pnl,
+                        COUNT(*) AS trades_count,
+                        COUNT(*) FILTER (WHERE realized_pnl > 0) AS wins
+                    FROM positions
+                    WHERE status = 'closed'
+                      AND exit_time >= $2
+                      AND agent_id = $1
+                    """,
+                    self._agent_id,
+                    started_at,
+                )
+
+        trades_count = int(row["trades_count"] or 0)
+        wins = int(row["wins"] or 0)
+        win_rate = (wins / trades_count * 100.0) if trades_count > 0 else 0.0
+        return float(row["total_pnl"] or 0.0), trades_count, win_rate
+
     async def get_daily_summary_details(self, day: date) -> dict[str, object]:
         """Return richer daily summary details for notifications/reporting."""
         async with self._db_lock:

--- a/src/utils/paper_validation_report.py
+++ b/src/utils/paper_validation_report.py
@@ -18,6 +18,17 @@ class PaperAgentSpec:
     symbols: tuple[str, ...]
     timeframe: str
     validation_started_at: str
+    min_review_days: int
+    min_review_trades: int
+
+
+@dataclass(frozen=True)
+class PromotionReadiness:
+    status: str
+    campaign_age_days: float
+    min_review_days: int
+    min_review_trades: int
+    reasons: list[str]
 
 
 @dataclass(frozen=True)
@@ -54,6 +65,7 @@ class PaperAgentReport:
     campaign_realized_pnl: float
     campaign_closed_trades: int
     campaign_win_rate: float
+    promotion_readiness: PromotionReadiness
     risk_state_matches_report_day: bool
     portfolio: PortfolioSummary
 
@@ -73,6 +85,8 @@ DEFAULT_PAPER_AGENTS: tuple[PaperAgentSpec, ...] = (
         symbols=("SOLUSDT",),
         timeframe="4h",
         validation_started_at="2026-06-01T21:45:00Z",
+        min_review_days=28,
+        min_review_trades=10,
     ),
     PaperAgentSpec(
         agent_id="sol-4h-panic-block-paper",
@@ -81,6 +95,8 @@ DEFAULT_PAPER_AGENTS: tuple[PaperAgentSpec, ...] = (
         symbols=("SOLUSDT",),
         timeframe="4h",
         validation_started_at="2026-06-01T21:45:00Z",
+        min_review_days=28,
+        min_review_trades=10,
     ),
 )
 
@@ -205,6 +221,32 @@ def load_risk_state(path: Path) -> RiskStateSummary:
     )
 
 
+def assess_promotion_readiness(
+    spec: PaperAgentSpec,
+    *,
+    campaign_closed_trades: int,
+    as_of: datetime,
+) -> PromotionReadiness:
+    validation_started_at = parse_iso_timestamp(spec.validation_started_at)
+    if validation_started_at is None:
+        raise ValueError(f"Invalid validation_started_at for {spec.agent_id}")
+
+    campaign_age_days = max((as_of - validation_started_at).total_seconds() / 86400, 0.0)
+    reasons: list[str] = []
+    if campaign_age_days < spec.min_review_days:
+        reasons.append(f"campaign age {campaign_age_days:.1f}d < {spec.min_review_days}d")
+    if campaign_closed_trades < spec.min_review_trades:
+        reasons.append(f"closed trades {campaign_closed_trades} < {spec.min_review_trades}")
+
+    return PromotionReadiness(
+        status="collecting_evidence" if reasons else "ready_for_review",
+        campaign_age_days=campaign_age_days,
+        min_review_days=spec.min_review_days,
+        min_review_trades=spec.min_review_trades,
+        reasons=reasons,
+    )
+
+
 async def collect_agent_report(
     spec: PaperAgentSpec,
     day: date,
@@ -228,6 +270,11 @@ async def collect_agent_report(
             campaign_win_rate,
         ) = await manager.get_closed_stats_since(validation_started_at)
         portfolio = await manager.get_portfolio_summary()
+    promotion_readiness = assess_promotion_readiness(
+        spec,
+        campaign_closed_trades=campaign_closed_trades,
+        as_of=datetime.now(UTC),
+    )
 
     risk_state_matches_report_day = risk.updated_day == day.isoformat()
 
@@ -242,6 +289,7 @@ async def collect_agent_report(
         campaign_realized_pnl=campaign_realized_pnl,
         campaign_closed_trades=campaign_closed_trades,
         campaign_win_rate=campaign_win_rate,
+        promotion_readiness=promotion_readiness,
         risk_state_matches_report_day=risk_state_matches_report_day,
         portfolio=portfolio,
     )
@@ -321,6 +369,17 @@ def render_markdown(report: PaperValidationReport) -> str:
         lines.append(f"- Campaign realized PnL: `{agent.campaign_realized_pnl:.2f} USDT`")
         lines.append(f"- Campaign closed trades: `{agent.campaign_closed_trades}`")
         lines.append(f"- Campaign win rate: `{agent.campaign_win_rate:.2f}%`")
+        lines.append(f"- Promotion readiness: `{agent.promotion_readiness.status}`")
+        lines.append(f"- Campaign age: `{agent.promotion_readiness.campaign_age_days:.1f} days`")
+        lines.append(
+            "- Minimum review evidence: "
+            f"`{agent.promotion_readiness.min_review_days} days + "
+            f"{agent.promotion_readiness.min_review_trades} closed trades`"
+        )
+        if agent.promotion_readiness.reasons:
+            lines.append(
+                f"- Evidence still needed: `{'; '.join(agent.promotion_readiness.reasons)}`"
+            )
         lines.append(f"- Daily signals: `{agent.events.signal_count}`")
         lines.append(f"- Daily order fills: `{agent.events.order_filled_count}`")
         lines.append(f"- Daily risk check failures: `{agent.events.risk_check_failed_count}`")

--- a/src/utils/paper_validation_report.py
+++ b/src/utils/paper_validation_report.py
@@ -70,17 +70,10 @@ DEFAULT_PAPER_AGENTS: tuple[PaperAgentSpec, ...] = (
         timeframe="4h",
     ),
     PaperAgentSpec(
-        agent_id="sentiment-macro-bot",
-        service="agent_sentiment_macro",
-        config_path="config/settings.sentiment_macro.yaml",
-        symbols=("BTCUSDT", "ETHUSDT", "SOLUSDT"),
-        timeframe="1h",
-    ),
-    PaperAgentSpec(
-        agent_id="avax-4h-ma",
-        service="agent_avax",
-        config_path="config/settings.avax_4h_ma.yaml",
-        symbols=("AVAXUSDT",),
+        agent_id="sol-4h-panic-block-paper",
+        service="agent_sol_panic_block_paper",
+        config_path="config/settings.sol_4h_panic_block_paper.yaml",
+        symbols=("SOLUSDT",),
         timeframe="4h",
     ),
 )

--- a/src/utils/paper_validation_report.py
+++ b/src/utils/paper_validation_report.py
@@ -17,6 +17,7 @@ class PaperAgentSpec:
     config_path: str
     symbols: tuple[str, ...]
     timeframe: str
+    validation_started_at: str
 
 
 @dataclass(frozen=True)
@@ -50,6 +51,9 @@ class PaperAgentReport:
     daily_realized_pnl: float
     daily_closed_trades: int
     daily_win_rate: float
+    campaign_realized_pnl: float
+    campaign_closed_trades: int
+    campaign_win_rate: float
     risk_state_matches_report_day: bool
     portfolio: PortfolioSummary
 
@@ -68,6 +72,7 @@ DEFAULT_PAPER_AGENTS: tuple[PaperAgentSpec, ...] = (
         config_path="config/settings.sol_trend_pullback_sparse.yaml",
         symbols=("SOLUSDT",),
         timeframe="4h",
+        validation_started_at="2026-06-01T21:45:00Z",
     ),
     PaperAgentSpec(
         agent_id="sol-4h-panic-block-paper",
@@ -75,6 +80,7 @@ DEFAULT_PAPER_AGENTS: tuple[PaperAgentSpec, ...] = (
         config_path="config/settings.sol_4h_panic_block_paper.yaml",
         symbols=("SOLUSDT",),
         timeframe="4h",
+        validation_started_at="2026-06-01T21:45:00Z",
     ),
 )
 
@@ -213,6 +219,14 @@ async def collect_agent_report(
     manager = PortfolioManager(db_config, agent_id=spec.agent_id)
     async with manager:
         daily_realized_pnl, daily_closed_trades, daily_win_rate = await manager.get_daily_stats(day)
+        validation_started_at = parse_iso_timestamp(spec.validation_started_at)
+        if validation_started_at is None:
+            raise ValueError(f"Invalid validation_started_at for {spec.agent_id}")
+        (
+            campaign_realized_pnl,
+            campaign_closed_trades,
+            campaign_win_rate,
+        ) = await manager.get_closed_stats_since(validation_started_at)
         portfolio = await manager.get_portfolio_summary()
 
     risk_state_matches_report_day = risk.updated_day == day.isoformat()
@@ -225,6 +239,9 @@ async def collect_agent_report(
         daily_realized_pnl=daily_realized_pnl,
         daily_closed_trades=daily_closed_trades,
         daily_win_rate=daily_win_rate,
+        campaign_realized_pnl=campaign_realized_pnl,
+        campaign_closed_trades=campaign_closed_trades,
+        campaign_win_rate=campaign_win_rate,
         risk_state_matches_report_day=risk_state_matches_report_day,
         portfolio=portfolio,
     )
@@ -300,14 +317,22 @@ def render_markdown(report: PaperValidationReport) -> str:
         lines.append(f"- Daily realized PnL: `{agent.daily_realized_pnl:.2f} USDT`")
         lines.append(f"- Daily closed trades: `{agent.daily_closed_trades}`")
         lines.append(f"- Daily win rate: `{agent.daily_win_rate:.2f}%`")
+        lines.append(f"- Validation campaign started: `{agent.agent.validation_started_at}`")
+        lines.append(f"- Campaign realized PnL: `{agent.campaign_realized_pnl:.2f} USDT`")
+        lines.append(f"- Campaign closed trades: `{agent.campaign_closed_trades}`")
+        lines.append(f"- Campaign win rate: `{agent.campaign_win_rate:.2f}%`")
         lines.append(f"- Daily signals: `{agent.events.signal_count}`")
         lines.append(f"- Daily order fills: `{agent.events.order_filled_count}`")
         lines.append(f"- Daily risk check failures: `{agent.events.risk_check_failed_count}`")
         lines.append(f"- Last signal: `{agent.events.last_signal_at or 'none'}`")
         lines.append(f"- Last order fill: `{agent.events.last_order_at or 'none'}`")
         lines.append(f"- Open positions: `{agent.portfolio.open_positions}`")
-        lines.append(f"- Total realized PnL: `{agent.portfolio.total_realized_pnl:.2f} USDT`")
-        lines.append(f"- Total win rate: `{agent.portfolio.win_rate:.2f}%`")
+        lines.append(
+            f"- Lifetime DB realized PnL (includes legacy runs): `{agent.portfolio.total_realized_pnl:.2f} USDT`"
+        )
+        lines.append(
+            f"- Lifetime DB win rate (includes legacy runs): `{agent.portfolio.win_rate:.2f}%`"
+        )
         lines.append(f"- Kill switch: `{agent.risk.kill_switch_triggered}`")
         lines.append(
             f"- Active breakers: `{', '.join(agent.risk.active_breakers) if agent.risk.active_breakers else 'none'}`"

--- a/src/utils/production_drift_sentinel.py
+++ b/src/utils/production_drift_sentinel.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import Any
 
 IGNORED_CONFIG_FILES = {"settings.autoresearch.yaml"}
+PRODUCTION_COMPOSE = "docker compose -f docker-compose.prod.yml"
 
 
 class Severity(StrEnum):
@@ -150,12 +151,12 @@ def collect_remote_service_snapshot(host: str, remote_dir: str) -> ServiceSnapsh
     all_services_output = run_remote_command(
         host,
         remote_dir,
-        "docker compose config --services",
+        f"{PRODUCTION_COMPOSE} config --services",
     )
     running_services_output = run_remote_command(
         host,
         remote_dir,
-        "docker compose ps --status running --services",
+        f"{PRODUCTION_COMPOSE} ps --status running --services",
     )
 
     all_services = [line.strip() for line in all_services_output.splitlines() if line.strip()]
@@ -180,7 +181,8 @@ def collect_remote_signal_snapshot(
     logs = run_remote_command(
         host,
         remote_dir,
-        f"docker compose logs --tail {tail_lines} --timestamps --no-log-prefix {rendered_services}",
+        f"{PRODUCTION_COMPOSE} logs --tail {tail_lines} --timestamps --no-log-prefix "
+        f"{rendered_services}",
         timeout=30,
     )
 
@@ -222,7 +224,8 @@ def collect_remote_watched_service_snapshot(
     logs = run_remote_command(
         host,
         remote_dir,
-        f"docker compose logs --tail {tail_lines} --timestamps --no-log-prefix {shlex.quote(service)}",
+        f"{PRODUCTION_COMPOSE} logs --tail {tail_lines} --timestamps --no-log-prefix "
+        f"{shlex.quote(service)}",
         timeout=30,
     )
     lines = logs.splitlines()

--- a/src/utils/production_drift_sentinel.py
+++ b/src/utils/production_drift_sentinel.py
@@ -13,6 +13,7 @@ from typing import Any
 
 IGNORED_CONFIG_FILES = {"settings.autoresearch.yaml"}
 PRODUCTION_COMPOSE = "docker compose -f docker-compose.prod.yml"
+REQUIRED_SYSTEMD_TIMERS = ("crypto-agent-paper-validation-report.timer",)
 
 
 class Severity(StrEnum):
@@ -43,6 +44,18 @@ class ServiceSnapshot:
 
 
 @dataclass(frozen=True)
+class TimerState:
+    timer: str
+    enabled: str
+    active: str
+
+
+@dataclass(frozen=True)
+class TimerSnapshot:
+    timers: list[TimerState]
+
+
+@dataclass(frozen=True)
 class SignalSnapshot:
     signal_count: int
     last_signal_at: str | None
@@ -68,6 +81,7 @@ class DriftReport:
     local_config_hashes: dict[str, str]
     remote_config_hashes: dict[str, str]
     service_snapshot: ServiceSnapshot | None
+    timer_snapshot: TimerSnapshot | None
     signal_snapshot: SignalSnapshot | None
     watched_service_snapshot: WatchedServiceSnapshot | None
     findings: list[Finding]
@@ -187,6 +201,33 @@ def collect_remote_service_snapshot(
     ]
 
     return ServiceSnapshot(all_services=all_services, running_services=running_services)
+
+
+def collect_remote_timer_snapshot(
+    host: str,
+    remote_dir: str,
+    timers: tuple[str, ...] = REQUIRED_SYSTEMD_TIMERS,
+    ssh_config: str | None = None,
+) -> TimerSnapshot:
+    states: list[TimerState] = []
+    for timer in timers:
+        rendered_timer = shlex.quote(timer)
+        enabled = run_remote_command(
+            host,
+            remote_dir,
+            f"systemctl is-enabled {rendered_timer} 2>/dev/null || true",
+            ssh_config=ssh_config,
+        )
+        active = run_remote_command(
+            host,
+            remote_dir,
+            f"systemctl is-active {rendered_timer} 2>/dev/null || true",
+            ssh_config=ssh_config,
+        )
+        states.append(
+            TimerState(timer=timer, enabled=enabled or "unknown", active=active or "unknown")
+        )
+    return TimerSnapshot(timers=states)
 
 
 def collect_remote_signal_snapshot(
@@ -314,6 +355,7 @@ def analyze_drift(
     local_config_hashes: dict[str, str],
     remote_config_hashes: dict[str, str],
     service_snapshot: ServiceSnapshot | None,
+    timer_snapshot: TimerSnapshot | None = None,
     signal_snapshot: SignalSnapshot | None,
     watched_service_snapshot: WatchedServiceSnapshot | None,
     remote_error: str | None,
@@ -456,6 +498,21 @@ def analyze_drift(
                 )
             )
 
+    if timer_snapshot is not None:
+        for timer in timer_snapshot.timers:
+            if timer.enabled != "enabled" or timer.active != "active":
+                findings.append(
+                    Finding(
+                        severity=Severity.ERROR,
+                        code="REQUIRED_TIMER_NOT_HEALTHY",
+                        message=(
+                            f"Required timer '{timer.timer}' is not healthy "
+                            f"(enabled={timer.enabled}, active={timer.active})"
+                        ),
+                        recommendation="Enable and start the required production timer.",
+                    )
+                )
+
     if signal_snapshot is not None:
         if signal_snapshot.saw_strategy_cycle and signal_snapshot.signal_count == 0:
             findings.append(
@@ -573,6 +630,7 @@ def report_to_json(report: DriftReport) -> str:
         "local_config_hashes": report.local_config_hashes,
         "remote_config_hashes": report.remote_config_hashes,
         "service_snapshot": asdict(report.service_snapshot) if report.service_snapshot else None,
+        "timer_snapshot": asdict(report.timer_snapshot) if report.timer_snapshot else None,
         "signal_snapshot": asdict(report.signal_snapshot) if report.signal_snapshot else None,
         "watched_service_snapshot": (
             asdict(report.watched_service_snapshot) if report.watched_service_snapshot else None

--- a/src/utils/production_drift_sentinel.py
+++ b/src/utils/production_drift_sentinel.py
@@ -105,13 +105,16 @@ def run_command(command: list[str], cwd: Path | None = None, timeout: int = 15) 
 
 
 def run_remote_command(
-    host: str,
+    host: str | None,
     remote_dir: str,
     command: str,
     timeout: int = 20,
     ssh_config: str | None = None,
 ) -> str:
     remote_script = f"cd {shlex.quote(remote_dir)} && {command}"
+    if host is None:
+        return run_command(["bash", "-lc", remote_script], timeout=timeout)
+
     ssh_command = ["ssh"]
     if ssh_config:
         ssh_command.extend(["-F", ssh_config])
@@ -126,7 +129,7 @@ def collect_repo_snapshot(cwd: Path | None = None) -> RepoSnapshot:
 
 
 def collect_remote_repo_snapshot(
-    host: str, remote_dir: str, ssh_config: str | None = None
+    host: str | None, remote_dir: str, ssh_config: str | None = None
 ) -> RepoSnapshot:
     branch = run_remote_command(
         host, remote_dir, "git rev-parse --abbrev-ref HEAD", ssh_config=ssh_config
@@ -156,7 +159,7 @@ def sha256_file(path: Path) -> str:
 
 
 def collect_remote_config_hashes(
-    host: str, remote_dir: str, ssh_config: str | None = None
+    host: str | None, remote_dir: str, ssh_config: str | None = None
 ) -> dict[str, str]:
     output = run_remote_command(
         host,
@@ -185,7 +188,7 @@ def parse_sha256_lines(text: str) -> dict[str, str]:
 
 
 def collect_remote_service_snapshot(
-    host: str, remote_dir: str, ssh_config: str | None = None
+    host: str | None, remote_dir: str, ssh_config: str | None = None
 ) -> ServiceSnapshot:
     all_services_output = run_remote_command(
         host,
@@ -209,7 +212,7 @@ def collect_remote_service_snapshot(
 
 
 def collect_remote_timer_snapshot(
-    host: str,
+    host: str | None,
     remote_dir: str,
     timers: tuple[str, ...] = REQUIRED_SYSTEMD_TIMERS,
     ssh_config: str | None = None,
@@ -276,7 +279,7 @@ def epoch_to_iso_timestamp(value: str) -> str | None:
 
 
 def collect_remote_signal_snapshot(
-    host: str,
+    host: str | None,
     remote_dir: str,
     service_snapshot: ServiceSnapshot,
     tail_lines: int = 500,
@@ -311,7 +314,7 @@ def collect_remote_signal_snapshot(
 
 
 def collect_remote_watched_service_snapshot(
-    host: str,
+    host: str | None,
     remote_dir: str,
     service_snapshot: ServiceSnapshot,
     service: str,

--- a/src/utils/production_drift_sentinel.py
+++ b/src/utils/production_drift_sentinel.py
@@ -85,9 +85,18 @@ def run_command(command: list[str], cwd: Path | None = None, timeout: int = 15) 
     return result.stdout.strip()
 
 
-def run_remote_command(host: str, remote_dir: str, command: str, timeout: int = 20) -> str:
+def run_remote_command(
+    host: str,
+    remote_dir: str,
+    command: str,
+    timeout: int = 20,
+    ssh_config: str | None = None,
+) -> str:
     remote_script = f"cd {shlex.quote(remote_dir)} && {command}"
-    return run_command(["ssh", host, remote_script], timeout=timeout)
+    ssh_command = ["ssh"]
+    if ssh_config:
+        ssh_command.extend(["-F", ssh_config])
+    return run_command([*ssh_command, host, remote_script], timeout=timeout)
 
 
 def collect_repo_snapshot(cwd: Path | None = None) -> RepoSnapshot:
@@ -97,10 +106,16 @@ def collect_repo_snapshot(cwd: Path | None = None) -> RepoSnapshot:
     return RepoSnapshot(branch=branch, commit=commit, dirty=dirty)
 
 
-def collect_remote_repo_snapshot(host: str, remote_dir: str) -> RepoSnapshot:
-    branch = run_remote_command(host, remote_dir, "git rev-parse --abbrev-ref HEAD")
-    commit = run_remote_command(host, remote_dir, "git rev-parse HEAD")
-    dirty = bool(run_remote_command(host, remote_dir, "git status --porcelain"))
+def collect_remote_repo_snapshot(
+    host: str, remote_dir: str, ssh_config: str | None = None
+) -> RepoSnapshot:
+    branch = run_remote_command(
+        host, remote_dir, "git rev-parse --abbrev-ref HEAD", ssh_config=ssh_config
+    )
+    commit = run_remote_command(host, remote_dir, "git rev-parse HEAD", ssh_config=ssh_config)
+    dirty = bool(
+        run_remote_command(host, remote_dir, "git status --porcelain", ssh_config=ssh_config)
+    )
     return RepoSnapshot(branch=branch, commit=commit, dirty=dirty)
 
 
@@ -121,11 +136,14 @@ def sha256_file(path: Path) -> str:
     return digest.hexdigest()
 
 
-def collect_remote_config_hashes(host: str, remote_dir: str) -> dict[str, str]:
+def collect_remote_config_hashes(
+    host: str, remote_dir: str, ssh_config: str | None = None
+) -> dict[str, str]:
     output = run_remote_command(
         host,
         remote_dir,
         'for f in config/settings*.yaml; do [ -f "$f" ] && sha256sum "$f"; done',
+        ssh_config=ssh_config,
     )
     return parse_sha256_lines(output)
 
@@ -147,16 +165,20 @@ def parse_sha256_lines(text: str) -> dict[str, str]:
     return hashes
 
 
-def collect_remote_service_snapshot(host: str, remote_dir: str) -> ServiceSnapshot:
+def collect_remote_service_snapshot(
+    host: str, remote_dir: str, ssh_config: str | None = None
+) -> ServiceSnapshot:
     all_services_output = run_remote_command(
         host,
         remote_dir,
         f"{PRODUCTION_COMPOSE} config --services",
+        ssh_config=ssh_config,
     )
     running_services_output = run_remote_command(
         host,
         remote_dir,
         f"{PRODUCTION_COMPOSE} ps --status running --services",
+        ssh_config=ssh_config,
     )
 
     all_services = [line.strip() for line in all_services_output.splitlines() if line.strip()]
@@ -172,6 +194,7 @@ def collect_remote_signal_snapshot(
     remote_dir: str,
     service_snapshot: ServiceSnapshot,
     tail_lines: int = 500,
+    ssh_config: str | None = None,
 ) -> SignalSnapshot:
     agent_services = [name for name in service_snapshot.all_services if name.startswith("agent")]
     if not agent_services:
@@ -184,6 +207,7 @@ def collect_remote_signal_snapshot(
         f"{PRODUCTION_COMPOSE} logs --tail {tail_lines} --timestamps --no-log-prefix "
         f"{rendered_services}",
         timeout=30,
+        ssh_config=ssh_config,
     )
 
     signal_lines = [line for line in logs.splitlines() if "Consensus Signal" in line]
@@ -206,6 +230,7 @@ def collect_remote_watched_service_snapshot(
     service_snapshot: ServiceSnapshot,
     service: str,
     tail_lines: int = 500,
+    ssh_config: str | None = None,
 ) -> WatchedServiceSnapshot:
     exists = service in service_snapshot.all_services
     running = service in service_snapshot.running_services
@@ -227,6 +252,7 @@ def collect_remote_watched_service_snapshot(
         f"{PRODUCTION_COMPOSE} logs --tail {tail_lines} --timestamps --no-log-prefix "
         f"{shlex.quote(service)}",
         timeout=30,
+        ssh_config=ssh_config,
     )
     lines = logs.splitlines()
     signal_lines = [line for line in lines if "Consensus Signal" in line]

--- a/src/utils/production_drift_sentinel.py
+++ b/src/utils/production_drift_sentinel.py
@@ -14,6 +14,8 @@ from typing import Any
 IGNORED_CONFIG_FILES = {"settings.autoresearch.yaml"}
 PRODUCTION_COMPOSE = "docker compose -f docker-compose.prod.yml"
 REQUIRED_SYSTEMD_TIMERS = ("crypto-agent-paper-validation-report.timer",)
+PAPER_VALIDATION_REPORT_GLOB = "data/reports/paper-validation-report-*.json"
+MAX_REPORT_ARTIFACT_AGE_HOURS = 36
 
 
 class Severity(StrEnum):
@@ -48,6 +50,9 @@ class TimerState:
     timer: str
     enabled: str
     active: str
+    service_result: str
+    exec_main_status: str
+    latest_report_at: str | None
 
 
 @dataclass(frozen=True)
@@ -224,10 +229,50 @@ def collect_remote_timer_snapshot(
             f"systemctl is-active {rendered_timer} 2>/dev/null || true",
             ssh_config=ssh_config,
         )
+        service = timer.removesuffix(".timer") + ".service"
+        rendered_service = shlex.quote(service)
+        service_result = run_remote_command(
+            host,
+            remote_dir,
+            f"systemctl show {rendered_service} --property=Result --value",
+            ssh_config=ssh_config,
+        )
+        exec_main_status = run_remote_command(
+            host,
+            remote_dir,
+            f"systemctl show {rendered_service} --property=ExecMainStatus --value",
+            ssh_config=ssh_config,
+        )
+        latest_report_epoch = run_remote_command(
+            host,
+            remote_dir,
+            (
+                f"find {shlex.quote(str(Path(PAPER_VALIDATION_REPORT_GLOB).parent))} "
+                f"-maxdepth 1 -type f -name {shlex.quote(Path(PAPER_VALIDATION_REPORT_GLOB).name)} "
+                "-printf '%T@\\n' 2>/dev/null | sort -nr | head -n 1"
+            ),
+            ssh_config=ssh_config,
+        )
+        latest_report_at = epoch_to_iso_timestamp(latest_report_epoch)
         states.append(
-            TimerState(timer=timer, enabled=enabled or "unknown", active=active or "unknown")
+            TimerState(
+                timer=timer,
+                enabled=enabled or "unknown",
+                active=active or "unknown",
+                service_result=service_result or "unknown",
+                exec_main_status=exec_main_status or "unknown",
+                latest_report_at=latest_report_at,
+            )
         )
     return TimerSnapshot(timers=states)
+
+
+def epoch_to_iso_timestamp(value: str) -> str | None:
+    try:
+        epoch = float(value.strip())
+    except ValueError:
+        return None
+    return datetime.fromtimestamp(epoch, tz=UTC).isoformat()
 
 
 def collect_remote_signal_snapshot(
@@ -512,6 +557,43 @@ def analyze_drift(
                         recommendation="Enable and start the required production timer.",
                     )
                 )
+            if timer.service_result != "success" or timer.exec_main_status != "0":
+                findings.append(
+                    Finding(
+                        severity=Severity.ERROR,
+                        code="REQUIRED_TIMER_SERVICE_FAILED",
+                        message=(
+                            f"Required timer service for '{timer.timer}' failed "
+                            f"(result={timer.service_result}, exec_status={timer.exec_main_status})"
+                        ),
+                        recommendation="Inspect the timer service journal and rerun the report.",
+                    )
+                )
+            if timer.latest_report_at is None:
+                findings.append(
+                    Finding(
+                        severity=Severity.ERROR,
+                        code="PAPER_VALIDATION_REPORT_MISSING",
+                        message="No generated paper-validation JSON report artifact was found",
+                        recommendation="Run the report wrapper and verify host artifact persistence.",
+                    )
+                )
+            else:
+                parsed = parse_iso_timestamp(timer.latest_report_at)
+                if parsed is not None:
+                    age_hours = (datetime.now(UTC) - parsed).total_seconds() / 3600
+                    if age_hours > MAX_REPORT_ARTIFACT_AGE_HOURS:
+                        findings.append(
+                            Finding(
+                                severity=Severity.ERROR,
+                                code="PAPER_VALIDATION_REPORT_STALE",
+                                message=(
+                                    "Latest paper-validation report artifact is stale "
+                                    f"({age_hours:.1f}h old at {timer.latest_report_at})"
+                                ),
+                                recommendation="Inspect the timer service and regenerate the report.",
+                            )
+                        )
 
     if signal_snapshot is not None:
         if signal_snapshot.saw_strategy_cycle and signal_snapshot.signal_count == 0:

--- a/src/utils/production_drift_sentinel.py
+++ b/src/utils/production_drift_sentinel.py
@@ -13,9 +13,16 @@ from typing import Any
 
 IGNORED_CONFIG_FILES = {"settings.autoresearch.yaml"}
 PRODUCTION_COMPOSE = "docker compose -f docker-compose.prod.yml"
-REQUIRED_SYSTEMD_TIMERS = ("crypto-agent-paper-validation-report.timer",)
 PAPER_VALIDATION_REPORT_GLOB = "data/reports/paper-validation-report-*.json"
-MAX_REPORT_ARTIFACT_AGE_HOURS = 36
+PRODUCTION_DRIFT_SENTINEL_REPORT_GLOB = "data/reports/production-drift-sentinel-*.json"
+REQUIRED_SYSTEMD_TIMERS = (
+    "crypto-agent-paper-validation-report.timer",
+    "crypto-agent-production-drift-sentinel.timer",
+)
+TIMER_ARTIFACT_POLICIES = {
+    "crypto-agent-paper-validation-report.timer": (PAPER_VALIDATION_REPORT_GLOB, 36),
+    "crypto-agent-production-drift-sentinel.timer": (PRODUCTION_DRIFT_SENTINEL_REPORT_GLOB, 2),
+}
 
 
 class Severity(StrEnum):
@@ -53,6 +60,7 @@ class TimerState:
     service_result: str
     exec_main_status: str
     latest_report_at: str | None
+    max_report_age_hours: int
 
 
 @dataclass(frozen=True)
@@ -219,6 +227,9 @@ def collect_remote_timer_snapshot(
 ) -> TimerSnapshot:
     states: list[TimerState] = []
     for timer in timers:
+        report_glob, max_report_age_hours = TIMER_ARTIFACT_POLICIES.get(
+            timer, (PAPER_VALIDATION_REPORT_GLOB, 36)
+        )
         rendered_timer = shlex.quote(timer)
         enabled = run_remote_command(
             host,
@@ -250,8 +261,8 @@ def collect_remote_timer_snapshot(
             host,
             remote_dir,
             (
-                f"find {shlex.quote(str(Path(PAPER_VALIDATION_REPORT_GLOB).parent))} "
-                f"-maxdepth 1 -type f -name {shlex.quote(Path(PAPER_VALIDATION_REPORT_GLOB).name)} "
+                f"find {shlex.quote(str(Path(report_glob).parent))} "
+                f"-maxdepth 1 -type f -name {shlex.quote(Path(report_glob).name)} "
                 "-printf '%T@\\n' 2>/dev/null | sort -nr | head -n 1"
             ),
             ssh_config=ssh_config,
@@ -265,6 +276,7 @@ def collect_remote_timer_snapshot(
                 service_result=service_result or "unknown",
                 exec_main_status=exec_main_status or "unknown",
                 latest_report_at=latest_report_at,
+                max_report_age_hours=max_report_age_hours,
             )
         )
     return TimerSnapshot(timers=states)
@@ -576,8 +588,8 @@ def analyze_drift(
                 findings.append(
                     Finding(
                         severity=Severity.ERROR,
-                        code="PAPER_VALIDATION_REPORT_MISSING",
-                        message="No generated paper-validation JSON report artifact was found",
+                        code="TIMER_REPORT_MISSING",
+                        message=f"No generated JSON report artifact was found for '{timer.timer}'",
                         recommendation="Run the report wrapper and verify host artifact persistence.",
                     )
                 )
@@ -585,13 +597,13 @@ def analyze_drift(
                 parsed = parse_iso_timestamp(timer.latest_report_at)
                 if parsed is not None:
                     age_hours = (datetime.now(UTC) - parsed).total_seconds() / 3600
-                    if age_hours > MAX_REPORT_ARTIFACT_AGE_HOURS:
+                    if age_hours > timer.max_report_age_hours:
                         findings.append(
                             Finding(
                                 severity=Severity.ERROR,
-                                code="PAPER_VALIDATION_REPORT_STALE",
+                                code="TIMER_REPORT_STALE",
                                 message=(
-                                    "Latest paper-validation report artifact is stale "
+                                    f"Latest report artifact for '{timer.timer}' is stale "
                                     f"({age_hours:.1f}h old at {timer.latest_report_at})"
                                 ),
                                 recommendation="Inspect the timer service and regenerate the report.",

--- a/tests/test_autoresearch.py
+++ b/tests/test_autoresearch.py
@@ -404,6 +404,11 @@ def test_autoresearch_loop_candidate_ranges_stay_bounded() -> None:
             "regime_gated_pullback_overlay",
             "breakout_retest_bridge",
             "regime_gated_pullback_bridge",
+        }:
+            strategy = candidate.overlay["strategy"]
+            assert len(strategy["strategies"]) == 6
+            assert 0.80 <= strategy["aggregator"]["buy_threshold"] <= 1.40
+        elif candidate.family in {
             "trend_pullback_standalone",
             "breakout_retest_standalone",
             "volatility_squeeze_standalone",
@@ -412,8 +417,8 @@ def test_autoresearch_loop_candidate_ranges_stay_bounded() -> None:
             "funding_primary_standalone",
         }:
             strategy = candidate.overlay["strategy"]
-            assert len(strategy["strategies"]) == 6
-            assert 0.80 <= strategy["aggregator"]["buy_threshold"] <= 1.40
+            assert len(strategy["strategies"]) == 1
+            assert 0.40 <= strategy["aggregator"]["buy_threshold"] <= 0.75
         else:
             raise AssertionError(f"unexpected candidate family: {candidate.family}")
 

--- a/tests/test_autoresearch.py
+++ b/tests/test_autoresearch.py
@@ -356,6 +356,10 @@ def test_autoresearch_loop_candidate_ranges_stay_bounded() -> None:
             "regime_gated_pullback_overlay",
             "breakout_retest_bridge",
             "regime_gated_pullback_bridge",
+            "trend_pullback_standalone",
+            "breakout_retest_standalone",
+            "volatility_squeeze_standalone",
+            "mtf_breakout_standalone",
         }:
             strategy = candidate.overlay["strategy"]
             assert len(strategy["strategies"]) == 6
@@ -577,6 +581,34 @@ def test_parse_families_accepts_wave2_overlay_names() -> None:
         "funding_extreme_overlay",
         "regime_gated_pullback_overlay",
     )
+
+
+def test_autoresearch_loop_trend_pullback_standalone_single_strategy() -> None:
+    candidate = generate_candidate(
+        7,
+        seed=42,
+        symbol="SOLUSDT",
+        families=("trend_pullback_standalone",),
+    )
+
+    assert candidate.family == "trend_pullback_standalone"
+    strategies = candidate.overlay["strategy"]["strategies"]
+    assert len(strategies) == 1
+    assert strategies[0]["name"] == "trend_pullback"
+    assert "SOLUSDT" in candidate.overlay["strategy"]["per_symbol_aggregator_config"]
+
+
+def test_autoresearch_loop_mtf_breakout_standalone_sets_1h_timeframe() -> None:
+    candidate = generate_candidate(
+        8,
+        seed=42,
+        symbol="SOLUSDT",
+        families=("mtf_breakout_standalone",),
+    )
+
+    assert candidate.family == "mtf_breakout_standalone"
+    assert candidate.overlay["trading"]["timeframe"] == "1h"
+    assert candidate.overlay["strategy"]["strategies"][0]["name"] == "mtf_breakout"
 
 
 def test_autoresearch_loop_builds_existing_runner_command() -> None:

--- a/tests/test_autoresearch.py
+++ b/tests/test_autoresearch.py
@@ -19,6 +19,7 @@ from scripts.run_autoresearch import (
     _append_results_row,
     _build_autopilot_command,
     _deep_merge,
+    _eligible_for_bootstrap_1000,
     _extract_output_path,
     _generate_run_id,
     _normalize_subprocess_output,
@@ -196,6 +197,53 @@ def test_probe_1h_gate_profile_resolves_expected_values() -> None:
         "min_oos_return_pct": 0.0,
         "max_profit_concentration_pct": 50.0,
     }
+
+
+def test_promotion_candidate_gate_profile_is_stricter_than_standard() -> None:
+    promo = GATE_PROFILES["promotion_candidate"]
+    standard = GATE_PROFILES["standard"]
+
+    assert promo["min_oos_return_pct"] > standard["min_oos_return_pct"]
+    assert promo["max_drawdown_pct"] < standard["max_drawdown_pct"]
+    assert promo["max_bootstrap_p_loss_pct"] < standard["max_bootstrap_p_loss_pct"]
+    assert promo["max_profit_concentration_pct"] < standard["max_profit_concentration_pct"]
+
+
+def test_eligible_for_bootstrap_1000_requires_promotion_candidate_at_b100() -> None:
+    strong = {
+        "symbol": "BNBUSDT",
+        "timeframe": "1h",
+        "start": "2024-01-01T00:00:00+00:00",
+        "end": "2026-01-01T00:00:00+00:00",
+        "total_trades": 30,
+        "win_rate": 55.0,
+        "total_return_pct": 12.0,
+        "max_drawdown_pct": 6.0,
+        "sharpe_ratio": 0.8,
+        "wfo_windows": 7,
+        "wfo_total_trades": 24,
+        "wfo_mean_sharpe": 0.6,
+        "wfo_total_return_pct": 3.5,
+        "bootstrap_p_loss_pct": 12.0,
+        "profit_concentration_pct": 30.0,
+        "passes_gates": True,
+        "failure_reasons": [],
+    }
+    weak = dict(strong)
+    weak["wfo_total_return_pct"] = 0.5
+    weak["bootstrap_p_loss_pct"] = 30.0
+
+    ok, failures = _eligible_for_bootstrap_1000(strong, bootstrap=100)
+    assert ok is True
+    assert failures == []
+
+    ok_weak, weak_failures = _eligible_for_bootstrap_1000(weak, bootstrap=100)
+    assert ok_weak is False
+    assert weak_failures
+
+    ok_b1000, b1000_failures = _eligible_for_bootstrap_1000(strong, bootstrap=1000)
+    assert ok_b1000 is False
+    assert b1000_failures == ["bootstrap_gt_100"]
 
 
 def test_explicit_gate_flags_override_profile_defaults() -> None:

--- a/tests/test_autoresearch.py
+++ b/tests/test_autoresearch.py
@@ -349,6 +349,15 @@ def test_autoresearch_loop_candidate_ranges_stay_bounded() -> None:
             assert 1.10 <= aggregator["buy_threshold"] <= 1.35
             assert 0.95 <= aggregator["buy_threshold_uptrend"] <= 1.15
             assert -0.86 <= aggregator["sell_threshold"] <= -0.74
+        elif candidate.family in {
+            "breakout_retest_overlay",
+            "volatility_squeeze_overlay",
+            "funding_extreme_overlay",
+            "regime_gated_pullback_overlay",
+        }:
+            strategy = candidate.overlay["strategy"]
+            assert len(strategy["strategies"]) == 6
+            assert 0.80 <= strategy["aggregator"]["buy_threshold"] <= 1.40
         else:
             raise AssertionError(f"unexpected candidate family: {candidate.family}")
 
@@ -492,6 +501,80 @@ def test_autoresearch_loop_trend_pullback_overlay_adds_complementary_signal() ->
     assert 0.015 <= pullback_config["vwap_pullback_distance_pct"] <= 0.035
     assert 2.10 <= execution["sl_atr_multiplier"] <= 2.45
     assert 3.60 <= execution["tp_atr_multiplier"] <= 4.40
+
+
+def test_autoresearch_loop_breakout_retest_overlay_adds_specialist() -> None:
+    candidate = generate_candidate(
+        3,
+        seed=42,
+        symbol="ETHUSDT",
+        families=("breakout_retest_overlay",),
+    )
+
+    assert candidate.family == "breakout_retest_overlay"
+    strategy = candidate.overlay["strategy"]
+    names = [entry["name"] for entry in strategy["strategies"]]
+    assert names[-1] == "breakout_retest"
+    assert "ETHUSDT" in strategy["per_symbol_aggregator_config"]
+    assert not strategy["aggregator"].get("btc_regime_filter_enabled")
+
+
+def test_autoresearch_loop_volatility_squeeze_overlay_adds_specialist() -> None:
+    candidate = generate_candidate(
+        4,
+        seed=42,
+        symbol="SOLUSDT",
+        families=("volatility_squeeze_overlay",),
+    )
+
+    assert candidate.family == "volatility_squeeze_overlay"
+    names = [entry["name"] for entry in candidate.overlay["strategy"]["strategies"]]
+    assert names[-1] == "volatility_squeeze"
+    squeeze = candidate.overlay["strategy"]["strategies"][-1]["config"]
+    assert 0.15 <= squeeze["squeeze_percentile"] <= 0.25
+
+
+def test_autoresearch_loop_funding_extreme_overlay_adds_specialist() -> None:
+    candidate = generate_candidate(
+        5,
+        seed=42,
+        symbol="BNBUSDT",
+        families=("funding_extreme_overlay",),
+    )
+
+    assert candidate.family == "funding_extreme_overlay"
+    names = [entry["name"] for entry in candidate.overlay["strategy"]["strategies"]]
+    assert names[-1] == "funding_rate"
+    assert "BNBUSDT" in candidate.overlay["strategy"]["per_symbol_aggregator_config"]
+
+
+def test_autoresearch_loop_regime_gated_pullback_enables_btc_filter() -> None:
+    candidate = generate_candidate(
+        6,
+        seed=42,
+        symbol="AVAXUSDT",
+        families=("regime_gated_pullback_overlay",),
+    )
+
+    assert candidate.family == "regime_gated_pullback_overlay"
+    strategy = candidate.overlay["strategy"]
+    assert strategy["aggregator"]["btc_regime_filter_enabled"] is True
+    assert strategy["strategies"][-1]["name"] == "trend_pullback"
+    pullback = strategy["strategies"][-1]["config"]
+    assert pullback["min_atr_pct"] >= 0.008
+
+
+def test_parse_families_accepts_wave2_overlay_names() -> None:
+    families = _parse_families(
+        "breakout_retest_overlay,volatility_squeeze_overlay,funding_extreme_overlay,"
+        "regime_gated_pullback_overlay"
+    )
+    assert families == (
+        "breakout_retest_overlay",
+        "volatility_squeeze_overlay",
+        "funding_extreme_overlay",
+        "regime_gated_pullback_overlay",
+    )
 
 
 def test_autoresearch_loop_builds_existing_runner_command() -> None:

--- a/tests/test_autoresearch.py
+++ b/tests/test_autoresearch.py
@@ -1,8 +1,17 @@
 from __future__ import annotations
 
 import argparse
+import sys
 from pathlib import Path
 
+import pytest
+
+from scripts.autoresearch_loop import (
+    _parse_families,
+    _run_command,
+    build_run_command,
+    generate_candidate,
+)
 from scripts.run_autoresearch import (
     GATE_PROFILES,
     RESULTS_FIELDNAMES,
@@ -12,6 +21,7 @@ from scripts.run_autoresearch import (
     _deep_merge,
     _extract_output_path,
     _generate_run_id,
+    _normalize_subprocess_output,
     _read_best_score,
     _resolve_gates,
     compute_score,
@@ -46,6 +56,12 @@ def test_extract_output_path_reads_autopilot_stdout() -> None:
     path = _extract_output_path(stdout, "JSON")
 
     assert path == Path("research/archive/result.json")
+
+
+def test_normalize_subprocess_output_decodes_timeout_bytes() -> None:
+    assert _normalize_subprocess_output(b"partial stdout\n") == "partial stdout\n"
+    assert _normalize_subprocess_output("stderr\n") == "stderr\n"
+    assert _normalize_subprocess_output(None) == ""
 
 
 def test_compute_score_rewards_passing_candidates() -> None:
@@ -157,6 +173,31 @@ def test_sparse_trend_gate_profile_resolves_expected_values() -> None:
     assert resolved == GATE_PROFILES["sparse_trend_3_2"]
 
 
+def test_probe_1h_gate_profile_resolves_expected_values() -> None:
+    args = argparse.Namespace(
+        gate_profile="probe_1h",
+        min_trades=None,
+        min_wfo_trades=None,
+        min_wfo_sharpe=None,
+        max_drawdown_pct=None,
+        max_bootstrap_p_loss_pct=None,
+        min_oos_return_pct=None,
+        max_profit_concentration_pct=None,
+    )
+
+    resolved = _resolve_gates(args)
+
+    assert resolved == {
+        "min_trades": 0,
+        "min_wfo_trades": 15,
+        "min_wfo_sharpe": 0.5,
+        "max_drawdown_pct": 10.0,
+        "max_bootstrap_p_loss_pct": 25.0,
+        "min_oos_return_pct": 0.0,
+        "max_profit_concentration_pct": 50.0,
+    }
+
+
 def test_explicit_gate_flags_override_profile_defaults() -> None:
     args = argparse.Namespace(
         gate_profile="sparse_trend_3_2",
@@ -224,3 +265,273 @@ def test_build_autopilot_command_forwards_replay_sentiment_flags(tmp_path: Path)
     assert "--replay-sentiment-max-age-hours" in command
     max_age_index = command.index("--replay-sentiment-max-age-hours")
     assert command[max_age_index + 1] == "24.0"
+
+
+def test_autoresearch_loop_candidate_generation_is_reproducible() -> None:
+    first = generate_candidate(1, seed=123)
+    second = generate_candidate(1, seed=123)
+
+    assert first == second
+    assert first.overlay
+    assert first.description
+
+
+def test_autoresearch_loop_candidate_ranges_stay_bounded() -> None:
+    candidates = [generate_candidate(index, seed=42) for index in range(1, 30)]
+
+    for candidate in candidates:
+        if candidate.family == "aggregator_thresholds":
+            aggregator = candidate.overlay["strategy"]["aggregator"]
+            assert 0.65 <= aggregator["buy_threshold"] <= 1.10
+            assert 0.55 <= aggregator["buy_threshold_uptrend"] <= 1.10
+            assert -0.90 <= aggregator["sell_threshold"] <= -0.50
+        elif candidate.family == "risk_atr_exits":
+            execution = candidate.overlay["trading_execution"]
+            assert 1.4 <= execution["sl_atr_multiplier"] <= 2.8
+            assert 2.2 <= execution["tp_atr_multiplier"] <= 5.0
+            assert 1.0 <= execution["trailing_activate_atr"] <= 2.4
+            assert 0.6 <= execution["trailing_offset_atr"] <= 1.5
+        elif candidate.family == "sentiment_filters":
+            config = candidate.overlay["strategy"]["strategies"][0]["config"]
+            assert 25.0 <= config["sentiment_gate_threshold"] <= 55.0
+            assert 10.0 <= config["sentiment_panic_threshold"] < config["sentiment_gate_threshold"]
+            assert config["sentiment_boost_threshold"] > config["sentiment_gate_threshold"]
+        elif candidate.family == "indicator_thresholds":
+            strategies = candidate.overlay["strategy"]["strategies"]
+            bollinger = strategies[0]["config"]
+            macd = strategies[1]["config"]
+            assert 0.002 <= bollinger["band_distance_threshold"] <= 0.012
+            assert bollinger["rsi_oversold"] in {30, 35, 40}
+            assert bollinger["rsi_overbought"] in {60, 65, 70}
+            assert 0.0 <= macd["min_histogram_threshold"] <= 0.0005
+            assert 0.002 <= macd["atr_min_pct"] <= 0.010
+        elif candidate.family == "combined_focus":
+            strategy = candidate.overlay["strategy"]
+            aggregator = strategy["aggregator"]
+            strategies = strategy["strategies"]
+            assert len(strategies) == 5
+            assert [entry["name"] for entry in strategies] == [
+                "rsi_reversal",
+                "macd_histogram",
+                "bollinger_bounce",
+                "cci_breakout",
+                "vwap_reversion",
+            ]
+            assert 1.04 <= aggregator["buy_threshold"] <= 1.16
+            assert 0.98 <= aggregator["buy_threshold_uptrend"] <= 1.16
+            assert -0.92 <= aggregator["sell_threshold"] <= -0.72
+        elif candidate.family == "near_pass_expansion":
+            strategy = candidate.overlay["strategy"]
+            aggregator = strategy["aggregator"]
+            assert len(strategy["strategies"]) == 5
+            assert 1.00 <= aggregator["buy_threshold"] <= 1.10
+            assert 0.94 <= aggregator["buy_threshold_uptrend"] <= 1.10
+            assert -0.90 <= aggregator["sell_threshold"] <= -0.74
+        elif candidate.family == "standard_gate_bridge":
+            strategy = candidate.overlay["strategy"]
+            aggregator = strategy["aggregator"]
+            assert len(strategy["strategies"]) == 5
+            assert 1.04 <= aggregator["buy_threshold"] <= 1.09
+            assert 1.01 <= aggregator["buy_threshold_uptrend"] <= 1.09
+            assert -0.78 <= aggregator["sell_threshold"] <= -0.71
+        elif candidate.family == "near_miss_trade_lift":
+            strategy = candidate.overlay["strategy"]
+            aggregator = strategy["aggregator"]
+            assert len(strategy["strategies"]) == 5
+            assert 1.05 <= aggregator["buy_threshold"] <= 1.10
+            assert 1.03 <= aggregator["buy_threshold_uptrend"] <= 1.10
+            assert -0.80 <= aggregator["sell_threshold"] <= -0.74
+        elif candidate.family == "trend_pullback_overlay":
+            strategy = candidate.overlay["strategy"]
+            aggregator = strategy["aggregator"]
+            assert len(strategy["strategies"]) == 6
+            assert strategy["strategies"][-1]["name"] == "trend_pullback"
+            assert 1.10 <= aggregator["buy_threshold"] <= 1.35
+            assert 0.95 <= aggregator["buy_threshold_uptrend"] <= 1.15
+            assert -0.86 <= aggregator["sell_threshold"] <= -0.74
+        else:
+            raise AssertionError(f"unexpected candidate family: {candidate.family}")
+
+
+def test_autoresearch_loop_parses_family_filter() -> None:
+    families = _parse_families("aggregator_thresholds, indicator_thresholds")
+
+    assert families == ("aggregator_thresholds", "indicator_thresholds")
+
+
+def test_autoresearch_loop_rejects_unknown_family() -> None:
+    with pytest.raises(ValueError, match="Unsupported candidate families"):
+        _parse_families("aggregator_thresholds,nope")
+
+
+def test_autoresearch_loop_focused_aggregator_candidates_stay_near_best_region() -> None:
+    candidates = [
+        generate_candidate(
+            index,
+            seed=42,
+            families=("aggregator_thresholds",),
+            aggregator_focus=True,
+        )
+        for index in range(1, 30)
+    ]
+
+    for candidate in candidates:
+        aggregator = candidate.overlay["strategy"]["aggregator"]
+        per_symbol = candidate.overlay["strategy"]["per_symbol_aggregator_config"]["SOLUSDT"]
+        assert 0.98 <= aggregator["buy_threshold"] <= 1.14
+        assert 0.90 <= aggregator["buy_threshold_uptrend"] <= 1.14
+        assert -0.92 <= aggregator["sell_threshold"] <= -0.72
+        assert per_symbol["min_agreement"] == 1
+
+
+def test_autoresearch_loop_combined_focus_keeps_full_strategy_stack() -> None:
+    candidate = generate_candidate(1, seed=42, families=("combined_focus",))
+
+    assert candidate.family == "combined_focus"
+    assert set(candidate.overlay) == {"trading_execution", "strategy"}
+    strategy = candidate.overlay["strategy"]
+    assert [entry["name"] for entry in strategy["strategies"]] == [
+        "rsi_reversal",
+        "macd_histogram",
+        "bollinger_bounce",
+        "cci_breakout",
+        "vwap_reversion",
+    ]
+    assert strategy["per_symbol_aggregator_config"]["SOLUSDT"]["min_agreement"] == 1
+    assert "sl_atr_multiplier" in candidate.overlay["trading_execution"]
+
+
+def test_autoresearch_loop_near_pass_expansion_targets_more_trades_region() -> None:
+    candidate = generate_candidate(1, seed=42, families=("near_pass_expansion",))
+
+    assert candidate.family == "near_pass_expansion"
+    strategy = candidate.overlay["strategy"]
+    execution = candidate.overlay["trading_execution"]
+    bollinger = {entry["name"]: entry["config"] for entry in strategy["strategies"]}[
+        "bollinger_bounce"
+    ]
+    macd = {entry["name"]: entry["config"] for entry in strategy["strategies"]}["macd_histogram"]
+
+    assert strategy["per_symbol_aggregator_config"]["SOLUSDT"]["min_agreement"] == 1
+    assert strategy["per_symbol_aggregator_config"]["SOLUSDT"]["sell_min_agreement"] == 2
+    assert 0.008 <= bollinger["band_distance_threshold"] <= 0.014
+    assert 0.0035 <= macd["atr_min_pct"] <= 0.007
+    assert 1.45 <= execution["sl_atr_multiplier"] <= 1.85
+    assert 2.6 <= execution["tp_atr_multiplier"] <= 3.4
+
+
+def test_autoresearch_loop_standard_gate_bridge_targets_near_miss_region() -> None:
+    candidate = generate_candidate(1, seed=42, families=("standard_gate_bridge",))
+
+    assert candidate.family == "standard_gate_bridge"
+    strategy = candidate.overlay["strategy"]
+    execution = candidate.overlay["trading_execution"]
+    strategies_by_name = {entry["name"]: entry["config"] for entry in strategy["strategies"]}
+    aggregator = strategy["aggregator"]
+    per_symbol = strategy["per_symbol_aggregator_config"]["SOLUSDT"]
+
+    assert 1.04 <= aggregator["buy_threshold"] <= 1.09
+    assert 1.01 <= aggregator["buy_threshold_uptrend"] <= aggregator["buy_threshold"]
+    assert -0.78 <= aggregator["sell_threshold"] <= -0.71
+    assert per_symbol["min_agreement"] == 1
+    assert 0.0045 <= strategies_by_name["bollinger_bounce"]["band_distance_threshold"] <= 0.0065
+    assert 0.0047 <= strategies_by_name["macd_histogram"]["atr_min_pct"] <= 0.0089
+    assert 0.0108 <= strategies_by_name["cci_breakout"]["atr_min_pct"] <= 0.0124
+    assert 2.05 <= execution["sl_atr_multiplier"] <= 2.35
+    assert 3.20 <= execution["tp_atr_multiplier"] <= 4.75
+
+
+def test_autoresearch_loop_near_miss_trade_lift_stays_close_to_best_candidate() -> None:
+    candidate = generate_candidate(1, seed=42, families=("near_miss_trade_lift",))
+
+    assert candidate.family == "near_miss_trade_lift"
+    strategy = candidate.overlay["strategy"]
+    execution = candidate.overlay["trading_execution"]
+    strategies_by_name = {entry["name"]: entry["config"] for entry in strategy["strategies"]}
+    aggregator = strategy["aggregator"]
+    per_symbol = strategy["per_symbol_aggregator_config"]["SOLUSDT"]
+
+    assert 1.05 <= aggregator["buy_threshold"] <= 1.10
+    assert 1.03 <= aggregator["buy_threshold_uptrend"] <= aggregator["buy_threshold"]
+    assert -0.80 <= aggregator["sell_threshold"] <= -0.74
+    assert per_symbol["min_agreement"] == 1
+    assert 0.0045 <= strategies_by_name["bollinger_bounce"]["band_distance_threshold"] <= 0.0058
+    assert 0.0075 <= strategies_by_name["macd_histogram"]["atr_min_pct"] <= 0.0092
+    assert 0.0105 <= strategies_by_name["cci_breakout"]["atr_min_pct"] <= 0.0118
+    assert 1.85 <= strategies_by_name["vwap_reversion"]["vwap_atr_multiplier"] <= 2.12
+    assert 2.15 <= execution["sl_atr_multiplier"] <= 2.35
+    assert 3.70 <= execution["tp_atr_multiplier"] <= 4.20
+
+
+def test_autoresearch_loop_trend_pullback_overlay_adds_complementary_signal() -> None:
+    candidate = generate_candidate(1, seed=42, families=("trend_pullback_overlay",))
+
+    assert candidate.family == "trend_pullback_overlay"
+    strategy = candidate.overlay["strategy"]
+    execution = candidate.overlay["trading_execution"]
+    strategy_names = [entry["name"] for entry in strategy["strategies"]]
+    pullback_config = strategy["strategies"][-1]["config"]
+    aggregator = strategy["aggregator"]
+    per_symbol = strategy["per_symbol_aggregator_config"]["SOLUSDT"]
+
+    assert strategy_names == [
+        "rsi_reversal",
+        "macd_histogram",
+        "bollinger_bounce",
+        "cci_breakout",
+        "vwap_reversion",
+        "trend_pullback",
+    ]
+    assert 1.10 <= aggregator["buy_threshold"] <= 1.35
+    assert 0.95 <= aggregator["buy_threshold_uptrend"] <= aggregator["buy_threshold"]
+    assert 0.0 <= aggregator["min_confidence"] <= 0.45
+    assert per_symbol["min_agreement"] == 1
+    assert pullback_config["rsi_reclaim_level"] in {48, 50, 52}
+    assert 0.006 <= pullback_config["min_trend_strength_pct"] <= 0.012
+    assert 0.015 <= pullback_config["max_pullback_distance_pct"] <= 0.030
+    assert 0.015 <= pullback_config["vwap_pullback_distance_pct"] <= 0.035
+    assert 2.10 <= execution["sl_atr_multiplier"] <= 2.45
+    assert 3.60 <= execution["tp_atr_multiplier"] <= 4.40
+
+
+def test_autoresearch_loop_builds_existing_runner_command() -> None:
+    args = argparse.Namespace(
+        config="config/settings.autoresearch.yaml",
+        output_dir="research",
+        symbol="SOLUSDT",
+        timeframe="4h",
+        start="2024-01-01",
+        end="2026-01-01",
+        train_months=3,
+        test_months=2,
+        bootstrap=100,
+        seed=7,
+        gate_profile="sparse_trend_3_2",
+        timeout_seconds=600,
+    )
+
+    command = build_run_command(
+        args,
+        overlay_path=Path("research/candidates/0001.yaml"),
+        description="candidate",
+    )
+
+    assert command[:2] == [sys.executable, "scripts/run_autoresearch.py"]
+    assert "--overlay" in command
+    assert command[command.index("--overlay") + 1] == "research/candidates/0001.yaml"
+    assert command[command.index("--description") + 1] == "candidate"
+    assert command[command.index("--gate-profile") + 1] == "sparse_trend_3_2"
+
+
+def test_autoresearch_loop_captures_child_output(tmp_path: Path) -> None:
+    log_path = tmp_path / "loop.log"
+
+    code = _run_command(
+        [sys.executable, "-c", "import sys; print('out'); print('err', file=sys.stderr)"],
+        log_path=log_path,
+    )
+
+    assert code == 0
+    log = log_path.read_text(encoding="utf-8")
+    assert "[stdout]\nout" in log
+    assert "[stderr]\nerr" in log

--- a/tests/test_autoresearch.py
+++ b/tests/test_autoresearch.py
@@ -408,6 +408,8 @@ def test_autoresearch_loop_candidate_ranges_stay_bounded() -> None:
             "breakout_retest_standalone",
             "volatility_squeeze_standalone",
             "mtf_breakout_standalone",
+            "range_reversion_bounded",
+            "funding_primary_standalone",
         }:
             strategy = candidate.overlay["strategy"]
             assert len(strategy["strategies"]) == 6
@@ -657,6 +659,31 @@ def test_autoresearch_loop_mtf_breakout_standalone_sets_1h_timeframe() -> None:
     assert candidate.family == "mtf_breakout_standalone"
     assert candidate.overlay["trading"]["timeframe"] == "1h"
     assert candidate.overlay["strategy"]["strategies"][0]["name"] == "mtf_breakout"
+
+
+def test_autoresearch_loop_range_reversion_bounded_has_time_stop() -> None:
+    candidate = generate_candidate(
+        9,
+        seed=42,
+        symbol="ETHUSDT",
+        families=("range_reversion_bounded",),
+    )
+
+    assert candidate.family == "range_reversion_bounded"
+    assert candidate.overlay["strategy"]["strategies"][0]["name"] == "bollinger_bounce"
+    assert candidate.overlay["trading_execution"]["exit_rules"]["time_stop_minutes"] >= 2880
+
+
+def test_autoresearch_loop_funding_primary_standalone_single_strategy() -> None:
+    candidate = generate_candidate(
+        10,
+        seed=42,
+        symbol="BTCUSDT",
+        families=("funding_primary_standalone",),
+    )
+
+    assert candidate.family == "funding_primary_standalone"
+    assert candidate.overlay["strategy"]["strategies"][0]["name"] == "funding_rate"
 
 
 def test_autoresearch_loop_builds_existing_runner_command() -> None:

--- a/tests/test_autoresearch.py
+++ b/tests/test_autoresearch.py
@@ -354,6 +354,8 @@ def test_autoresearch_loop_candidate_ranges_stay_bounded() -> None:
             "volatility_squeeze_overlay",
             "funding_extreme_overlay",
             "regime_gated_pullback_overlay",
+            "breakout_retest_bridge",
+            "regime_gated_pullback_bridge",
         }:
             strategy = candidate.overlay["strategy"]
             assert len(strategy["strategies"]) == 6

--- a/tests/test_backtest_futures.py
+++ b/tests/test_backtest_futures.py
@@ -275,3 +275,50 @@ def test_fixed_notional_default_preserves_all_capital_futures_sizing():
     quantity = engine._calculate_entry_qty(80.0, atr=0.0)
 
     assert quantity == pytest.approx(37.5)
+
+
+def test_quantity_step_truncates_fixed_notional_futures_size():
+    engine = BacktestEngine(
+        BacktestConfig(
+            symbol="SOLUSDT",
+            timeframe="1h",
+            start_date="2023-01-01",
+            end_date="2023-01-02",
+            initial_capital=1000.0,
+            fee_rate=0.0,
+            futures_mode=True,
+            futures_leverage=3,
+            fixed_notional_usdt=22.0,
+            quantity_step_size=0.01,
+            min_notional_usdt=20.0,
+        ),
+        IndicatorReader({}),
+    )
+
+    quantity = engine._calculate_entry_qty(79.0, atr=0.0)
+
+    assert quantity == pytest.approx(0.27)
+
+
+def test_quantity_step_bumps_when_truncation_drops_below_min_notional():
+    engine = BacktestEngine(
+        BacktestConfig(
+            symbol="ETHUSDT",
+            timeframe="1h",
+            start_date="2023-01-01",
+            end_date="2023-01-02",
+            initial_capital=1000.0,
+            fee_rate=0.0,
+            futures_mode=True,
+            futures_leverage=3,
+            fixed_notional_usdt=20.0,
+            quantity_step_size=0.001,
+            min_notional_usdt=20.0,
+        ),
+        IndicatorReader({}),
+    )
+
+    quantity = engine._calculate_entry_qty(2340.0, atr=0.0)
+
+    assert quantity == pytest.approx(0.009)
+    assert quantity * 2340.0 >= 20.0

--- a/tests/test_backtest_futures.py
+++ b/tests/test_backtest_futures.py
@@ -234,3 +234,44 @@ def test_higher_leverage_allows_larger_position_sizes_with_same_cash():
     assert low_qty == pytest.approx(20.0)
     assert high_qty == pytest.approx(100.0)
     assert high_qty > low_qty
+
+
+def test_fixed_notional_caps_futures_position_size():
+    engine = BacktestEngine(
+        BacktestConfig(
+            symbol="SOLUSDT",
+            timeframe="1h",
+            start_date="2023-01-01",
+            end_date="2023-01-02",
+            initial_capital=1000.0,
+            fee_rate=0.0,
+            futures_mode=True,
+            futures_leverage=3,
+            fixed_notional_usdt=22.0,
+        ),
+        IndicatorReader({}),
+    )
+
+    quantity = engine._calculate_entry_qty(80.0, atr=0.0)
+
+    assert quantity == pytest.approx(22.0 / 80.0)
+
+
+def test_fixed_notional_default_preserves_all_capital_futures_sizing():
+    engine = BacktestEngine(
+        BacktestConfig(
+            symbol="SOLUSDT",
+            timeframe="1h",
+            start_date="2023-01-01",
+            end_date="2023-01-02",
+            initial_capital=1000.0,
+            fee_rate=0.0,
+            futures_mode=True,
+            futures_leverage=3,
+        ),
+        IndicatorReader({}),
+    )
+
+    quantity = engine._calculate_entry_qty(80.0, atr=0.0)
+
+    assert quantity == pytest.approx(37.5)

--- a/tests/test_config_merge.py
+++ b/tests/test_config_merge.py
@@ -211,8 +211,6 @@ log_level: INFO
 
 trading:
   pairs:
-    - BTCUSDT
-    - ETHUSDT
     - SOLUSDT
   timeframe: 1h
 
@@ -269,8 +267,6 @@ trading_execution:
 futures:
   enabled: true
   symbols:
-    - BTCUSDT
-    - ETHUSDT
     - SOLUSDT
   default_leverage: 3
   max_leverage: 10
@@ -295,7 +291,7 @@ strategy:
         volatility_regime_filter: true
         atr_pct_threshold: 0.005
   global_trend_filter_enabled: true
-  global_trend_filter_buffer_pct: 0.05
+  global_trend_filter_buffer_pct: 0.0
   aggregator:
     min_agreement: 1
     buy_threshold: 0.6

--- a/tests/test_funding_normalization_probe.py
+++ b/tests/test_funding_normalization_probe.py
@@ -7,6 +7,7 @@ from scripts.probe_funding_normalization import (
     NormalizationSide,
     ProbeConfig,
     detect_normalization_events,
+    entry_threshold_negative_tail,
     evaluate_pulse,
     index_price_bars,
     probe_funding_series,
@@ -93,6 +94,14 @@ def test_probe_funding_series_computes_net_forward_after_drag() -> None:
 def test_evaluate_pulse_sparse_when_below_min_events() -> None:
     summary = probe_funding_series([], _price_rows(4), _config(min_events_for_pulse=5))
     assert evaluate_pulse(summary, _config(min_events_for_pulse=5)) == "NO_PULSE"
+
+
+def test_negative_tail_threshold_uses_extreme_quantile() -> None:
+    negatives = [-0.0001 * (i + 1) for i in range(15)]
+    rates = [0.0001] * 50 + negatives
+    threshold = entry_threshold_negative_tail(rates, tail_pct=20.0)
+    assert threshold >= 0.0001
+    assert threshold <= 0.0020
 
 
 def test_evaluate_pulse_has_pulse_with_positive_net_and_enough_events() -> None:

--- a/tests/test_funding_normalization_probe.py
+++ b/tests/test_funding_normalization_probe.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+from scripts.probe_funding_normalization import (
+    FundingTick,
+    NormalizationSide,
+    ProbeConfig,
+    detect_normalization_events,
+    evaluate_pulse,
+    index_price_bars,
+    probe_funding_series,
+)
+
+
+def _config(**overrides: object) -> ProbeConfig:
+    values = {
+        "symbol": "ETHUSDT",
+        "timeframe": "1h",
+        "start": "2024-01-01T00:00:00",
+        "end": "2024-02-01T00:00:00",
+        "entry_threshold": 0.0005,
+        "exit_threshold": 0.00015,
+        "forward_bars_12h": 2,
+        "forward_bars_24h": 4,
+        "min_events_for_pulse": 2,
+        "max_profit_concentration_pct": 30.0,
+        "long_only": True,
+    }
+    values.update(overrides)
+    return ProbeConfig(**values)
+
+
+def _price_rows(
+    count: int, start_price: float = 100.0, step: float = 1.0
+) -> list[dict[str, object]]:
+    rows: list[dict[str, object]] = []
+    for index in range(count):
+        price = start_price + step * index
+        rows.append(
+            {
+                "time": datetime(2024, 1, 1) + timedelta(hours=index),
+                "close_price": price,
+            }
+        )
+    return rows
+
+
+def test_detect_normalization_fires_once_per_negative_cycle() -> None:
+    base = datetime(2024, 1, 1)
+    ticks = [
+        FundingTick(base, -0.0008),
+        FundingTick(base + timedelta(hours=8), -0.0007),
+        FundingTick(base + timedelta(hours=16), 0.00005),
+        FundingTick(base + timedelta(hours=24), 0.00004),
+        FundingTick(base + timedelta(hours=32), -0.0009),
+        FundingTick(base + timedelta(hours=40), 0.00003),
+    ]
+    price_rows = _price_rows(48)
+    events = detect_normalization_events(
+        ticks,
+        *index_price_bars(price_rows),
+        _config(forward_bars_12h=2, forward_bars_24h=4),
+    )
+
+    long_events = [event for event in events if event.side == NormalizationSide.LONG_FROM_NEGATIVE]
+    assert len(long_events) == 2
+    assert long_events[0].prior_extreme_rate == -0.0008
+    assert long_events[1].prior_extreme_rate == -0.0009
+
+
+def test_probe_funding_series_computes_net_forward_after_drag() -> None:
+    base = datetime(2024, 1, 1)
+    ticks = [
+        FundingTick(base, -0.0006),
+        FundingTick(base + timedelta(hours=8), 0.00005),
+        FundingTick(base + timedelta(hours=16), 0.0002),
+    ]
+    price_rows = _price_rows(32, start_price=100.0, step=2.0)
+    summary = probe_funding_series(
+        ticks,
+        price_rows,
+        _config(forward_bars_12h=12, forward_bars_24h=16),
+    )
+
+    assert len(summary.long_events) == 1
+    event = summary.long_events[0]
+    assert event.gross_forward_12h_pct > 0
+    assert event.funding_drag_12h_pct > 0
+    assert event.net_forward_12h_pct < event.gross_forward_12h_pct
+
+
+def test_evaluate_pulse_sparse_when_below_min_events() -> None:
+    summary = probe_funding_series([], _price_rows(4), _config(min_events_for_pulse=5))
+    assert evaluate_pulse(summary, _config(min_events_for_pulse=5)) == "NO_PULSE"
+
+
+def test_evaluate_pulse_has_pulse_with_positive_net_and_enough_events() -> None:
+    base = datetime(2024, 1, 1)
+    ticks = []
+    for cycle in range(3):
+        offset = cycle * 48
+        ticks.extend(
+            [
+                FundingTick(base + timedelta(hours=offset), -0.0007),
+                FundingTick(base + timedelta(hours=offset + 8), 0.00004),
+            ]
+        )
+    price_rows = _price_rows(200, start_price=100.0, step=0.5)
+    summary = probe_funding_series(
+        ticks,
+        price_rows,
+        _config(forward_bars_12h=2, forward_bars_24h=4, min_events_for_pulse=2),
+    )
+    verdict = evaluate_pulse(
+        summary,
+        _config(forward_bars_12h=2, forward_bars_24h=4, min_events_for_pulse=2),
+    )
+    assert verdict in {"HAS_PULSE", "WEAK_EDGE", "CONCENTRATED", "SPARSE"}
+    assert len(summary.long_events) >= 2

--- a/tests/test_futures_config.py
+++ b/tests/test_futures_config.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from unittest.mock import MagicMock
+
 import pytest
 import yaml
 
@@ -61,8 +63,10 @@ class TestFuturesConfig:
         assert settings.mode == "paper"
         assert settings.trading_pairs == ["BTCUSDT", "ETHUSDT"]
 
-    def test_futures_enabled_valid_config(self, base_config, tmp_path):
+    def test_futures_enabled_valid_config(self, base_config, tmp_path, monkeypatch):
         """Test loading valid futures configuration."""
+        logger = MagicMock()
+        monkeypatch.setattr("src.main.get_logger", lambda _name: logger)
         base_config["futures"] = {
             "enabled": True,
             "symbols": ["BTCUSDT", "ETHUSDT"],
@@ -83,6 +87,7 @@ class TestFuturesConfig:
         # Should load without errors
         assert settings.mode == "paper"
         assert settings.trading_execution.test_mode is True
+        assert "leverage=5x, max_leverage=10x" in logger.info.call_args.args[0]
 
     def test_futures_max_leverage_enforced_rejects_50x(self, base_config, tmp_path):
         """Test that leverage > 20x is rejected."""

--- a/tests/test_futures_executor.py
+++ b/tests/test_futures_executor.py
@@ -87,6 +87,7 @@ class TestFuturesTradingExecutor:
         risk_manager.check_max_leverage.return_value = (True, "OK")
         risk_manager.check_margin_usage.return_value = (True, "OK")
         risk_manager.check_liquidation_buffer.return_value = (True, "OK")
+        risk_manager.check_position_limit.return_value = (True, "OK")
 
         metrics = MagicMock(spec=ExecutionMetrics)
 
@@ -113,7 +114,7 @@ class TestFuturesTradingExecutor:
         )
 
         with pytest.raises(RuntimeError) as exc_info:
-            await executor.place_futures_order("BTCUSDT", "BUY", 0.01)
+            await executor.place_futures_order("BTCUSDT", "BUY", 0.01, reference_price=50000.0)
 
         assert "disabled" in str(exc_info.value).lower()
 
@@ -163,11 +164,52 @@ class TestFuturesTradingExecutor:
             quantity=0.009670032130879488,
             position_side="LONG",
             reduce_only=False,
+            reference_price=2276.25,
         )
 
         executor._portfolio_manager.open_position.assert_awaited_once()
         open_kwargs = executor._portfolio_manager.open_position.await_args.kwargs
         assert open_kwargs["quantity"] == pytest.approx(0.009)
+        executor._risk_manager.register_open_position.assert_called_once_with(
+            "ETHUSDT",
+            pytest.approx(0.009 * 2276.25),
+            pytest.approx(2276.25),
+        )
+
+    @pytest.mark.asyncio
+    async def test_place_futures_order_blocks_position_limit_before_exchange_order(self, executor):
+        mock_client = MagicMock()
+        mock_client.get_account_info = AsyncMock(
+            return_value=MagicMock(total_margin_balance=5000.0, available_balance=5000.0)
+        )
+        executor._client = mock_client
+        executor._risk_manager.check_position_limit.return_value = (
+            False,
+            "Position size exceeds configured max",
+        )
+
+        with pytest.raises(RuntimeError, match="Position limit check failed"):
+            await executor.place_futures_order(
+                "BTCUSDT",
+                "BUY",
+                0.01,
+                reference_price=50000.0,
+            )
+
+        mock_client.place_order.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_place_futures_order_requires_reference_price_for_open(self, executor):
+        mock_client = MagicMock()
+        mock_client.get_account_info = AsyncMock(
+            return_value=MagicMock(total_margin_balance=5000.0, available_balance=5000.0)
+        )
+        executor._client = mock_client
+
+        with pytest.raises(ValueError, match="reference_price"):
+            await executor.place_futures_order("BTCUSDT", "BUY", 0.01)
+
+        mock_client.place_order.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_on_signal_buy_opens_long(self, executor):
@@ -743,6 +785,11 @@ class TestFuturesTradingExecutor:
         assert "BTCUSDT" in executor._sl_tp_orders
         assert executor._sl_tp_orders["BTCUSDT"]["sl_order_id"] == "sl_r"
         assert executor._sl_tp_orders["BTCUSDT"]["tp_order_id"] == "tp_r"
+        executor._risk_manager.register_open_position.assert_called_once_with(
+            "BTCUSDT",
+            pytest.approx(500.0),
+            pytest.approx(50000.0),
+        )
 
     @pytest.mark.asyncio
     async def test_recover_skips_symbol_with_no_open_position(self, executor):
@@ -809,6 +856,7 @@ class TestFuturesTradingExecutor:
 
         # Tracking should be cleaned up
         assert "BTCUSDT" not in executor._sl_tp_orders
+        executor._risk_manager.register_close_position.assert_called_once_with("BTCUSDT")
 
     @pytest.mark.asyncio
     async def test_monitor_sends_close_notification_on_sl_close(self, executor):
@@ -899,6 +947,8 @@ class TestFuturesTradingExecutor:
         assert call_kwargs["price"] == pytest.approx(74_949.1)
         assert call_kwargs["pnl"] == pytest.approx(-0.7689)
         assert call_kwargs["close_reason"] == "stop_loss"
+        executor._risk_manager.record_trade.assert_called_once_with("BTCUSDT", -0.7689, 5000.0)
+        executor._risk_manager.register_close_position.assert_called_once_with("BTCUSDT")
 
     @pytest.mark.asyncio
     async def test_monitor_falls_back_to_mark_when_binance_fill_lookup_fails(self, executor):
@@ -970,6 +1020,39 @@ class TestFuturesTradingExecutor:
         assert call_kwargs["close_reason"] == "take_profit"
         assert call_kwargs["pnl"] == pytest.approx((84100.0 - 80000.0) * 0.01)
         assert "BTCUSDT" not in executor._sl_tp_orders
+
+    @pytest.mark.asyncio
+    async def test_monitor_software_sl_records_risk_close_after_estimating_pnl(self, executor):
+        position = FuturesPositionInfo(
+            symbol="BTCUSDT",
+            position_side="LONG",
+            position_amt=0.01,
+            entry_price=80000.0,
+            mark_price=78000.0,
+            liquidation_price=70000.0,
+            leverage=5,
+            isolated_margin=100.0,
+            unrealized_pnl=-20.0,
+            notional_value=780.0,
+        )
+        mock_client = MagicMock()
+        mock_client.get_account_info = AsyncMock(
+            return_value=MagicMock(total_margin_balance=5000.0, available_balance=5000.0)
+        )
+        mock_client.get_position_risk = AsyncMock(
+            side_effect=lambda symbol: [position] if symbol == "BTCUSDT" else []
+        )
+        mock_client.place_order = AsyncMock(
+            return_value=_make_order(order_id="software_close", side="SELL", reduce_only=True)
+        )
+        executor._client = mock_client
+        executor._notifier = AsyncMock()
+        executor._sl_tp_prices["BTCUSDT"] = {"sl_price": 78100.0, "tp_price": 84000.0}
+
+        await executor._monitor_and_update()
+
+        executor._risk_manager.record_trade.assert_called_once_with("BTCUSDT", -20.0, 5000.0)
+        executor._risk_manager.register_close_position.assert_called_once_with("BTCUSDT")
 
     @pytest.mark.asyncio
     async def test_liquidation_buffer_check(self, executor):

--- a/tests/test_futures_executor.py
+++ b/tests/test_futures_executor.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import time
+from dataclasses import replace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -1053,6 +1055,113 @@ class TestFuturesTradingExecutor:
 
         executor._risk_manager.record_trade.assert_called_once_with("BTCUSDT", -20.0, 5000.0)
         executor._risk_manager.register_close_position.assert_called_once_with("BTCUSDT")
+
+    @pytest.mark.asyncio
+    async def test_monitor_software_time_stop_closes_and_cancels_exchange_orders(self, executor):
+        executor._config = replace(executor._config, time_stop_minutes=60)
+        position = FuturesPositionInfo(
+            symbol="BTCUSDT",
+            position_side="LONG",
+            position_amt=0.01,
+            entry_price=80000.0,
+            mark_price=80100.0,
+            liquidation_price=70000.0,
+            leverage=5,
+            isolated_margin=100.0,
+            unrealized_pnl=1.0,
+            notional_value=801.0,
+        )
+        mock_client = MagicMock()
+        mock_client.get_account_info = AsyncMock(
+            return_value=MagicMock(total_margin_balance=5000.0, available_balance=5000.0)
+        )
+        mock_client.get_position_risk = AsyncMock(
+            side_effect=lambda symbol: [position] if symbol == "BTCUSDT" else []
+        )
+        mock_client.cancel_algo_order = AsyncMock()
+        mock_client.place_order = AsyncMock(
+            return_value=_make_order(order_id="time_stop_close", side="SELL", reduce_only=True)
+        )
+        executor._client = mock_client
+        executor._notifier = AsyncMock()
+        executor._sl_tp_prices["BTCUSDT"] = {
+            "sl_price": 78000.0,
+            "tp_price": 84000.0,
+            "entry_price": 80000.0,
+            "atr_14": 1000.0,
+            "high_water_mark": 80000.0,
+            "opened_at": time.time() - 61 * 60,
+        }
+        executor._sl_tp_orders["BTCUSDT"] = {
+            "sl_order_id": "sl_algo",
+            "tp_order_id": "tp_algo",
+            "sl_is_algo": True,
+            "tp_is_algo": True,
+        }
+
+        await executor._monitor_and_update()
+
+        assert mock_client.cancel_algo_order.await_count == 2
+        executor._notifier.send_trade_alert.assert_awaited_once()
+        assert executor._notifier.send_trade_alert.await_args.kwargs["close_reason"] == "time_stop"
+        assert "BTCUSDT" not in executor._sl_tp_orders
+
+    @pytest.mark.asyncio
+    async def test_monitor_software_trailing_stop_closes_after_activation(self, executor):
+        executor._config = replace(
+            executor._config,
+            trailing_activate_atr=1.0,
+            trailing_offset_atr=0.5,
+        )
+        marks = iter([81500.0, 80900.0])
+
+        async def position_risk(symbol: str):
+            if symbol != "BTCUSDT":
+                return []
+            mark = next(marks)
+            return [
+                FuturesPositionInfo(
+                    symbol="BTCUSDT",
+                    position_side="LONG",
+                    position_amt=0.01,
+                    entry_price=80000.0,
+                    mark_price=mark,
+                    liquidation_price=70000.0,
+                    leverage=5,
+                    isolated_margin=100.0,
+                    unrealized_pnl=(mark - 80000.0) * 0.01,
+                    notional_value=mark * 0.01,
+                )
+            ]
+
+        mock_client = MagicMock()
+        mock_client.get_account_info = AsyncMock(
+            return_value=MagicMock(total_margin_balance=5000.0, available_balance=5000.0)
+        )
+        mock_client.get_position_risk = AsyncMock(side_effect=position_risk)
+        mock_client.place_order = AsyncMock(
+            return_value=_make_order(order_id="trailing_close", side="SELL", reduce_only=True)
+        )
+        executor._client = mock_client
+        executor._notifier = AsyncMock()
+        executor._sl_tp_prices["BTCUSDT"] = {
+            "sl_price": 78000.0,
+            "tp_price": 84000.0,
+            "entry_price": 80000.0,
+            "atr_14": 1000.0,
+            "high_water_mark": 80000.0,
+            "opened_at": time.time(),
+        }
+
+        await executor._monitor_and_update()
+        assert executor._sl_tp_prices["BTCUSDT"]["sl_price"] == pytest.approx(81000.0)
+        mock_client.place_order.assert_not_awaited()
+
+        await executor._monitor_and_update()
+
+        mock_client.place_order.assert_awaited_once()
+        executor._notifier.send_trade_alert.assert_awaited_once()
+        assert executor._notifier.send_trade_alert.await_args.kwargs["close_reason"] == "stop_loss"
 
     @pytest.mark.asyncio
     async def test_liquidation_buffer_check(self, executor):

--- a/tests/test_notify_systemd_failure.py
+++ b/tests/test_notify_systemd_failure.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
+from argparse import Namespace
 from unittest.mock import MagicMock
 
 import pytest
 
-from scripts.notify_systemd_failure import build_message, send_failure_alert, telegram_enabled
+from scripts.notify_systemd_failure import build_message, main, send_failure_alert, telegram_enabled
 
 
 def test_telegram_enabled_accepts_common_true_values() -> None:
@@ -62,3 +63,17 @@ def test_send_failure_alert_posts_encoded_payload(monkeypatch) -> None:
     assert request.full_url.endswith("/botsecret-token/sendMessage")
     assert b"chat_id=12345" in request.data
     assert b"crypto-agent-test.service" in request.data
+
+
+def test_main_does_not_log_exception_details(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(
+        "scripts.notify_systemd_failure.parse_args",
+        lambda: Namespace(unit="crypto-agent-test.service"),
+    )
+    monkeypatch.setattr(
+        "scripts.notify_systemd_failure.send_failure_alert",
+        MagicMock(side_effect=RuntimeError("secret-token")),
+    )
+
+    assert main() == 1
+    assert capsys.readouterr().err == "Failed to send Telegram failure alert\n"

--- a/tests/test_notify_systemd_failure.py
+++ b/tests/test_notify_systemd_failure.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from scripts.notify_systemd_failure import build_message, send_failure_alert, telegram_enabled
+
+
+def test_telegram_enabled_accepts_common_true_values() -> None:
+    assert telegram_enabled("true")
+    assert telegram_enabled("YES")
+    assert not telegram_enabled("false")
+    assert not telegram_enabled(None)
+
+
+def test_build_message_contains_unit_and_host() -> None:
+    message = build_message("crypto-agent-test.service", "prod-host")
+
+    assert "prod-host" in message
+    assert "crypto-agent-test.service" in message
+
+
+def test_send_failure_alert_requires_enabled_config() -> None:
+    with pytest.raises(RuntimeError, match="disabled"):
+        send_failure_alert(
+            unit="test.service",
+            hostname="prod-host",
+            bot_token="token",
+            chat_id="chat",
+            enabled="false",
+        )
+
+
+def test_send_failure_alert_requires_complete_credentials() -> None:
+    with pytest.raises(RuntimeError, match="incomplete"):
+        send_failure_alert(
+            unit="test.service",
+            hostname="prod-host",
+            bot_token=None,
+            chat_id="chat",
+            enabled="true",
+        )
+
+
+def test_send_failure_alert_posts_encoded_payload(monkeypatch) -> None:
+    response = MagicMock()
+    response.read.return_value = b'{"ok": true}'
+    response.__enter__.return_value = response
+    urlopen = MagicMock(return_value=response)
+    monkeypatch.setattr("urllib.request.urlopen", urlopen)
+
+    send_failure_alert(
+        unit="crypto-agent-test.service",
+        hostname="prod-host",
+        bot_token="secret-token",
+        chat_id="12345",
+        enabled="true",
+    )
+
+    request = urlopen.call_args.args[0]
+    assert request.full_url.endswith("/botsecret-token/sendMessage")
+    assert b"chat_id=12345" in request.data
+    assert b"crypto-agent-test.service" in request.data

--- a/tests/test_paper_executor.py
+++ b/tests/test_paper_executor.py
@@ -732,3 +732,36 @@ class TestSignalIgnoredLogging:
             call for call in mock_event_log.log.call_args_list if call.args[0] == "signal_ignored"
         ][0]
         assert ignored_call.args[1]["reason"] == "futures_sell_from_flat_long_only"
+
+
+class TestRiskCheckLogging:
+    @pytest.mark.asyncio
+    async def test_blocked_buy_logs_one_risk_check_failed_event(self):
+        executor = _make_executor()
+        executor._risk_manager.is_trading_allowed.return_value = (False, "Daily loss limit")
+        mock_event_log = AsyncMock()
+        mock_event_log.log = AsyncMock()
+        executor._event_log = mock_event_log
+        signal = Signal(
+            type=SignalType.BUY,
+            symbol="BTCUSDT",
+            price=50000.0,
+            confidence=0.9,
+            reason="Test BUY",
+            indicators={"close_price": 50000.0},
+            trading_mode="spot",
+        )
+
+        await executor.on_signal(signal)
+
+        risk_failures = [
+            call
+            for call in mock_event_log.log.call_args_list
+            if call.args[0] == "risk_check_failed"
+        ]
+        assert len(risk_failures) == 1
+        assert risk_failures[0].args[1] == {
+            "symbol": "BTCUSDT",
+            "reason": "Daily loss limit",
+            "stage": "paper_buy",
+        }

--- a/tests/test_paper_validation_report.py
+++ b/tests/test_paper_validation_report.py
@@ -4,7 +4,7 @@ import json
 import os
 import subprocess
 import sys
-from datetime import date
+from datetime import UTC, date, datetime
 from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
@@ -16,7 +16,9 @@ from src.utils.paper_validation_report import (
     EventSummary,
     PaperAgentReport,
     PaperValidationReport,
+    PromotionReadiness,
     RiskStateSummary,
+    assess_promotion_readiness,
     collect_agent_report,
     default_event_log_path,
     default_risk_state_path,
@@ -47,6 +49,29 @@ def test_parse_iso_timestamp_handles_z_suffix() -> None:
 
     assert parsed is not None
     assert parsed.isoformat() == "2026-03-19T21:00:00+00:00"
+
+
+def test_assess_promotion_readiness_collects_evidence_until_both_floors_pass() -> None:
+    readiness = assess_promotion_readiness(
+        DEFAULT_PAPER_AGENTS[0],
+        campaign_closed_trades=0,
+        as_of=datetime(2026, 6, 2, 21, 45, tzinfo=UTC),
+    )
+
+    assert readiness.status == "collecting_evidence"
+    assert readiness.campaign_age_days == 1.0
+    assert readiness.reasons == ["campaign age 1.0d < 28d", "closed trades 0 < 10"]
+
+
+def test_assess_promotion_readiness_requires_human_review_after_floors_pass() -> None:
+    readiness = assess_promotion_readiness(
+        DEFAULT_PAPER_AGENTS[0],
+        campaign_closed_trades=10,
+        as_of=datetime(2026, 6, 29, 21, 45, tzinfo=UTC),
+    )
+
+    assert readiness.status == "ready_for_review"
+    assert readiness.reasons == []
 
 
 def test_summarize_event_log_counts_only_requested_day(tmp_path: Path) -> None:
@@ -305,6 +330,13 @@ def test_render_markdown_contains_key_sections() -> None:
         campaign_realized_pnl=4.5,
         campaign_closed_trades=1,
         campaign_win_rate=100.0,
+        promotion_readiness=PromotionReadiness(
+            status="collecting_evidence",
+            campaign_age_days=1.0,
+            min_review_days=28,
+            min_review_trades=10,
+            reasons=["campaign age 1.0d < 28d", "closed trades 1 < 10"],
+        ),
         risk_state_matches_report_day=True,
         portfolio=PortfolioSummary(
             total_positions=1,
@@ -330,6 +362,8 @@ def test_render_markdown_contains_key_sections() -> None:
     assert "SOLUSDT" in markdown
     assert "Daily realized PnL" in markdown
     assert "Campaign realized PnL" in markdown
+    assert "Promotion readiness" in markdown
+    assert "collecting_evidence" in markdown
     assert "Lifetime DB realized PnL (includes legacy runs)" in markdown
     assert "Current risk-state PnL snapshot" in markdown
     assert "Risk-state matches report day" in markdown
@@ -361,6 +395,13 @@ def test_report_to_json_serializes_datetime_fields() -> None:
         campaign_realized_pnl=1.25,
         campaign_closed_trades=1,
         campaign_win_rate=100.0,
+        promotion_readiness=PromotionReadiness(
+            status="ready_for_review",
+            campaign_age_days=28.0,
+            min_review_days=28,
+            min_review_trades=10,
+            reasons=[],
+        ),
         risk_state_matches_report_day=True,
         portfolio=PortfolioSummary(
             total_positions=1,

--- a/tests/test_paper_validation_report.py
+++ b/tests/test_paper_validation_report.py
@@ -34,6 +34,14 @@ def test_default_paths_handle_default_and_named_agents() -> None:
     assert default_event_log_path("agent-x") == Path("data/event_log_agent-x.jsonl")
 
 
+def test_default_paper_agents_match_active_paper_services() -> None:
+    assert [spec.service for spec in DEFAULT_PAPER_AGENTS] == [
+        "agent_sol_sparse",
+        "agent_sol_panic_block_paper",
+    ]
+    assert all(spec.symbols == ("SOLUSDT",) for spec in DEFAULT_PAPER_AGENTS)
+
+
 def test_parse_iso_timestamp_handles_z_suffix() -> None:
     parsed = parse_iso_timestamp("2026-03-19T21:00:00Z")
 
@@ -261,7 +269,7 @@ async def test_collect_agent_report_flags_risk_state_day_mismatch(tmp_path: Path
 
 def test_render_markdown_contains_key_sections() -> None:
     report = PaperAgentReport(
-        agent=DEFAULT_PAPER_AGENTS[2],
+        agent=DEFAULT_PAPER_AGENTS[1],
         day="2026-03-19",
         events=EventSummary(
             signal_count=2,
@@ -269,8 +277,8 @@ def test_render_markdown_contains_key_sections() -> None:
             risk_check_failed_count=0,
             last_signal_at="2026-03-19T12:00:00+00:00",
             last_order_at="2026-03-19T13:00:00+00:00",
-            signals_by_symbol={"AVAXUSDT": 2},
-            orders_by_symbol={"AVAXUSDT": 1},
+            signals_by_symbol={"SOLUSDT": 2},
+            orders_by_symbol={"SOLUSDT": 1},
         ),
         risk=RiskStateSummary(
             kill_switch_triggered=False,
@@ -305,8 +313,8 @@ def test_render_markdown_contains_key_sections() -> None:
     )
 
     assert "Daily Paper Validation Report" in markdown
-    assert "agent_avax" in markdown
-    assert "AVAXUSDT" in markdown
+    assert "agent_sol_panic_block_paper" in markdown
+    assert "SOLUSDT" in markdown
     assert "Daily realized PnL" in markdown
     assert "Current risk-state PnL snapshot" in markdown
     assert "Risk-state matches report day" in markdown

--- a/tests/test_paper_validation_report.py
+++ b/tests/test_paper_validation_report.py
@@ -188,6 +188,10 @@ async def test_collect_agent_report_aggregates_db_and_files(tmp_path: Path) -> N
             AsyncMock(return_value=(12.5, 3, 66.67)),
         ),
         patch(
+            "src.utils.paper_validation_report.PortfolioManager.get_closed_stats_since",
+            AsyncMock(return_value=(8.5, 2, 50.0)),
+        ),
+        patch(
             "src.utils.paper_validation_report.PortfolioManager.get_portfolio_summary",
             AsyncMock(
                 return_value=PortfolioSummary(
@@ -213,6 +217,8 @@ async def test_collect_agent_report_aggregates_db_and_files(tmp_path: Path) -> N
     assert report.events.signal_count == 1
     assert report.risk.snapshot_daily_pnl == 7.25
     assert report.daily_closed_trades == 3
+    assert report.campaign_realized_pnl == 8.5
+    assert report.campaign_closed_trades == 2
     assert report.risk_state_matches_report_day is True
     assert report.portfolio.total_realized_pnl == 25.0
 
@@ -248,6 +254,10 @@ async def test_collect_agent_report_flags_risk_state_day_mismatch(tmp_path: Path
         patch("src.utils.paper_validation_report.PortfolioManager.__aexit__", _exit),
         patch(
             "src.utils.paper_validation_report.PortfolioManager.get_daily_stats",
+            AsyncMock(return_value=(0.0, 0, 0.0)),
+        ),
+        patch(
+            "src.utils.paper_validation_report.PortfolioManager.get_closed_stats_since",
             AsyncMock(return_value=(0.0, 0, 0.0)),
         ),
         patch(
@@ -292,6 +302,9 @@ def test_render_markdown_contains_key_sections() -> None:
         daily_realized_pnl=4.5,
         daily_closed_trades=1,
         daily_win_rate=100.0,
+        campaign_realized_pnl=4.5,
+        campaign_closed_trades=1,
+        campaign_win_rate=100.0,
         risk_state_matches_report_day=True,
         portfolio=PortfolioSummary(
             total_positions=1,
@@ -316,6 +329,8 @@ def test_render_markdown_contains_key_sections() -> None:
     assert "agent_sol_panic_block_paper" in markdown
     assert "SOLUSDT" in markdown
     assert "Daily realized PnL" in markdown
+    assert "Campaign realized PnL" in markdown
+    assert "Lifetime DB realized PnL (includes legacy runs)" in markdown
     assert "Current risk-state PnL snapshot" in markdown
     assert "Risk-state matches report day" in markdown
 
@@ -343,6 +358,9 @@ def test_report_to_json_serializes_datetime_fields() -> None:
         daily_realized_pnl=0.0,
         daily_closed_trades=0,
         daily_win_rate=0.0,
+        campaign_realized_pnl=1.25,
+        campaign_closed_trades=1,
+        campaign_win_rate=100.0,
         risk_state_matches_report_day=True,
         portfolio=PortfolioSummary(
             total_positions=1,

--- a/tests/test_portfolio_manager.py
+++ b/tests/test_portfolio_manager.py
@@ -283,3 +283,29 @@ async def test_get_daily_stats_uses_full_utc_day_window():
     assert fetch_call.args[1] == manager._agent_id
     assert fetch_call.args[2] == expected_start
     assert fetch_call.args[3] == expected_end
+
+
+@pytest.mark.asyncio
+async def test_get_closed_stats_since_uses_campaign_start() -> None:
+    manager = PortfolioManager({}, agent_id="sol-trend-pullback-sparse")
+
+    mock_pool = MagicMock()
+    mock_conn = AsyncMock()
+    mock_pool.acquire.return_value.__aenter__.return_value = mock_conn
+    mock_conn.fetchrow.return_value = {
+        "total_pnl": 2.5,
+        "trades_count": 4,
+        "wins": 3,
+    }
+    started_at = datetime(2026, 6, 1, 21, 45, tzinfo=UTC)
+
+    with patch("src.portfolio.manager.get_pool", return_value=mock_pool):
+        total_pnl, trades_count, win_rate = await manager.get_closed_stats_since(started_at)
+
+    assert total_pnl == pytest.approx(2.5)
+    assert trades_count == 4
+    assert win_rate == pytest.approx(75.0)
+    fetchrow_call = mock_conn.fetchrow.call_args
+    assert fetchrow_call is not None
+    assert fetchrow_call.args[1] == "sol-trend-pullback-sparse"
+    assert fetchrow_call.args[2] == started_at

--- a/tests/test_portfolio_manager.py
+++ b/tests/test_portfolio_manager.py
@@ -117,6 +117,36 @@ async def test_portfolio_manager_scopes_symbols_for_non_default_agent():
             # The first argument is the SQL, arguments start from the second element
             # Actually, fetchval arguments are (query, *args)
             assert insert_call.args[1] == "agent2::BTCUSDT:spot"
+            assert insert_call.args[8] == "agent2"
+
+            trade_insert_call = mock_conn.execute.call_args_list[-1]
+            assert trade_insert_call.args[9] == "agent2"
+
+
+@pytest.mark.asyncio
+async def test_portfolio_manager_ensure_schema_adds_agent_id_columns() -> None:
+    """Runtime schema hardening should create/backfill agent attribution columns."""
+    manager = PortfolioManager({})
+
+    mock_pool = MagicMock()
+    mock_conn = AsyncMock()
+    mock_pool.acquire.return_value.__aenter__.return_value = mock_conn
+
+    with patch("src.portfolio.manager.get_pool", return_value=mock_pool):
+        await manager._ensure_schema()
+
+    executed_sql = "\n".join(str(call.args[0]) for call in mock_conn.execute.call_args_list)
+
+    assert (
+        "ALTER TABLE positions ADD COLUMN IF NOT EXISTS agent_id TEXT DEFAULT 'default'"
+        in executed_sql
+    )
+    assert (
+        "ALTER TABLE trades ADD COLUMN IF NOT EXISTS agent_id TEXT DEFAULT 'default'"
+        in executed_sql
+    )
+    assert "UPDATE positions SET agent_id = 'default' WHERE agent_id IS NULL" in executed_sql
+    assert "UPDATE trades SET agent_id = 'default' WHERE agent_id IS NULL" in executed_sql
 
 
 @pytest.mark.asyncio

--- a/tests/test_production_drift_sentinel.py
+++ b/tests/test_production_drift_sentinel.py
@@ -5,10 +5,13 @@ from src.utils.production_drift_sentinel import (
     RepoSnapshot,
     ServiceSnapshot,
     SignalSnapshot,
+    TimerSnapshot,
+    TimerState,
     WatchedServiceSnapshot,
     analyze_drift,
     collect_local_config_hashes,
     collect_remote_service_snapshot,
+    collect_remote_timer_snapshot,
     parse_iso_timestamp,
     parse_sha256_lines,
     run_remote_command,
@@ -82,6 +85,31 @@ def test_run_remote_command_passes_explicit_ssh_config(monkeypatch) -> None:
     assert commands == [["ssh", "-F", "~/.ssh/config", "host", "cd /srv/app && git status"]]
 
 
+def test_collect_remote_timer_snapshot_reads_enabled_and_active(monkeypatch) -> None:
+    commands = []
+
+    def fake_run_remote_command(
+        host: str, remote_dir: str, command: str, ssh_config: str | None = None
+    ) -> str:
+        commands.append(command)
+        return "enabled" if "is-enabled" in command else "active"
+
+    monkeypatch.setattr(
+        "src.utils.production_drift_sentinel.run_remote_command",
+        fake_run_remote_command,
+    )
+
+    snapshot = collect_remote_timer_snapshot("host", "/srv/app", timers=("report.timer",))
+
+    assert snapshot == TimerSnapshot(
+        timers=[TimerState(timer="report.timer", enabled="enabled", active="active")]
+    )
+    assert commands == [
+        "systemctl is-enabled report.timer 2>/dev/null || true",
+        "systemctl is-active report.timer 2>/dev/null || true",
+    ]
+
+
 def test_analyze_drift_detects_remote_branch_mismatch_and_dirty() -> None:
     findings = analyze_drift(
         expected_branch="main",
@@ -129,6 +157,35 @@ def test_analyze_drift_detects_config_and_service_drift() -> None:
     assert "REMOTE_CONFIG_MISSING" in codes
     assert "SERVICES_NOT_RUNNING" in codes
     assert "SIGNAL_DROUGHT" in codes
+
+
+def test_analyze_drift_detects_unhealthy_required_timer() -> None:
+    findings = analyze_drift(
+        expected_branch="main",
+        local_repo=RepoSnapshot(branch="main", commit="a" * 40, dirty=False),
+        remote_repo=RepoSnapshot(branch="main", commit="a" * 40, dirty=False),
+        local_config_hashes={"settings.yaml": "111"},
+        remote_config_hashes={"settings.yaml": "111"},
+        service_snapshot=ServiceSnapshot(all_services=["agent"], running_services=["agent"]),
+        timer_snapshot=TimerSnapshot(
+            timers=[
+                TimerState(
+                    timer="crypto-agent-paper-validation-report.timer",
+                    enabled="disabled",
+                    active="inactive",
+                )
+            ]
+        ),
+        signal_snapshot=SignalSnapshot(
+            signal_count=1, last_signal_at=None, saw_strategy_cycle=True
+        ),
+        watched_service_snapshot=None,
+        remote_error=None,
+        signal_stale_hours=24,
+    )
+
+    codes = {finding.code for finding in findings}
+    assert "REQUIRED_TIMER_NOT_HEALTHY" in codes
 
 
 def test_remote_error_short_circuits_remote_analysis() -> None:

--- a/tests/test_production_drift_sentinel.py
+++ b/tests/test_production_drift_sentinel.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from datetime import UTC, datetime, timedelta
+
 from src.utils.production_drift_sentinel import (
     IGNORED_CONFIG_FILES,
     RepoSnapshot,
@@ -12,6 +14,7 @@ from src.utils.production_drift_sentinel import (
     collect_local_config_hashes,
     collect_remote_service_snapshot,
     collect_remote_timer_snapshot,
+    epoch_to_iso_timestamp,
     parse_iso_timestamp,
     parse_sha256_lines,
     run_remote_command,
@@ -92,7 +95,15 @@ def test_collect_remote_timer_snapshot_reads_enabled_and_active(monkeypatch) -> 
         host: str, remote_dir: str, command: str, ssh_config: str | None = None
     ) -> str:
         commands.append(command)
-        return "enabled" if "is-enabled" in command else "active"
+        if "is-enabled" in command:
+            return "enabled"
+        if "is-active" in command:
+            return "active"
+        if "--property=Result" in command:
+            return "success"
+        if "--property=ExecMainStatus" in command:
+            return "0"
+        return "1780359302.0"
 
     monkeypatch.setattr(
         "src.utils.production_drift_sentinel.run_remote_command",
@@ -102,12 +113,28 @@ def test_collect_remote_timer_snapshot_reads_enabled_and_active(monkeypatch) -> 
     snapshot = collect_remote_timer_snapshot("host", "/srv/app", timers=("report.timer",))
 
     assert snapshot == TimerSnapshot(
-        timers=[TimerState(timer="report.timer", enabled="enabled", active="active")]
+        timers=[
+            TimerState(
+                timer="report.timer",
+                enabled="enabled",
+                active="active",
+                service_result="success",
+                exec_main_status="0",
+                latest_report_at="2026-06-02T00:15:02+00:00",
+            )
+        ]
     )
     assert commands == [
         "systemctl is-enabled report.timer 2>/dev/null || true",
         "systemctl is-active report.timer 2>/dev/null || true",
+        "systemctl show report.service --property=Result --value",
+        "systemctl show report.service --property=ExecMainStatus --value",
+        "find data/reports -maxdepth 1 -type f -name 'paper-validation-report-*.json' -printf '%T@\\n' 2>/dev/null | sort -nr | head -n 1",
     ]
+
+
+def test_epoch_to_iso_timestamp_returns_none_for_missing_artifact() -> None:
+    assert epoch_to_iso_timestamp("") is None
 
 
 def test_analyze_drift_detects_remote_branch_mismatch_and_dirty() -> None:
@@ -173,6 +200,9 @@ def test_analyze_drift_detects_unhealthy_required_timer() -> None:
                     timer="crypto-agent-paper-validation-report.timer",
                     enabled="disabled",
                     active="inactive",
+                    service_result="success",
+                    exec_main_status="0",
+                    latest_report_at=datetime.now(UTC).isoformat(),
                 )
             ]
         ),
@@ -186,6 +216,68 @@ def test_analyze_drift_detects_unhealthy_required_timer() -> None:
 
     codes = {finding.code for finding in findings}
     assert "REQUIRED_TIMER_NOT_HEALTHY" in codes
+
+
+def test_analyze_drift_detects_failed_timer_service_and_missing_report() -> None:
+    findings = analyze_drift(
+        expected_branch="main",
+        local_repo=RepoSnapshot(branch="main", commit="a" * 40, dirty=False),
+        remote_repo=RepoSnapshot(branch="main", commit="a" * 40, dirty=False),
+        local_config_hashes={},
+        remote_config_hashes={},
+        service_snapshot=None,
+        timer_snapshot=TimerSnapshot(
+            timers=[
+                TimerState(
+                    timer="report.timer",
+                    enabled="enabled",
+                    active="active",
+                    service_result="failed",
+                    exec_main_status="1",
+                    latest_report_at=None,
+                )
+            ]
+        ),
+        signal_snapshot=None,
+        watched_service_snapshot=None,
+        remote_error=None,
+        signal_stale_hours=24,
+    )
+
+    codes = {finding.code for finding in findings}
+    assert "REQUIRED_TIMER_SERVICE_FAILED" in codes
+    assert "PAPER_VALIDATION_REPORT_MISSING" in codes
+
+
+def test_analyze_drift_detects_stale_paper_validation_report() -> None:
+    stale_report = (datetime.now(UTC) - timedelta(hours=37)).isoformat()
+    findings = analyze_drift(
+        expected_branch="main",
+        local_repo=RepoSnapshot(branch="main", commit="a" * 40, dirty=False),
+        remote_repo=RepoSnapshot(branch="main", commit="a" * 40, dirty=False),
+        local_config_hashes={},
+        remote_config_hashes={},
+        service_snapshot=None,
+        timer_snapshot=TimerSnapshot(
+            timers=[
+                TimerState(
+                    timer="report.timer",
+                    enabled="enabled",
+                    active="active",
+                    service_result="success",
+                    exec_main_status="0",
+                    latest_report_at=stale_report,
+                )
+            ]
+        ),
+        signal_snapshot=None,
+        watched_service_snapshot=None,
+        remote_error=None,
+        signal_stale_hours=24,
+    )
+
+    codes = {finding.code for finding in findings}
+    assert "PAPER_VALIDATION_REPORT_STALE" in codes
 
 
 def test_remote_error_short_circuits_remote_analysis() -> None:

--- a/tests/test_production_drift_sentinel.py
+++ b/tests/test_production_drift_sentinel.py
@@ -88,6 +88,20 @@ def test_run_remote_command_passes_explicit_ssh_config(monkeypatch) -> None:
     assert commands == [["ssh", "-F", "~/.ssh/config", "host", "cd /srv/app && git status"]]
 
 
+def test_run_remote_command_can_inspect_production_locally(monkeypatch) -> None:
+    commands = []
+
+    def fake_run_command(command: list[str], cwd=None, timeout: int = 15) -> str:
+        commands.append(command)
+        return ""
+
+    monkeypatch.setattr("src.utils.production_drift_sentinel.run_command", fake_run_command)
+
+    run_remote_command(None, "/srv/app", "git status")
+
+    assert commands == [["bash", "-lc", "cd /srv/app && git status"]]
+
+
 def test_collect_remote_timer_snapshot_reads_enabled_and_active(monkeypatch) -> None:
     commands = []
 

--- a/tests/test_production_drift_sentinel.py
+++ b/tests/test_production_drift_sentinel.py
@@ -8,6 +8,7 @@ from src.utils.production_drift_sentinel import (
     WatchedServiceSnapshot,
     analyze_drift,
     collect_local_config_hashes,
+    collect_remote_service_snapshot,
     parse_iso_timestamp,
     parse_sha256_lines,
 )
@@ -40,6 +41,27 @@ def test_collect_local_config_hashes_ignores_research_only_configs(tmp_path) -> 
 
     assert "settings.yaml" in hashes
     assert ignored_name not in hashes
+
+
+def test_collect_remote_service_snapshot_uses_production_compose(monkeypatch) -> None:
+    commands = []
+
+    def fake_run_remote_command(host: str, remote_dir: str, command: str) -> str:
+        commands.append(command)
+        return "agent_sentiment_macro\n" if "config --services" in command else ""
+
+    monkeypatch.setattr(
+        "src.utils.production_drift_sentinel.run_remote_command",
+        fake_run_remote_command,
+    )
+
+    snapshot = collect_remote_service_snapshot("host", "/srv/app")
+
+    assert snapshot.all_services == ["agent_sentiment_macro"]
+    assert commands == [
+        "docker compose -f docker-compose.prod.yml config --services",
+        "docker compose -f docker-compose.prod.yml ps --status running --services",
+    ]
 
 
 def test_analyze_drift_detects_remote_branch_mismatch_and_dirty() -> None:

--- a/tests/test_production_drift_sentinel.py
+++ b/tests/test_production_drift_sentinel.py
@@ -135,6 +135,7 @@ def test_collect_remote_timer_snapshot_reads_enabled_and_active(monkeypatch) -> 
                 service_result="success",
                 exec_main_status="0",
                 latest_report_at="2026-06-02T00:15:02+00:00",
+                max_report_age_hours=36,
             )
         ]
     )
@@ -145,6 +146,42 @@ def test_collect_remote_timer_snapshot_reads_enabled_and_active(monkeypatch) -> 
         "systemctl show report.service --property=ExecMainStatus --value",
         "find data/reports -maxdepth 1 -type f -name 'paper-validation-report-*.json' -printf '%T@\\n' 2>/dev/null | sort -nr | head -n 1",
     ]
+
+
+def test_collect_remote_timer_snapshot_uses_hourly_sentinel_artifact_policy(monkeypatch) -> None:
+    commands = []
+
+    def fake_run_remote_command(
+        host: str, remote_dir: str, command: str, ssh_config: str | None = None
+    ) -> str:
+        commands.append(command)
+        if "is-enabled" in command:
+            return "enabled"
+        if "is-active" in command:
+            return "active"
+        if "--property=Result" in command:
+            return "success"
+        if "--property=ExecMainStatus" in command:
+            return "0"
+        return "1780359302.0"
+
+    monkeypatch.setattr(
+        "src.utils.production_drift_sentinel.run_remote_command",
+        fake_run_remote_command,
+    )
+
+    snapshot = collect_remote_timer_snapshot(
+        "host",
+        "/srv/app",
+        timers=("crypto-agent-production-drift-sentinel.timer",),
+    )
+
+    assert snapshot.timers[0].max_report_age_hours == 2
+    assert (
+        "find data/reports -maxdepth 1 -type f "
+        "-name 'production-drift-sentinel-*.json' -printf '%T@\\n' "
+        "2>/dev/null | sort -nr | head -n 1"
+    ) in commands
 
 
 def test_epoch_to_iso_timestamp_returns_none_for_missing_artifact() -> None:
@@ -217,6 +254,7 @@ def test_analyze_drift_detects_unhealthy_required_timer() -> None:
                     service_result="success",
                     exec_main_status="0",
                     latest_report_at=datetime.now(UTC).isoformat(),
+                    max_report_age_hours=36,
                 )
             ]
         ),
@@ -249,6 +287,7 @@ def test_analyze_drift_detects_failed_timer_service_and_missing_report() -> None
                     service_result="failed",
                     exec_main_status="1",
                     latest_report_at=None,
+                    max_report_age_hours=36,
                 )
             ]
         ),
@@ -260,7 +299,7 @@ def test_analyze_drift_detects_failed_timer_service_and_missing_report() -> None
 
     codes = {finding.code for finding in findings}
     assert "REQUIRED_TIMER_SERVICE_FAILED" in codes
-    assert "PAPER_VALIDATION_REPORT_MISSING" in codes
+    assert "TIMER_REPORT_MISSING" in codes
 
 
 def test_analyze_drift_detects_stale_paper_validation_report() -> None:
@@ -281,6 +320,7 @@ def test_analyze_drift_detects_stale_paper_validation_report() -> None:
                     service_result="success",
                     exec_main_status="0",
                     latest_report_at=stale_report,
+                    max_report_age_hours=36,
                 )
             ]
         ),
@@ -291,7 +331,7 @@ def test_analyze_drift_detects_stale_paper_validation_report() -> None:
     )
 
     codes = {finding.code for finding in findings}
-    assert "PAPER_VALIDATION_REPORT_STALE" in codes
+    assert "TIMER_REPORT_STALE" in codes
 
 
 def test_remote_error_short_circuits_remote_analysis() -> None:

--- a/tests/test_production_drift_sentinel.py
+++ b/tests/test_production_drift_sentinel.py
@@ -11,6 +11,7 @@ from src.utils.production_drift_sentinel import (
     collect_remote_service_snapshot,
     parse_iso_timestamp,
     parse_sha256_lines,
+    run_remote_command,
 )
 
 
@@ -46,7 +47,10 @@ def test_collect_local_config_hashes_ignores_research_only_configs(tmp_path) -> 
 def test_collect_remote_service_snapshot_uses_production_compose(monkeypatch) -> None:
     commands = []
 
-    def fake_run_remote_command(host: str, remote_dir: str, command: str) -> str:
+    def fake_run_remote_command(
+        host: str, remote_dir: str, command: str, ssh_config: str | None = None
+    ) -> str:
+        assert ssh_config is None
         commands.append(command)
         return "agent_sentiment_macro\n" if "config --services" in command else ""
 
@@ -62,6 +66,20 @@ def test_collect_remote_service_snapshot_uses_production_compose(monkeypatch) ->
         "docker compose -f docker-compose.prod.yml config --services",
         "docker compose -f docker-compose.prod.yml ps --status running --services",
     ]
+
+
+def test_run_remote_command_passes_explicit_ssh_config(monkeypatch) -> None:
+    commands = []
+
+    def fake_run_command(command: list[str], cwd=None, timeout: int = 15) -> str:
+        commands.append(command)
+        return ""
+
+    monkeypatch.setattr("src.utils.production_drift_sentinel.run_command", fake_run_command)
+
+    run_remote_command("host", "/srv/app", "git status", ssh_config="~/.ssh/config")
+
+    assert commands == [["ssh", "-F", "~/.ssh/config", "host", "cd /srv/app && git status"]]
 
 
 def test_analyze_drift_detects_remote_branch_mismatch_and_dirty() -> None:

--- a/tests/test_prometheus_config.py
+++ b/tests/test_prometheus_config.py
@@ -38,14 +38,21 @@ def test_file_sd_targets_cover_all_current_agent_services() -> None:
         "agent_sol_sparse",
         "agent_sentiment_macro",
         "agent_sol_panic_block_paper",
+        "agent_sol_1h_trend_pullback_overlay_live",
     }
     assert targets_by_service["agent_sol_sparse"] == ["agent_sol_sparse:8000"]
     assert targets_by_service["agent_sentiment_macro"] == ["agent_sentiment_macro:8000"]
     assert targets_by_service["agent_sol_panic_block_paper"] == ["agent_sol_panic_block_paper:8000"]
+    assert targets_by_service["agent_sol_1h_trend_pullback_overlay_live"] == [
+        "agent_sol_1h_trend_pullback_overlay_live:8000"
+    ]
     assert labels_by_service["agent_sol_sparse"]["agent_id"] == "sol-trend-pullback-sparse"
     assert labels_by_service["agent_sentiment_macro"]["agent_id"] == "sentiment-macro-bot"
     assert labels_by_service["agent_sol_panic_block_paper"]["agent_id"] == (
         "sol-4h-panic-block-paper"
+    )
+    assert labels_by_service["agent_sol_1h_trend_pullback_overlay_live"]["agent_id"] == (
+        "sol-1h-trend-pullback-overlay-live"
     )
 
 

--- a/tests/test_prometheus_config.py
+++ b/tests/test_prometheus_config.py
@@ -35,16 +35,18 @@ def test_file_sd_targets_cover_all_current_agent_services() -> None:
     targets_by_service = {entry["labels"]["service"]: entry["targets"] for entry in entries}
 
     assert set(labels_by_service) == {
-        "agent_avax",
         "agent_sol_sparse",
         "agent_sentiment_macro",
+        "agent_sol_panic_block_paper",
     }
-    assert targets_by_service["agent_avax"] == ["agent_avax:8000"]
     assert targets_by_service["agent_sol_sparse"] == ["agent_sol_sparse:8000"]
     assert targets_by_service["agent_sentiment_macro"] == ["agent_sentiment_macro:8000"]
-    assert labels_by_service["agent_avax"]["agent_id"] == "avax-4h-ma"
+    assert targets_by_service["agent_sol_panic_block_paper"] == ["agent_sol_panic_block_paper:8000"]
     assert labels_by_service["agent_sol_sparse"]["agent_id"] == "sol-trend-pullback-sparse"
     assert labels_by_service["agent_sentiment_macro"]["agent_id"] == "sentiment-macro-bot"
+    assert labels_by_service["agent_sol_panic_block_paper"]["agent_id"] == (
+        "sol-4h-panic-block-paper"
+    )
 
 
 def test_compose_mounts_prometheus_target_directory() -> None:

--- a/tests/test_relative_strength_probe.py
+++ b/tests/test_relative_strength_probe.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+from scripts.probe_relative_strength_rotation import (
+    ProbeConfig,
+    align_same_timestamp_rows,
+    probe_rows,
+)
+
+
+def _config(**overrides: object) -> ProbeConfig:
+    values = {
+        "target_symbol": "ETHUSDT",
+        "anchor_symbol": "BTCUSDT",
+        "timeframe": "1h",
+        "start": "2024-01-01T00:00:00",
+        "end": "2024-01-03T00:00:00",
+        "fast_lookback_bars": 2,
+        "slow_lookback_bars": 4,
+        "forward_bars": 2,
+        "min_fast_rs_pct": 1.0,
+        "min_slow_rs_pct": 2.0,
+        "max_rs_deterioration_pct": -1.5,
+        "max_pullback_distance_pct": 3.0,
+        "rsi_reset_min": 35.0,
+        "rsi_reset_max": 65.0,
+        "anchor_max_fast_loss_pct": 3.0,
+        "anchor_min_ema200_distance_pct": -5.0,
+    }
+    values.update(overrides)
+    return ProbeConfig(**values)
+
+
+def _row(
+    index: int,
+    close: float,
+    *,
+    ema_50: float | None = None,
+    ema_200: float | None = None,
+    vwap: float | None = None,
+    rsi_14: float = 50.0,
+) -> dict[str, object]:
+    row_time = datetime(2024, 1, 1) + timedelta(hours=index)
+    return {
+        "time": row_time,
+        "close_price": close,
+        "ema_50": close if ema_50 is None else ema_50,
+        "ema_200": close if ema_200 is None else ema_200,
+        "vwap": close if vwap is None else vwap,
+        "rsi_14": rsi_14,
+    }
+
+
+def test_align_same_timestamp_rows_uses_only_matching_closed_bars() -> None:
+    target_rows = [_row(0, 100.0), _row(1, 101.0), _row(2, 102.0)]
+    anchor_rows = [_row(0, 50.0), _row(2, 51.0), _row(3, 52.0)]
+
+    aligned_target, aligned_anchor = align_same_timestamp_rows(target_rows, anchor_rows)
+
+    assert [row["time"] for row in aligned_target] == [
+        target_rows[0]["time"],
+        target_rows[2]["time"],
+    ]
+    assert [row["time"] for row in aligned_anchor] == [
+        anchor_rows[0]["time"],
+        anchor_rows[1]["time"],
+    ]
+
+
+def test_probe_rows_counts_events_and_forward_excess_return() -> None:
+    target_prices = [100.0, 101.0, 102.0, 104.0, 106.0, 107.0, 110.0, 112.0]
+    anchor_prices = [100.0, 100.0, 100.5, 101.0, 101.0, 101.5, 102.0, 102.0]
+    target_rows = [
+        _row(index, price, ema_50=price * 0.99, ema_200=price * 0.95, vwap=price * 0.995)
+        for index, price in enumerate(target_prices)
+    ]
+    anchor_rows = [
+        _row(index, price, ema_50=price, ema_200=price * 0.98, vwap=price)
+        for index, price in enumerate(anchor_prices)
+    ]
+
+    summary = probe_rows(target_rows, anchor_rows, _config(max_rs_deterioration_pct=-3.0))
+
+    assert summary.aligned_rows == 8
+    assert summary.event_count >= 1
+    assert summary.mean_forward_return_pct > 0.0
+    assert summary.mean_excess_forward_return_pct > 0.0
+
+
+def test_probe_rows_returns_no_events_when_rs_is_negative() -> None:
+    target_prices = [100.0, 100.0, 99.0, 99.0, 98.0, 98.0, 98.0]
+    anchor_prices = [100.0, 101.0, 102.0, 103.0, 104.0, 105.0, 106.0]
+    target_rows = [
+        _row(index, price, ema_50=price * 0.99, ema_200=price * 0.95, vwap=price)
+        for index, price in enumerate(target_prices)
+    ]
+    anchor_rows = [
+        _row(index, price, ema_50=price, ema_200=price * 0.98, vwap=price)
+        for index, price in enumerate(anchor_prices)
+    ]
+
+    summary = probe_rows(target_rows, anchor_rows, _config())
+
+    assert summary.event_count == 0
+    assert summary.mean_forward_return_pct == 0.0
+    assert summary.mean_excess_forward_return_pct == 0.0


### PR DESCRIPTION
## Summary

Preserves the candidate-search research record and operational fixes while pivoting the **next surface** to funding/crowding primary (normalization trigger).

## Included

- Relative-strength feasibility probe + result (paused — do not implement RS v0)
- Phase 0 forward snapshot, entry-overlap remote fix, profit_report asyncpg fix
- Production funding_rates backfill for BTC/ETH/SOL
- **New:** `funding-crowding-primary-surface-v0.md` + `probe_funding_normalization.py` + tests

## Goal unchanged

5–10 independent deployable agents; count subordinate to gates. Current deployable technical: **1** (SOL 1h overlay live) + sentiment-macro.

## After merge

1. Weekly `./scripts/run_entry_overlap_remote.sh`
2. Run funding normalization probe on prod DB for BTC/ETH/SOL
3. Implement autoresearch family **only** if probe verdict is `HAS_PULSE`

Co-Authored-By: Grok <noreply@x.ai>