### PR TITLE
feat(backtest): add sentiment portfolio replay (T033)

### DIFF
--- a/scripts/run_sentiment_portfolio_replay.py
+++ b/scripts/run_sentiment_portfolio_replay.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import sys
+from pathlib import Path
+
+import yaml
+
+# Add project root when invoked as python scripts/run_sentiment_portfolio_replay.py.
+sys.path.append(os.getcwd())
+
+from src.backtest.portfolio import PortfolioReplayConfig, PortfolioReplayEngine
+from src.db import close_pool, init_pool
+from src.features.reader import IndicatorReader
+from src.main import _resolve_strategy_config, load_settings
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run sentiment portfolio replay")
+    parser.add_argument("--config", default="config/settings.sentiment_macro.yaml")
+    parser.add_argument("--start", required=True)
+    parser.add_argument("--end", required=True)
+    parser.add_argument("--replay-sentiment-log", required=True)
+    parser.add_argument("--replay-sentiment-max-age-hours", type=float, default=24.0)
+    return parser.parse_args()
+
+
+async def main() -> None:
+    args = parse_args()
+    settings = load_settings(Path(args.config))
+    strategy_classes, strategy_configs, aggregator_config = _resolve_strategy_config(
+        settings.strategy
+    )[:3]
+    with Path(args.config).open("r", encoding="utf-8") as file_handle:
+        raw_config = yaml.safe_load(file_handle) or {}
+    trading_execution = raw_config.get("trading_execution", {})
+    exit_rules = trading_execution.get("exit_rules", {}) or {}
+    futures = raw_config.get("futures", {})
+    db_config = {
+        "host": os.getenv("DB_HOST", settings.database.get("host", "localhost")),
+        "port": int(os.getenv("DB_PORT", settings.database.get("port", 5432))),
+        "name": os.getenv("DB_NAME", settings.database.get("name", "marketdata")),
+        "user": os.getenv("DB_USER", settings.database.get("user", "trading")),
+        "password": os.getenv("DB_PASSWORD", settings.database.get("password", "")),
+    }
+    config = PortfolioReplayConfig(
+        symbols=settings.trading_pairs,
+        timeframe=settings.timeframe,
+        start_date=args.start,
+        end_date=args.end,
+        strategy_classes=strategy_classes,
+        strategy_configs=strategy_configs,
+        aggregator_config=aggregator_config,
+        replay_sentiment_path=args.replay_sentiment_log,
+        replay_sentiment_max_age_seconds=args.replay_sentiment_max_age_hours * 3600,
+        global_trend_filter_buffer_pct=settings.strategy.global_trend_filter_buffer_pct,
+        max_concurrent_longs=int(futures.get("max_concurrent_longs", 1)),
+        sl_cooldown_minutes=float(futures.get("sl_cooldown_minutes", 0)),
+        order_size_usdt=settings.trading_execution.order_size_usdt,
+        sl_atr_multiplier=float(trading_execution.get("sl_atr_multiplier", 2.0)),
+        tp_atr_multiplier=float(trading_execution.get("tp_atr_multiplier", 3.5)),
+        trailing_activate_atr=float(trading_execution.get("trailing_activate_atr", 1.5)),
+        trailing_offset_atr=float(trading_execution.get("trailing_offset_atr", 1.0)),
+        time_stop_minutes=float(exit_rules.get("time_stop_minutes", 0)),
+    )
+    await init_pool(db_config)
+    try:
+        reader = IndicatorReader(db_config)
+        async with reader:
+            result = await PortfolioReplayEngine(config, reader).run()
+    finally:
+        await close_pool()
+
+    print("SENTIMENT PORTFOLIO REPLAY")
+    print(f"Symbols:              {', '.join(config.symbols)}")
+    print(f"Trades:               {len(result.trades)}")
+    print(f"Win rate:             {result.win_rate:.2f}%")
+    print(f"Total P&L:            {result.total_pnl:.4f} USDT")
+    print(f"Profit factor:        {result.profit_factor:.2f}")
+    print(f"Skipped slot buys:    {result.skipped_slot_buys}")
+    print(f"Skipped cooldown buys:{result.skipped_cooldown_buys:>5}")
+    for trade in result.trades:
+        print(
+            f"{trade.entry_time} -> {trade.exit_time} {trade.symbol} "
+            f"{trade.exit_reason} {trade.pnl:+.4f} USDT ({trade.return_pct:+.2f}%)"
+        )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/src/backtest/portfolio.py
+++ b/src/backtest/portfolio.py
@@ -1,0 +1,271 @@
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from datetime import datetime
+
+from src.backtest.sentiment_replay import ReplaySentimentScorer
+from src.features.reader import IndicatorReader
+from src.strategy.aggregator import SignalAggregator
+from src.strategy.base import BaseStrategy
+from src.strategy.sentiment_mean_reversion import SentimentMeanReversionStrategy
+from src.strategy.signals import SignalType
+
+
+@dataclass(frozen=True)
+class PortfolioReplayConfig:
+    symbols: list[str]
+    timeframe: str
+    start_date: str
+    end_date: str
+    strategy_classes: list[type[BaseStrategy]]
+    strategy_configs: list[Mapping[str, object] | None] = field(default_factory=list)
+    aggregator_config: Mapping[str, object] = field(default_factory=dict)
+    replay_sentiment_path: str | None = None
+    replay_sentiment_max_age_seconds: float | None = None
+    global_trend_filter_buffer_pct: float = 0.0
+    max_concurrent_longs: int = 1
+    sl_cooldown_minutes: float = 0.0
+    order_size_usdt: float = 100.0
+    fee_rate: float = 0.0005
+    slippage_pct: float = 0.001
+    sl_atr_multiplier: float = 2.0
+    tp_atr_multiplier: float = 3.5
+    trailing_activate_atr: float = 1.5
+    trailing_offset_atr: float = 1.0
+    time_stop_minutes: float = 0.0
+
+
+@dataclass(frozen=True)
+class PortfolioReplayTrade:
+    symbol: str
+    entry_time: str
+    exit_time: str
+    entry_price: float
+    exit_price: float
+    quantity: float
+    pnl: float
+    return_pct: float
+    exit_reason: str
+
+
+@dataclass(frozen=True)
+class PortfolioReplayResult:
+    trades: list[PortfolioReplayTrade]
+    skipped_slot_buys: int
+    skipped_cooldown_buys: int
+    total_pnl: float
+    win_rate: float
+    profit_factor: float
+
+
+@dataclass
+class _OpenLong:
+    symbol: str
+    entry_time: str
+    entry_price: float
+    quantity: float
+    atr: float
+    sl_price: float
+    tp_price: float
+    high_water_mark: float
+    entry_fee: float
+
+
+class PortfolioReplayEngine:
+    """Replay long-only strategy signals with the live futures portfolio slot rules."""
+
+    def __init__(self, config: PortfolioReplayConfig, reader: IndicatorReader) -> None:
+        if config.max_concurrent_longs != 1:
+            raise ValueError("Portfolio replay currently supports max_concurrent_longs=1 only")
+        self._config = config
+        self._reader = reader
+        self._aggregator = SignalAggregator(config.aggregator_config)
+        self._position: _OpenLong | None = None
+        self._last_stop_loss: dict[str, datetime] = {}
+        self._trades: list[PortfolioReplayTrade] = []
+        self._skipped_slot_buys = 0
+        self._skipped_cooldown_buys = 0
+
+    async def run(self) -> PortfolioReplayResult:
+        replay_scorer = self._build_replay_scorer()
+        strategies = self._build_strategies(replay_scorer)
+        rows_by_symbol = {
+            symbol: await self._reader.fetch_range(
+                symbol,
+                self._config.timeframe,
+                self._config.start_date,
+                self._config.end_date,
+            )
+            for symbol in self._config.symbols
+        }
+        rows_by_time: dict[str, dict[str, dict[str, float]]] = {}
+        for symbol, rows in rows_by_symbol.items():
+            for row in rows:
+                rows_by_time.setdefault(str(row["time"]), {})[symbol] = row
+
+        for timestamp in sorted(rows_by_time):
+            rows = rows_by_time[timestamp]
+            self._process_exit(timestamp, rows)
+            for symbol in self._config.symbols:
+                row = rows.get(symbol)
+                if row is not None:
+                    await self._process_signal_cycle(symbol, timestamp, row, strategies[symbol])
+
+        if self._position is not None:
+            rows = rows_by_symbol[self._position.symbol]
+            if rows:
+                self._close_position(
+                    str(rows[-1]["time"]),
+                    float(rows[-1]["close_price"]),
+                    "END_OF_REPLAY",
+                )
+        return self._create_result()
+
+    def _build_replay_scorer(self) -> ReplaySentimentScorer | None:
+        if not self._config.replay_sentiment_path:
+            return None
+        return ReplaySentimentScorer(
+            self._config.replay_sentiment_path,
+            max_age_seconds=self._config.replay_sentiment_max_age_seconds,
+        )
+
+    def _build_strategies(
+        self, replay_scorer: ReplaySentimentScorer | None
+    ) -> dict[str, list[BaseStrategy]]:
+        strategies_by_symbol = {}
+        for symbol in self._config.symbols:
+            strategies = []
+            for index, strategy_class in enumerate(self._config.strategy_classes):
+                strategy_config = (
+                    self._config.strategy_configs[index]
+                    if index < len(self._config.strategy_configs)
+                    else None
+                )
+                strategy = strategy_class(strategy_config)
+                if replay_scorer is not None and isinstance(
+                    strategy, SentimentMeanReversionStrategy
+                ):
+                    strategy.set_scorer(replay_scorer)
+                strategies.append(strategy)
+            strategies_by_symbol[symbol] = strategies
+        return strategies_by_symbol
+
+    def _process_exit(self, timestamp: str, rows: Mapping[str, Mapping[str, float]]) -> None:
+        position = self._position
+        if position is None:
+            return
+        row = rows.get(position.symbol)
+        if row is None:
+            return
+        high_price = float(row.get("high_price", row["close_price"]))
+        low_price = float(row.get("low_price", row["close_price"]))
+        position.high_water_mark = max(position.high_water_mark, high_price)
+        trailing_activation = (
+            position.entry_price + self._config.trailing_activate_atr * position.atr
+        )
+        if position.high_water_mark >= trailing_activation:
+            position.sl_price = max(
+                position.sl_price,
+                position.high_water_mark - self._config.trailing_offset_atr * position.atr,
+            )
+        if low_price <= position.sl_price:
+            self._close_position(timestamp, position.sl_price, "STOP_LOSS")
+            return
+        if high_price >= position.tp_price:
+            self._close_position(timestamp, position.tp_price, "TAKE_PROFIT")
+            return
+        if self._config.time_stop_minutes > 0:
+            elapsed = datetime.fromisoformat(timestamp) - datetime.fromisoformat(
+                position.entry_time
+            )
+            if elapsed.total_seconds() / 60 >= self._config.time_stop_minutes:
+                self._close_position(timestamp, float(row["close_price"]), "TIME_STOP")
+
+    async def _process_signal_cycle(
+        self,
+        symbol: str,
+        timestamp: str,
+        row: Mapping[str, float],
+        strategies: list[BaseStrategy],
+    ) -> None:
+        signals = [await strategy.evaluate(symbol, row) for strategy in strategies]
+        signal = self._aggregator.aggregate(symbol, signals, ema_200=row.get("ema_200"))
+        current_price = float(row["close_price"])
+        if signal.type == SignalType.BUY:
+            ema_200 = row.get("ema_200")
+            if ema_200 is not None and current_price < float(ema_200) * (
+                1 - self._config.global_trend_filter_buffer_pct
+            ):
+                return
+            if self._position is not None:
+                self._skipped_slot_buys += 1
+                return
+            last_stop = self._last_stop_loss.get(symbol)
+            if last_stop is not None:
+                elapsed = datetime.fromisoformat(timestamp) - last_stop
+                if elapsed.total_seconds() / 60 < self._config.sl_cooldown_minutes:
+                    self._skipped_cooldown_buys += 1
+                    return
+            self._open_position(symbol, timestamp, current_price, float(row.get("atr_14", 0.0)))
+        elif (
+            signal.type == SignalType.SELL
+            and self._position is not None
+            and self._position.symbol == symbol
+        ):
+            self._close_position(timestamp, current_price, "SIGNAL")
+
+    def _open_position(self, symbol: str, timestamp: str, price: float, atr: float) -> None:
+        entry_price = price * (1 + self._config.slippage_pct)
+        quantity = self._config.order_size_usdt / entry_price
+        self._position = _OpenLong(
+            symbol=symbol,
+            entry_time=timestamp,
+            entry_price=entry_price,
+            quantity=quantity,
+            atr=atr,
+            sl_price=entry_price - self._config.sl_atr_multiplier * atr,
+            tp_price=entry_price + self._config.tp_atr_multiplier * atr,
+            high_water_mark=entry_price,
+            entry_fee=entry_price * quantity * self._config.fee_rate,
+        )
+
+    def _close_position(self, timestamp: str, price: float, reason: str) -> None:
+        position = self._position
+        if position is None:
+            return
+        exit_price = price * (1 - self._config.slippage_pct)
+        exit_fee = exit_price * position.quantity * self._config.fee_rate
+        pnl = (
+            (exit_price - position.entry_price) * position.quantity - position.entry_fee - exit_fee
+        )
+        self._trades.append(
+            PortfolioReplayTrade(
+                symbol=position.symbol,
+                entry_time=position.entry_time,
+                exit_time=timestamp,
+                entry_price=position.entry_price,
+                exit_price=exit_price,
+                quantity=position.quantity,
+                pnl=pnl,
+                return_pct=pnl / self._config.order_size_usdt * 100,
+                exit_reason=reason,
+            )
+        )
+        if reason == "STOP_LOSS":
+            self._last_stop_loss[position.symbol] = datetime.fromisoformat(timestamp)
+        self._position = None
+
+    def _create_result(self) -> PortfolioReplayResult:
+        wins = [trade.pnl for trade in self._trades if trade.pnl > 0]
+        losses = [trade.pnl for trade in self._trades if trade.pnl <= 0]
+        gross_loss = abs(sum(losses))
+        return PortfolioReplayResult(
+            trades=self._trades,
+            skipped_slot_buys=self._skipped_slot_buys,
+            skipped_cooldown_buys=self._skipped_cooldown_buys,
+            total_pnl=sum(trade.pnl for trade in self._trades),
+            win_rate=len(wins) / len(self._trades) * 100 if self._trades else 0.0,
+            profit_factor=sum(wins) / gross_loss if gross_loss else math.inf if wins else 0.0,
+        )

--- a/tests/test_portfolio_backtest.py
+++ b/tests/test_portfolio_backtest.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import pytest
+
+from src.backtest.portfolio import PortfolioReplayConfig, PortfolioReplayEngine
+from src.features.reader import IndicatorReader
+from src.strategy.base import BaseStrategy
+from src.strategy.signals import Signal, SignalType
+
+
+class BuyAtFirstBarStrategy(BaseStrategy):
+    def get_name(self) -> str:
+        return "BuyAtFirstBar"
+
+    async def evaluate(self, symbol: str, indicators: dict[str, float]) -> Signal:
+        signal_type = SignalType.BUY if indicators["close_price"] == 100.0 else SignalType.HOLD
+        return Signal(signal_type, symbol, indicators["close_price"], 1.0, "test", indicators)
+
+
+def _row(timestamp: str, close: float, *, high: float | None = None, low: float | None = None):
+    return {
+        "time": timestamp,
+        "close_price": close,
+        "high_price": close if high is None else high,
+        "low_price": close if low is None else low,
+        "atr_14": 1.0,
+        "ema_200": 90.0,
+    }
+
+
+def _reader(rows_by_symbol: dict[str, list[dict[str, float]]]) -> IndicatorReader:
+    reader = IndicatorReader({})
+
+    async def fetch_range(symbol: str, *_args):
+        return rows_by_symbol[symbol]
+
+    reader.fetch_range = fetch_range
+    return reader
+
+
+def _config() -> PortfolioReplayConfig:
+    return PortfolioReplayConfig(
+        symbols=["ETHUSDT", "SOLUSDT"],
+        timeframe="1h",
+        start_date="2026-01-01",
+        end_date="2026-01-02",
+        strategy_classes=[BuyAtFirstBarStrategy],
+        aggregator_config={"min_agreement": 1, "buy_threshold": 0.5},
+        order_size_usdt=100.0,
+        fee_rate=0.0,
+        slippage_pct=0.0,
+        sl_atr_multiplier=1.0,
+        tp_atr_multiplier=3.0,
+    )
+
+
+@pytest.mark.asyncio
+async def test_first_symbol_claims_slot_and_blocks_second_buy_in_same_cycle() -> None:
+    rows = {
+        "ETHUSDT": [_row("2026-01-01T00:00:00", 100.0), _row("2026-01-01T01:00:00", 101.0)],
+        "SOLUSDT": [_row("2026-01-01T00:00:00", 100.0), _row("2026-01-01T01:00:00", 101.0)],
+    }
+
+    result = await PortfolioReplayEngine(_config(), _reader(rows)).run()
+
+    assert [trade.symbol for trade in result.trades] == ["ETHUSDT"]
+    assert result.skipped_slot_buys == 1
+
+
+@pytest.mark.asyncio
+async def test_atr_exit_releases_slot_before_next_signal_cycle() -> None:
+    rows = {
+        "ETHUSDT": [
+            _row("2026-01-01T00:00:00", 100.0),
+            _row("2026-01-01T01:00:00", 99.0, low=98.5),
+        ],
+        "SOLUSDT": [
+            _row("2026-01-01T00:00:00", 101.0),
+            _row("2026-01-01T01:00:00", 100.0),
+        ],
+    }
+
+    result = await PortfolioReplayEngine(_config(), _reader(rows)).run()
+
+    assert [trade.symbol for trade in result.trades] == ["ETHUSDT", "SOLUSDT"]
+    assert result.trades[0].exit_reason == "STOP_LOSS"


### PR DESCRIPTION
## Summary

Cherry-picked from the original `feat/T033-sentiment-portfolio-replay` branch (commit `d318a07` by yderf + OpenCode, 2026-06-01) onto current main. The original branch was ~100 commits behind, so opening a PR from it directly would have produced a noisy diff showing everything that landed after June 1 as 'removed'. This branch is just the single feature commit applied cleanly on top of `df067f4`.

## What this adds

A portfolio-level replay engine for sentiment strategies — lets us backtest concurrent-position behavior (slot allocation, SL cooldowns, multi-symbol coordination) rather than treating each symbol in isolation.

**New files (450 lines)**:
- `src/backtest/portfolio.py` (271) — `PortfolioReplay` engine with `PortfolioReplayConfig`/`PortfolioReplayTrade` dataclasses, slot-based position tracking, ATR-based exit logic, SL cooldown enforcement
- `scripts/run_sentiment_portfolio_replay.py` (93) — CLI entrypoint
- `tests/test_portfolio_backtest.py` (86) — slot-claim and ATR-exit unit tests

## Verification
- `uv run ruff check .` — clean
- `uv run ruff format --check .` — clean (267 files)
- `uv run pytest tests/test_portfolio_backtest.py -v` — 2 passed
- `uv run pytest -q` — **867 passed, 1 skipped** (full suite)
- No conflicts with current main; cherry-pick applied without manual intervention
- All imports resolve against current main (`sentiment_replay`, `IndicatorReader`, `SignalAggregator`, `SentimentMeanReversionStrategy`)

## Provenance

Original branch deleted in favor of this one. Original commit author attribution preserved (`yderf` + `OpenCode` Co-Authored-By).

## Test plan
- [x] Lint + format clean
- [x] All 867 existing tests still pass
- [x] T033's own 2 tests pass
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)