### PR TITLE
feat(strategy): B-SOL funding normalization autoresearch sprint

### DIFF
--- a/docs/reports/autoresearch-candidate-ledger.md
+++ b/docs/reports/autoresearch-candidate-ledger.md
@@ -170,6 +170,27 @@ Per [autoresearch-next-candidate-path-2026-06-04.md](./autoresearch-next-candida
 
 Launcher: `scripts/run_phase7_4h_campaigns.sh`
 
+## Wave 9 — B-SOL funding normalization (in progress)
+
+Tightly scoped sprint after prod probe reshape (`neg_tail_10pct` HAS_PULSE on SOL only).
+**Not** a gate change; **not** live deploy from probe.
+
+| Item | Value |
+|------|-------|
+| Symbol | **SOLUSDT only** |
+| TF | 1h |
+| Family | `funding_normalization_standalone` |
+| Strategy | `funding_normalization` (normalize-from-negative, long-only) |
+| Entry band | 0.00012–0.00022 (~SOL 10% negative tail) |
+| Time stops | 12h / 24h / 48h |
+| Output | `research/solusdt-1h-w9-sol-1h-funding-norm` |
+| Launcher | `scripts/run_b_sol_funding_norm_campaign.sh` |
+
+**Mandatory before promotion:** entry overlap vs `agent_sol_1h_trend_pullback_overlay_live` +
+`agent_sentiment_macro`. Expect **correlated symbol risk** even if entries differ.
+
+**ETH 4h bounded b=1000:** skipped (formal reject expected; near-miss only).
+
 ## Wave 3 — Bridge + funding
 
 | Date | Symbol | TF | Families | Runs | Passes | Near-miss | Output dir | Decision |

--- a/docs/reports/autoresearch-candidate-ledger.md
+++ b/docs/reports/autoresearch-candidate-ledger.md
@@ -170,26 +170,28 @@ Per [autoresearch-next-candidate-path-2026-06-04.md](./autoresearch-next-candida
 
 Launcher: `scripts/run_phase7_4h_campaigns.sh`
 
-## Wave 9 — B-SOL funding normalization (in progress)
+## Wave 9 — B-SOL funding normalization (complete, CLOSED)
 
 Tightly scoped sprint after prod probe reshape (`neg_tail_10pct` HAS_PULSE on SOL only).
-**Not** a gate change; **not** live deploy from probe.
+**0 standard passes. 0 promotion_candidate eligibles.**
 
 | Item | Value |
 |------|-------|
-| Symbol | **SOLUSDT only** |
-| TF | 1h |
-| Family | `funding_normalization_standalone` |
-| Strategy | `funding_normalization` (normalize-from-negative, long-only) |
-| Entry band | 0.00012–0.00022 (~SOL 10% negative tail) |
-| Time stops | 12h / 24h / 48h |
-| Output | `research/solusdt-1h-w9-sol-1h-funding-norm` |
-| Launcher | `scripts/run_b_sol_funding_norm_campaign.sh` |
+| Runs | 80 |
+| Best OOS | +0.82% |
+| Best WFO trades | **15** (max across campaign; **0** runs ≥ 20) |
+| Best Sharpe | 0.52 |
+| Best DD | 7.4% |
+| P(loss) / conc (best) | 53% / **100%** |
+| Verdict | **CLOSED** — too sparse for standard gate; probe pulse did not transfer to WFO |
 
-**Mandatory before promotion:** entry overlap vs `agent_sol_1h_trend_pullback_overlay_live` +
-`agent_sentiment_macro`. Expect **correlated symbol risk** even if entries differ.
+**Read:** Cheap probe counted 44 normalization **events** on funding ticks; backtest/WFO
+produced at most **15** trades (28 runs had ≥10). Concentration and P(loss) fail on the
+best config. **Do not** run bootstrap=1000. **Do not** deploy.
 
-**ETH 4h bounded b=1000:** skipped (formal reject expected; near-miss only).
+**Funding-primary on SOL:** closed. Next: **Option F** (new first-principles surface).
+
+Launcher: `scripts/run_b_sol_funding_norm_campaign.sh`
 
 ## Wave 3 — Bridge + funding
 

--- a/docs/reports/autoresearch-plan-overview.md
+++ b/docs/reports/autoresearch-plan-overview.md
@@ -117,7 +117,7 @@ phases — it is listed separately as the active next research target.
 | 3 | `funding_primary_standalone` BTC 4h | **closed** (0 trades) |
 | 4 | Short-side / two-sided (paper + execution parity first) | queued |
 | 5 | Longer-history revalidation | per-candidate |
-| **New surface** | `funding_normalization` primary (BTC/ETH/SOL) | **probe done** — default thresholds NO_PULSE/SPARSE; reshape before impl |
+| **New surface** | `funding_normalization` SOL (Wave 9) | **closed** — 0 passes; probe pulse ≠ WFO edge |
 
 Full phase detail, gate-profile choices, and stop conditions are in the
 [next-candidate-path doc](./autoresearch-next-candidate-path-2026-06-04.md).

--- a/docs/reports/candidate-search-options-2026-06-04.md
+++ b/docs/reports/candidate-search-options-2026-06-04.md
@@ -187,12 +187,13 @@ ssh crypto-agent 'cd /opt/crypto-agent && docker run --rm --network crypto-agent
 ## Recommended priority stack
 
 ```text
-1. Merge PR #55 (Option G)
-2. Continue Option A weekly
-3. Run Option B reshape matrix (B1–B3); stop if no HAS_PULSE
-4. If B fails: Option F (new brief) OR Option D1 (ETH b=1000 record only)
-5. Option E only after execution parity doc exists
-6. Option C only if RS probe v2 passes
+1. Merge PR #55 — DONE (main)
+2. Continue Option A weekly (`run_phase0_weekly.sh`)
+3. Wave 9 B-SOL autoresearch — IN PROGRESS (`run_b_sol_funding_norm_campaign.sh`)
+4. Option D1 (ETH b=1000) — SKIPPED
+5. If Wave 9 fails standard gates → Option F (new surface brief)
+6. Option E only after execution parity doc exists
+7. Option C only if RS probe v2 passes
 ```
 
 **Do not:** Rerun BNB/BTC 1h standalone, AVAX/ETH #0004, SOL 1h clones, or lower gates.
@@ -208,6 +209,7 @@ ssh crypto-agent 'cd /opt/crypto-agent && docker run --rm --network crypto-agent
 | `probe_funding_normalization.py` | Single-symbol funding probe |
 | `run_funding_probe_reshape.py` | Multi-scenario reshape matrix |
 | `probe_relative_strength_rotation.py` | RS feasibility (paused) |
+| `run_b_sol_funding_norm_campaign.sh` | Wave 9 SOL funding-normalization autoresearch |
 
 ---
 

--- a/scripts/autoresearch_loop.py
+++ b/scripts/autoresearch_loop.py
@@ -38,6 +38,7 @@ DEFAULT_FAMILIES = (
     "mtf_breakout_standalone",
     "range_reversion_bounded",
     "funding_primary_standalone",
+    "funding_normalization_standalone",
 )
 
 BASE_STRATEGY_CONFIGS: tuple[dict[str, Any], ...] = (
@@ -1053,6 +1054,35 @@ def generate_candidate(
         desc = (
             f"funding-primary entry={entry_thresh:.5f} exit={exit_thresh:.5f} "
             f"lookback={overlay['strategy']['strategies'][0]['config']['lookback_periods']}"
+        )
+    elif family == "funding_normalization_standalone":
+        # B-SOL sprint: band around SOL neg_tail_10pct probe (~0.00016 entry).
+        entry_thresh = _round(rng.uniform(0.00012, 0.00022), 5)
+        exit_thresh = _round(rng.uniform(0.00008, 0.00018), 5)
+        time_stop_min = float(rng.choice([720.0, 1440.0, 2880.0]))
+        overlay, desc = _standalone_strategy_overlay(
+            trading_symbol=trading_symbol,
+            rng=rng,
+            strategy_entry={
+                "name": "funding_normalization",
+                "config": {
+                    "entry_threshold": entry_thresh,
+                    "exit_threshold": exit_thresh,
+                    "long_only": True,
+                },
+            },
+            buy_low=0.45,
+            buy_high=0.72,
+            sl_atr=_round(rng.uniform(1.8, 2.4), 2),
+            tp_atr=_round(rng.uniform(2.8, 4.0), 2),
+        )
+        overlay["trading_execution"]["exit_rules"] = {
+            "backtest_use_executor_exit_model": True,
+            "time_stop_minutes": time_stop_min,
+        }
+        desc = (
+            f"funding-norm entry={entry_thresh:.5f} exit={exit_thresh:.5f} "
+            f"time_stop={time_stop_min:.0f}m"
         )
     else:
         buy = _round(rng.uniform(1.00, 1.10), 2)

--- a/scripts/run_b_sol_funding_norm_campaign.sh
+++ b/scripts/run_b_sol_funding_norm_campaign.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# B-SOL research sprint: funding normalization primary on SOLUSDT 1h only.
+# Prerequisite: probe reshape showed HAS_PULSE for SOL neg_tail_10pct (cheap probe only).
+# Post-campaign: entry overlap vs live SOL overlay + sentiment-macro before any b=1000.
+set -euo pipefail
+
+SYMBOL="${1:-SOLUSDT}"
+if [[ "${SYMBOL}" != "SOLUSDT" ]]; then
+  echo "B-SOL sprint is scoped to SOLUSDT only. Got: ${SYMBOL}" >&2
+  exit 1
+fi
+
+export GATE_PROFILE=standard
+export BOOTSTRAP=100
+export MAX_RUNS="${MAX_RUNS:-80}"
+export FAMILIES=funding_normalization_standalone
+
+./scripts/run_autoresearch_campaign_remote.sh SOLUSDT 1h w9-sol-1h-funding-norm

--- a/src/main.py
+++ b/src/main.py
@@ -51,6 +51,7 @@ from src.strategy import (
     BollingerBounceStrategy,
     CCIBreakoutStrategy,
     EngineConfig,
+    FundingNormalizationStrategy,
     FundingRateStrategy,
     MACDHistogramStrategy,
     MacroVolatilityStrategy,
@@ -738,6 +739,7 @@ def _build_strategy_registry() -> dict[str, type[BaseStrategy]]:
         "sentiment_mean_reversion": SentimentMeanReversionStrategy,
         "macro_volatility": MacroVolatilityStrategy,
         "funding_rate": FundingRateStrategy,
+        "funding_normalization": FundingNormalizationStrategy,
     }
 
     optional_strategies = {

--- a/src/strategy/__init__.py
+++ b/src/strategy/__init__.py
@@ -5,6 +5,7 @@ from src.strategy.bollinger_strategy import BollingerBounceStrategy
 from src.strategy.breakout_retest import BreakoutRetestStrategy
 from src.strategy.cci_strategy import CCIBreakoutStrategy
 from src.strategy.engine import EngineConfig, StrategyEngine
+from src.strategy.funding_normalization import FundingNormalizationStrategy
 from src.strategy.funding_rate import FundingRateStrategy
 from src.strategy.macd_strategy import MACDHistogramStrategy
 from src.strategy.macro_volatility import MacroVolatilityStrategy
@@ -38,6 +39,7 @@ __all__ = [
     "PanicBlockMACrossoverStrategy",
     "CCIBreakoutStrategy",
     "FundingRateStrategy",
+    "FundingNormalizationStrategy",
     "VWAPReversionStrategy",
     "MeanReversionStrategy",
     "SentimentMeanReversionStrategy",

--- a/src/strategy/funding_normalization.py
+++ b/src/strategy/funding_normalization.py
@@ -1,0 +1,109 @@
+"""Long-only funding normalization strategy (primary trigger).
+
+Enters when funding normalizes from an extreme negative (crowded shorts),
+not when funding first hits the extreme. One entry per extreme→normalize cycle.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import TYPE_CHECKING
+
+from src.strategy.base import BaseStrategy
+from src.strategy.signals import Signal, SignalType
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+
+class _FundingState(StrEnum):
+    IDLE = "idle"
+    EXTREME_NEGATIVE = "extreme_negative"
+    COOLDOWN_NEGATIVE = "cooldown_negative"
+
+
+@dataclass
+class FundingNormalizationConfig:
+    entry_threshold: float = 0.00016
+    exit_threshold: float = 0.00015
+    long_only: bool = True
+
+
+class FundingNormalizationStrategy(BaseStrategy):
+    """Mean-reversion long after negative funding crowding unwinds."""
+
+    def __init__(self, config: Mapping[str, object] | None = None) -> None:
+        super().__init__(config)
+        self._norm_config = FundingNormalizationConfig(
+            entry_threshold=float(self._config.get("entry_threshold", 0.00016)),
+            exit_threshold=float(self._config.get("exit_threshold", 0.00015)),
+            long_only=bool(self._config.get("long_only", True)),
+        )
+        self._state: dict[str, _FundingState] = {}
+        self._prior_extreme: dict[str, float] = {}
+
+    def _state_for(self, symbol: str) -> _FundingState:
+        return self._state.get(symbol, _FundingState.IDLE)
+
+    async def evaluate(self, symbol: str, indicators: dict[str, float]) -> Signal:
+        funding_rate = indicators.get("funding_rate")
+        price = float(indicators.get("close_price", 0.0))
+
+        if funding_rate is None:
+            return Signal(
+                type=SignalType.HOLD,
+                symbol=symbol,
+                price=price,
+                confidence=0.0,
+                reason="no_funding_rate",
+                indicators=indicators,
+            )
+
+        rate = float(funding_rate)
+        entry_thresh = self._norm_config.entry_threshold
+        exit_thresh = self._norm_config.exit_threshold
+        normalized = abs(rate) < exit_thresh
+        state = self._state_for(symbol)
+
+        if rate <= -entry_thresh:
+            if state in {_FundingState.IDLE, _FundingState.COOLDOWN_NEGATIVE}:
+                self._state[symbol] = _FundingState.EXTREME_NEGATIVE
+                self._prior_extreme[symbol] = rate
+            elif state == _FundingState.EXTREME_NEGATIVE:
+                self._prior_extreme[symbol] = min(self._prior_extreme.get(symbol, rate), rate)
+            return Signal(
+                type=SignalType.HOLD,
+                symbol=symbol,
+                price=price,
+                confidence=0.0,
+                reason="funding_extreme_negative",
+                indicators=indicators,
+            )
+
+        if state == _FundingState.EXTREME_NEGATIVE and normalized:
+            self._state[symbol] = _FundingState.COOLDOWN_NEGATIVE
+            confidence = min(abs(self._prior_extreme.get(symbol, rate)) / entry_thresh, 1.0)
+            return Signal(
+                type=SignalType.BUY,
+                symbol=symbol,
+                price=price,
+                confidence=confidence,
+                reason="funding_normalized_from_negative",
+                indicators=indicators,
+            )
+
+        if normalized and state != _FundingState.EXTREME_NEGATIVE:
+            self._state[symbol] = _FundingState.IDLE
+
+        return Signal(
+            type=SignalType.HOLD,
+            symbol=symbol,
+            price=price,
+            confidence=0.0,
+            reason="funding_normalization_wait",
+            indicators=indicators,
+        )
+
+    def get_name(self) -> str:
+        return "funding_normalization"

--- a/tests/test_autoresearch.py
+++ b/tests/test_autoresearch.py
@@ -415,6 +415,7 @@ def test_autoresearch_loop_candidate_ranges_stay_bounded() -> None:
             "mtf_breakout_standalone",
             "range_reversion_bounded",
             "funding_primary_standalone",
+            "funding_normalization_standalone",
         }:
             strategy = candidate.overlay["strategy"]
             assert len(strategy["strategies"]) == 1
@@ -677,6 +678,21 @@ def test_autoresearch_loop_range_reversion_bounded_has_time_stop() -> None:
     assert candidate.family == "range_reversion_bounded"
     assert candidate.overlay["strategy"]["strategies"][0]["name"] == "bollinger_bounce"
     assert candidate.overlay["trading_execution"]["exit_rules"]["time_stop_minutes"] >= 2880
+
+
+def test_autoresearch_loop_funding_normalization_standalone_single_strategy() -> None:
+    candidate = generate_candidate(
+        11,
+        seed=42,
+        symbol="SOLUSDT",
+        families=("funding_normalization_standalone",),
+    )
+
+    assert candidate.family == "funding_normalization_standalone"
+    strat = candidate.overlay["strategy"]["strategies"][0]
+    assert strat["name"] == "funding_normalization"
+    assert strat["config"]["long_only"] is True
+    assert 0.00012 <= strat["config"]["entry_threshold"] <= 0.00022
 
 
 def test_autoresearch_loop_funding_primary_standalone_single_strategy() -> None:

--- a/tests/test_funding_normalization_strategy.py
+++ b/tests/test_funding_normalization_strategy.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import pytest
+
+from src.strategy.funding_normalization import FundingNormalizationStrategy
+from src.strategy.signals import SignalType
+
+
+@pytest.mark.asyncio
+async def test_funding_normalization_buys_once_per_negative_cycle() -> None:
+    strategy = FundingNormalizationStrategy(
+        {"entry_threshold": 0.0005, "exit_threshold": 0.00015, "long_only": True}
+    )
+    symbol = "SOLUSDT"
+    base = {"close_price": 100.0}
+
+    hold_extreme = await strategy.evaluate(symbol, {**base, "funding_rate": -0.0008})
+    assert hold_extreme.type == SignalType.HOLD
+
+    buy = await strategy.evaluate(symbol, {**base, "funding_rate": 0.00005})
+    assert buy.type == SignalType.BUY
+    assert buy.reason == "funding_normalized_from_negative"
+
+    hold_cooldown = await strategy.evaluate(symbol, {**base, "funding_rate": 0.00004})
+    assert hold_cooldown.type == SignalType.HOLD
+
+    await strategy.evaluate(symbol, {**base, "funding_rate": -0.0007})
+    second_buy = await strategy.evaluate(symbol, {**base, "funding_rate": 0.00003})
+    assert second_buy.type == SignalType.BUY
+
+
+@pytest.mark.asyncio
+async def test_funding_normalization_holds_without_funding() -> None:
+    strategy = FundingNormalizationStrategy({})
+    signal = await strategy.evaluate("SOLUSDT", {"close_price": 50.0})
+    assert signal.type == SignalType.HOLD
+    assert signal.reason == "no_funding_rate"


### PR DESCRIPTION
## Summary

Wave 9: tightly scoped `funding_normalization_standalone` on **SOLUSDT 1h only**, after prod probe showed sole HAS_PULSE on SOL `neg_tail_10pct`.

## Scope

- New strategy `funding_normalization` (long-only, enter on normalize-from-negative)
- Autoresearch family with entry band 0.00012–0.00022, time stops 12h/24h/48h
- Launcher: `scripts/run_b_sol_funding_norm_campaign.sh`

## Not in this PR

- Live deploy
- bootstrap=1000 (only after promotion_candidate + overlap check)
- ETH 4h bounded b=1000 (skipped — formal reject expected)

## Post-merge ops

```bash
./scripts/run_b_sol_funding_norm_campaign.sh
```

Then overlap vs live SOL agents before any promotion.

Co-Authored-By: Grok <noreply@x.ai>