### PR TITLE
feat(backtest): add supervised RBI autoresearch loop

### DIFF
--- a/config/autoresearch/rbi_loop.basis-premium-filter-v0.yaml
+++ b/config/autoresearch/rbi_loop.basis-premium-filter-v0.yaml
@@ -1,0 +1,61 @@
+# RBI lane manifest: basis-premium risk filter v0 (filter-first on SOL 1h overlay)
+#
+# Probe (cheap, read-only) produced HAS_PULSE on perp basis/premium tails.
+# Subsequent Phase 1/2 WFO A/B (filter attached to promoted SOL overlay) REJECTED.
+# This manifest records the full supervised path through the RBI guard.
+#
+# See:
+# - docs/reports/basis-premium-probe-2026-06-05.md (HAS_PULSE)
+# - docs/specs/basis-premium-risk-filter-surface-v0.md (full surface + Phase 2 CLOSED result)
+# - docs/reports/research-reset-2026-06-06.md (basis long filter on SOL overlay now closed/banned)
+#
+# Default (no --execute): only writes decision + report. Execution of any command requires
+# explicit review + --execute (and for this lane the WFO already ran and failed).
+
+lane_name: basis-premium-filter-v0
+lane_brief: docs/specs/basis-premium-risk-filter-surface-v0.md
+probe_verdict: HAS_PULSE
+
+# After the "RUN_AUTORESEARCH" equivalent (here the custom basis filter WFO A/B),
+# point last_result at a record that captures the rejection.
+# We use a minimal structure the guard understands (passes_gates=false or not promotion eligible).
+last_result: research/rbi_loop/basis-premium-filter-v0/last_wfo_result.json
+
+# Overlap with the live SOL 1h overlay was checked in the WFO A/B era;
+# we can point at the existing overlap artifact or let the guard ask for CHECK_OVERLAP.
+overlap_report: docs/reports/entry-overlap-sol-1h.json
+
+decision_output: research/rbi_loop/basis-premium-filter-v0/decision.json
+report_output: docs/reports/rbi-loop-basis-premium-filter-v0.md
+timeout_seconds: 1800
+
+commands:
+  # The "cheap probe" step was already executed historically (see probe report).
+  # We record the command for reproducibility / future re-probe.
+  RUN_CHEAP_PROBE: >-
+    uv run python scripts/probe_basis_premium.py
+    --symbols BTCUSDT,ETHUSDT,SOLUSDT
+    --timeframe 1h
+
+  # The main validation work for this surface was the dedicated basis filter WFO A/B
+  # (not a generic autoresearch family sweep). Record it here as the "research" step.
+  RUN_AUTORESEARCH: >-
+    bash scripts/run_basis_filter_wfo_ab.sh
+
+  # If we ever wanted a broader search around the filter thresholds, this would be it.
+  # (Not executed for v0; the direct WFO A/B was used instead.)
+  RUN_BOOTSTRAP_1000: >-
+    uv run python scripts/run_autoresearch.py
+    --config config/settings.autoresearch.yaml
+    --symbol SOLUSDT
+    --timeframe 1h
+    --train-months 3
+    --test-months 2
+    --bootstrap 1000
+    --gate-profile standard
+    --description basis-premium-filter-b1000
+
+  # Overlap vs the live promoted agent (and any other paper candidates).
+  CHECK_OVERLAP: >-
+    uv run python scripts/analyze_entry_overlap.py
+    --output docs/reports/rbi-loop-basis-premium-filter-v0-overlap.json

--- a/config/autoresearch/rbi_loop.cross-venue-basis-v1.yaml
+++ b/config/autoresearch/rbi_loop.cross-venue-basis-v1.yaml
@@ -1,0 +1,67 @@
+# RBI lane manifest: cross-venue basis / dislocation v1
+#
+# Highest-priority new primitive per research-reset-2026-06-06.
+# Single-venue basis/premium filter work (basis-premium-filter-v0) reached HAS_PULSE
+# on probe but was later WFO-rejected as an overlay filter and is now closed.
+#
+# This lane requires new multi-venue data before a real cheap probe can run.
+# probe_verdict is intentionally left empty → guard should recommend RUN_CHEAP_PROBE
+# (or WRITE_LANE_BRIEF if the brief is missing) on first evaluation.
+#
+# Drive with:
+#   uv run python scripts/rbi_loop_from_manifest.py --manifest config/autoresearch/rbi_loop.cross-venue-basis-v1.yaml
+# (dry by default; --execute only after reviewing the guard decision)
+
+lane_name: cross-venue-basis-v1
+lane_brief: docs/specs/cross-venue-basis-dislocation-brief-v0.md
+probe_verdict:   # Empty on purpose — first step is cheap probe after data lands
+
+# last_result and overlap_report will be populated by prior steps once the lane advances.
+last_result:
+overlap_report:
+
+decision_output: research/rbi_loop/cross-venue-basis-v1/decision.json
+report_output: docs/reports/rbi-loop-cross-venue-basis-v1.md
+timeout_seconds: 3600
+
+commands:
+  # Cheap probe / coverage + dislocation signal (read-only).
+  # Does not exist yet; will be a new or extended script (see investigation of
+  # probe_basis_premium.py + audit_basis_premium_coverage.py + funding probes).
+  # Must support at least two venues and compute relative dislocation metrics.
+  RUN_CHEAP_PROBE: >-
+    uv run python scripts/probe_cross_venue_basis.py
+    --venues binance_usdm,bybit,okx
+    --symbols BTCUSDT,ETHUSDT,SOLUSDT
+    --timeframe 1h
+    --start 2024-01-01
+
+  # Bounded autoresearch only after HAS_PULSE + guard allows.
+  # Families will be new (dislocation / venue-regime / cross-basis filters), not
+  # the exhausted trend_pullback_overlay or single-venue premium families.
+  RUN_AUTORESEARCH: >-
+    uv run python scripts/autoresearch_loop.py
+    --config config/settings.autoresearch.yaml
+    --symbol SOLUSDT
+    --timeframe 1h
+    --train-months 3
+    --test-months 2
+    --gate-profile standard
+    --families cross_venue_dislocation,venue_basis_filter
+    --max-runs 30
+
+  RUN_BOOTSTRAP_1000: >-
+    uv run python scripts/run_autoresearch.py
+    --config config/settings.autoresearch.yaml
+    --symbol SOLUSDT
+    --timeframe 1h
+    --train-months 3
+    --test-months 2
+    --bootstrap 1000
+    --gate-profile standard
+    --description cross-venue-basis-v1-b1000
+
+  CHECK_OVERLAP: >-
+    uv run python scripts/analyze_entry_overlap.py
+    --output docs/reports/rbi-loop-cross-venue-basis-v1-overlap.json
+    --against sol-1h-trend-pullback-overlay-live,sentiment-macro

--- a/config/autoresearch/rbi_loop.example.yaml
+++ b/config/autoresearch/rbi_loop.example.yaml
@@ -6,6 +6,9 @@
 lane_name: example-data-first-lane
 lane_brief: docs/specs/example-data-first-lane.md
 probe_verdict:
+# After the RUN_AUTORESEARCH step runs, point last_result at the child run result
+# it writes (run_autoresearch.py defaults to research/last_result.json) so the next
+# pass can advance from RUN_AUTORESEARCH to RUN_BOOTSTRAP_1000.
 last_result:
 overlap_report:
 

--- a/config/autoresearch/rbi_loop.example.yaml
+++ b/config/autoresearch/rbi_loop.example.yaml
@@ -1,0 +1,40 @@
+# Example RBI loop lane manifest.
+#
+# This file is a template. Copy it to a lane-specific path and replace placeholders before use.
+# Default runner behavior records a decision/report only; execution requires --execute.
+
+lane_name: example-data-first-lane
+lane_brief: docs/specs/example-data-first-lane.md
+probe_verdict:
+last_result:
+overlap_report:
+
+decision_output: research/rbi_loop/example-data-first-lane/decision.json
+report_output: docs/reports/rbi-loop-example-data-first-lane.md
+timeout_seconds: 1800
+
+commands:
+  RUN_CHEAP_PROBE: uv run python scripts/probe_basis_premium.py
+  RUN_AUTORESEARCH: >-
+    uv run python scripts/autoresearch_loop.py
+    --config config/settings.autoresearch.yaml
+    --symbol SOLUSDT
+    --timeframe 1h
+    --train-months 3
+    --test-months 2
+    --gate-profile standard
+    --families trend_pullback_overlay
+    --max-runs 30
+  RUN_BOOTSTRAP_1000: >-
+    uv run python scripts/run_autoresearch.py
+    --config config/settings.autoresearch.yaml
+    --symbol SOLUSDT
+    --timeframe 1h
+    --train-months 3
+    --test-months 2
+    --bootstrap 1000
+    --gate-profile standard
+    --description example-data-first-lane-b1000
+  CHECK_OVERLAP: >-
+    uv run python scripts/analyze_entry_overlap.py
+    --output docs/reports/rbi-loop-example-data-first-lane-overlap.json

--- a/docs/EXPERIMENT_AUTOPILOT.md
+++ b/docs/EXPERIMENT_AUTOPILOT.md
@@ -2,6 +2,10 @@
 
 `experiment_autopilot` combines baseline backtest, walk-forward validation, bootstrap uncertainty, and explicit acceptance gates in one command.
 
+For the higher-level RBI loop that decides when to run autoresearch, when to stop,
+and when a result can advance toward implementation or deployment, see
+[`RBI_AUTORESEARCH_LOOP.md`](RBI_AUTORESEARCH_LOOP.md).
+
 ## What It Does
 
 - Runs baseline backtest on a full range

--- a/docs/RBI_AUTORESEARCH_LOOP.md
+++ b/docs/RBI_AUTORESEARCH_LOOP.md
@@ -1,0 +1,408 @@
+# RBI Autoresearch Loop
+
+This document defines the closed-loop operating system for pursuing profitability in
+`crypto-trading-agent`.
+
+RBI means:
+
+1. **Research**: generate a falsifiable edge thesis and cheap probe.
+2. **Backtest**: validate through WFO, bootstrap, overlap, and robustness gates.
+3. **Implement**: ship only the minimum code/config needed, then paper or live-forward validate.
+
+The loop exists to let agents do repetitive exploration while keeping promotion decisions
+strict, auditable, and hard to game.
+
+## Current Portfolio Truth
+
+As of 2026-06-09, the evidence says:
+
+- `agent_sol_1h_trend_pullback_overlay_live` is the only promotion-grade technical agent.
+- `agent_sentiment_macro` is an independent small live experiment, not a clean backtest pass.
+- `agent_sol_sparse` and `agent_sol_panic_block_paper` are paper/research only.
+- New campaigns are paused unless a new primitive first shows a cheap-probe `HAS_PULSE`.
+
+Do not start from the assumption that more agents are needed. Start from the assumption that
+more bad agents increase correlated drawdown. Count is secondary to edge quality.
+
+## Loop Architecture
+
+```text
+VISION / constraints
+  -> Lane brief
+  -> Cheap probe
+  -> Autoresearch campaign
+  -> Standard WFO/bootstrap gate
+  -> Promotion-candidate gate
+  -> Bootstrap=1000 revalidation
+  -> Entry-overlap and portfolio-impact check
+  -> Paper / live-forward validation
+  -> Small live deployment or reject/close
+  -> Ledger update
+```
+
+The loop is closed because every stage writes artifacts that the next stage must read.
+The loop is bounded because every stage has kill criteria.
+
+## State Files
+
+Agents must treat these as the control plane:
+
+| File | Purpose |
+|---|---|
+| `docs/reports/research-reset-2026-06-06.md` | Current stop rules, banned hypotheses, allowed next families |
+| `docs/reports/autoresearch-candidate-ledger.md` | Canonical campaign and promotion ledger |
+| `docs/RESEARCH_FRAMEWORK.md` | Phase model and validation philosophy |
+| `docs/EXPERIMENT_AUTOPILOT.md` | Autopilot/autoresearch command reference |
+| `research/results.tsv` | Local autoresearch result ledger |
+| `research/last_result.json` | Latest local child run result |
+| Remote `/opt/crypto-agent/research/**/results.tsv` | Production DB-backed campaign ledgers |
+| Remote `/opt/crypto-agent/research/**/last_result.json` | Latest production DB-backed campaign result |
+
+If these files disagree, prefer the most recent committed report plus the raw `results.tsv`
+from the campaign being evaluated.
+
+## Agent Roles
+
+Use separate agent roles conceptually, even if one Codex instance performs them.
+
+| Role | Allowed work | Not allowed |
+|---|---|---|
+| Supervisor | Read ledgers, choose next lane, enforce stop rules | Tune parameters directly |
+| Researcher | Write lane brief, define cheap probe, inspect data coverage | Promote configs |
+| Probe Runner | Run read-only probe scripts and classify `HAS_PULSE`, `WEAK_EDGE`, `NO_PULSE` | Write strategy code |
+| Autoresearch Runner | Run bounded config-only sweeps | Change live configs or production services |
+| Validator | Check WFO/bootstrap, concentration, overlap, portfolio risk | Accept single-window winners |
+| Implementer | Add minimal code/config for a passed lane | Broaden scope or add knobs without evidence |
+| Operator | Deploy paper/live, monitor drift, rollback | Increase size without milestone evidence |
+
+## Hard Gates
+
+### Gate 0: Lane Brief
+
+Before code or sweeps, create or update a short brief in `docs/specs/` or `docs/reports/`:
+
+- edge thesis
+- why this primitive is different from banned lanes
+- expected regime
+- expected failure mode
+- signal definition
+- target symbol/timeframe
+- target trade density
+- independence expectation vs live agents
+- validation command plan
+
+Kill immediately if the brief is just "try parameters".
+
+### Gate 1: Cheap Probe
+
+Run a read-only probe before any strategy class or autoresearch campaign.
+
+Allowed examples:
+
+```bash
+uv run python scripts/probe_basis_premium.py
+uv run python scripts/probe_funding_normalization.py
+uv run python scripts/probe_volatility_squeeze_breakout.py
+uv run python scripts/probe_range_break_continuation.py
+```
+
+Probe classification:
+
+| Label | Meaning | Next action |
+|---|---|---|
+| `HAS_PULSE` | Forward return and MAE/fee profile are plausibly exploitable | Write bounded strategy surface |
+| `WEAK_EDGE` | Some signal exists but not enough after fees/risk | Close or redesign thesis |
+| `NO_PULSE` | No useful predictive structure | Close lane |
+
+No `HAS_PULSE`, no autoresearch.
+
+### Gate 2: Bounded Autoresearch
+
+Autoresearch is config-only unless the lane brief explicitly requires a new strategy class.
+
+Primary tools:
+
+```bash
+uv run python scripts/autoresearch_loop.py \
+  --config config/settings.autoresearch.yaml \
+  --symbol SOLUSDT \
+  --timeframe 1h \
+  --train-months 3 \
+  --test-months 2 \
+  --gate-profile standard \
+  --families <family> \
+  --max-runs 30
+```
+
+Before launching or advancing a lane, run the supervisor guard against the artifacts
+available so far:
+
+```bash
+uv run python scripts/rbi_loop_guard.py \
+  --lane-brief docs/specs/<lane>.md \
+  --probe-verdict HAS_PULSE \
+  --last-result research/last_result.json \
+  --overlap-report docs/reports/<overlap>.json \
+  --pretty
+```
+
+The guard does not run backtests. It returns the next allowed action from the current
+artifacts, such as `RUN_CHEAP_PROBE`, `RUN_AUTORESEARCH`, `RUN_BOOTSTRAP_1000`,
+`CHECK_OVERLAP`, `READY_FOR_PAPER_REVIEW`, or `ITERATE_OR_CLOSE`.
+
+Use the runner when an agent should persist the decision and optionally execute the next
+local command:
+
+```bash
+uv run python scripts/rbi_loop_runner.py \
+  --lane-name <lane> \
+  --lane-brief docs/specs/<lane>.md \
+  --probe-verdict HAS_PULSE \
+  --last-result research/last_result.json \
+  --autoresearch-command "uv run python scripts/autoresearch_loop.py --config config/settings.autoresearch.yaml --symbol SOLUSDT --timeframe 1h --train-months 3 --test-months 2 --gate-profile standard --families <family> --max-runs 30"
+```
+
+Default runner mode only writes `research/rbi_loop/<lane>/decision.json`. Add `--execute`
+only for local read-only probes, config-only autoresearch, bootstrap revalidation, or
+overlap checks. Do not use the runner for production deploys or live risk changes.
+
+For repeatable lanes, prefer a manifest:
+
+```bash
+cp config/autoresearch/rbi_loop.example.yaml config/autoresearch/rbi_loop.<lane>.yaml
+uv run python scripts/rbi_loop_from_manifest.py --manifest config/autoresearch/rbi_loop.<lane>.yaml
+```
+
+The manifest is the lane's local control file: it records artifact paths, timeout, and
+the exact commands mapped to `RUN_CHEAP_PROBE`, `RUN_AUTORESEARCH`,
+`RUN_BOOTSTRAP_1000`, and `CHECK_OVERLAP`. Add `--execute` only after reviewing the
+manifest and confirming the selected action is safe.
+
+For a multi-lane supervisor pass:
+
+```bash
+uv run python scripts/rbi_loop_batch.py \
+  --glob "config/autoresearch/rbi_loop.*.yaml" \
+  --summary-output research/rbi_loop/batch-summary.json \
+  --markdown-output docs/reports/rbi-loop-batch-summary.md
+```
+
+Batch mode skips `rbi_loop.example.yaml` by default. It runs one guarded step per lane,
+writes per-lane decision/report artifacts, and produces a batch summary. Use `--execute`
+only for an explicitly reviewed manifest set; batch mode is not a production deploy tool.
+
+For scheduled dry supervision on the production host, install:
+
+```bash
+sudo cp ops/systemd/crypto-agent-rbi-loop-batch.service /etc/systemd/system/
+sudo cp ops/systemd/crypto-agent-rbi-loop-batch.timer /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now crypto-agent-rbi-loop-batch.timer
+```
+
+The systemd job runs `scripts/run_rbi_loop_batch.sh` without `--execute`. It only writes
+decision/report summaries. To change manifest discovery or output paths, use
+`/etc/default/crypto-agent-rbi-loop-batch`:
+
+```bash
+MANIFEST_GLOB=config/autoresearch/rbi_loop.*.yaml
+SUMMARY_OUTPUT=research/rbi_loop/batch-summary.json
+MARKDOWN_OUTPUT=docs/reports/rbi-loop-batch-summary.md
+```
+
+After each runner step, render a durable report artifact:
+
+```bash
+uv run python scripts/rbi_loop_report.py \
+  --decision research/rbi_loop/<lane>/decision.json \
+  --output docs/reports/rbi-loop-<lane>.md
+```
+
+Use the generated report as the reviewable handoff. Fold only final accepted outcomes into
+`docs/reports/autoresearch-candidate-ledger.md`; do not auto-edit the canonical ledger from
+raw runner output.
+
+For production DB-backed research:
+
+```bash
+scripts/run_autoresearch_tunnel.sh \
+  --mode loop \
+  --config config/settings.autoresearch.yaml \
+  --symbol SOLUSDT \
+  --timeframe 1h \
+  --train-months 3 \
+  --test-months 2 \
+  --bootstrap 100 \
+  --gate-profile standard \
+  --families <family> \
+  --max-runs 30 \
+  --timeout-seconds 900 \
+  --output-dir /tmp/crypto-agent-autoresearch-<lane>
+```
+
+Standard gate:
+
+- WFO trades >= 20
+- mean OOS Sharpe >= 0.5
+- OOS return > 0
+- max drawdown <= 10%
+- bootstrap P(loss) <= 25%
+- profit concentration <= 50%
+
+Do not lower the standard gate to create more agents. `probe_1h` is only a probe profile,
+not a promotion profile.
+
+### Gate 3: Promotion Candidate
+
+Before spending bootstrap=1000, the candidate must satisfy the stricter pre-filter:
+
+- WFO trades >= 20
+- OOS return >= 1%
+- max drawdown <= 8%
+- bootstrap P(loss) <= 20% at bootstrap=100
+- profit concentration <= 40%
+- Sharpe >= 0.5
+
+If it misses this gate, record the near-miss and stop unless the failure suggests a new
+first-principles surface.
+
+### Gate 4: Bootstrap=1000
+
+Run one final revalidation with bootstrap=1000. This is the real promotion filter.
+
+Near-misses at bootstrap=100 are not deployable. Prior AVAX/ETH near-misses collapsed at
+bootstrap=1000; treat that as the default expectation.
+
+### Gate 5: Independence and Portfolio Impact
+
+Before paper/live promotion:
+
+```bash
+uv run python scripts/analyze_entry_overlap.py --help
+```
+
+Compare candidate entries against:
+
+- `agent_sol_1h_trend_pullback_overlay_live`
+- `agent_sentiment_macro`
+- any currently enabled paper candidate on the same symbol/timeframe
+
+Reject or keep paper-only if overlap is high and the candidate does not add clear risk
+diversification.
+
+### Gate 6: Paper / Forward Validation
+
+Paper or minimum-size live-forward validation must track:
+
+- expected vs actual entries/month
+- fills and slippage
+- SL/TP placement reliability
+- trade duration
+- realized PnL
+- drawdown
+- overlap with existing agents
+- unexplained missed or extra signals
+
+Milestones for a new live agent:
+
+- 5 closed trades: sanity check only
+- 10 closed trades: behavior review
+- 20 closed trades: first serious forward verdict
+
+Do not scale before 20 closed trades unless there is an explicit human exception.
+
+## Stop Rules
+
+Stop the lane and write a ledger update if any of these happen:
+
+- No cheap-probe `HAS_PULSE`.
+- Three consecutive WFO attempts fail the same critical gate.
+- The candidate needs more than five free parameters.
+- The fix contradicts the original thesis.
+- Bootstrap=1000 P(loss) exceeds 25%.
+- Profit concentration exceeds 50%.
+- WFO trades stay below 20 after a trade-density-specific attempt.
+- Candidate overlaps heavily with a live agent without improving portfolio risk.
+- The lane belongs to a banned family in `research-reset-2026-06-06.md`.
+
+When a lane closes, write the reason in `docs/reports/autoresearch-candidate-ledger.md`
+or a dedicated report under `docs/reports/`.
+
+## Human Approval Points
+
+Agents may run read-only probes, local tests, and config-only sweeps within the configured
+budget. Human approval is required before:
+
+- live config changes
+- production service rebuilds or restarts
+- enabling a paper service in `docker-compose.prod.yml`
+- changing risk limits
+- increasing notional size
+- adding a new data provider with credentials
+- allowing short entries beyond research/paper mode
+
+## Implementation Rules
+
+Implement only after validation proves the lane deserves code.
+
+When implementation is needed:
+
+1. Add the smallest strategy/data/risk module that expresses the validated thesis.
+2. Add focused tests for signal behavior, config parsing, and execution routing.
+3. Run:
+
+```bash
+uv run ruff check .
+uv run ruff format --check .
+uv run pytest -v
+```
+
+4. Re-run the exact validation that justified the change.
+5. Update the ledger with artifact paths and the final decision.
+
+## Current Best Next Loop
+
+Given the 2026-06 research reset, the next profitable-agent loop should not be another
+SOL 1h threshold/filter campaign or another single-symbol 1h OHLCV structure probe.
+The liquidity-sweep and range-break families are closed unless new evidence appears.
+
+The next lane should be data-first:
+
+1. Cross-venue basis / dislocation.
+2. Higher-timeframe portfolio regime allocator.
+3. News/event calendar risk filter.
+4. Order book or liquidation data.
+
+For the next run:
+
+```text
+Write brief -> add/read data coverage probe -> classify pulse -> only then decide
+whether autoresearch is justified.
+```
+
+Until then, the active operating loop is Phase 0 forward validation of:
+
+- `agent_sol_1h_trend_pullback_overlay_live`
+- `agent_sentiment_macro`
+
+Weekly command:
+
+```bash
+uv run python scripts/paper_validation_report.py --help
+uv run python scripts/production_drift_sentinel.py
+scripts/run_phase0_weekly.sh
+```
+
+## Completion Definition
+
+The RBI loop is working only if every campaign leaves behind:
+
+- a lane brief or report
+- probe result
+- exact commands
+- raw artifact paths
+- gate decision
+- ledger update
+- explicit next action: promote, paper, iterate, or close
+
+Anything else is manual prompting with extra steps, not a closed loop.

--- a/docs/RESEARCH_FRAMEWORK.md
+++ b/docs/RESEARCH_FRAMEWORK.md
@@ -2,6 +2,10 @@
 
 A formal protocol for developing, validating, and promoting trading strategies in this codebase. Follow this for every new strategy and every major revision to an existing one.
 
+For the automated closed-loop operating model that wraps this framework with
+autoresearch, stop rules, artifact handoff, and human approval points, see
+[`RBI_AUTORESEARCH_LOOP.md`](RBI_AUTORESEARCH_LOOP.md).
+
 ---
 
 ## Overview

--- a/docs/reports/autoresearch-candidate-ledger.md
+++ b/docs/reports/autoresearch-candidate-ledger.md
@@ -57,6 +57,16 @@ Monitor: `ssh crypto-agent 'tail -f /opt/crypto-agent/research/<lane>/campaign.l
 |-------|--------|-----|-------|
 | agent_sol_1h_trend_pullback_overlay_live | SOLUSDT | 1h | Standard-gate technical stack + trend_pullback |
 | agent_sentiment_macro | SOLUSDT | 1h | Sentiment/macro — overlap risk for second SOL 1h technical |
+
+## RBI Loop Records (post 2026-06-09)
+
+Lanes are now processed through the supervised RBI guard + manifest system (see `docs/RBI_AUTORESEARCH_LOOP.md` and `config/autoresearch/rbi_loop.*.yaml`).
+
+| Lane | Probe Verdict | Validation Outcome | RBI Decision | Artifacts |
+|------|---------------|--------------------|--------------|-----------|
+| basis-premium-filter-v0 | HAS_PULSE (2026-06-05 probe) | Phase 2 WFO A/B: only 1 block, no DD/P(loss)/concentration improvement vs baseline (31 vs 36 trades). Surface v0 spec marked CLOSED. | ITERATE_OR_CLOSE (standard gate fail) | `research/rbi_loop/basis-premium-filter-v0/decision.json`, `docs/reports/rbi-loop-basis-premium-filter-v0.md` (generated via `rbi_loop_from_manifest.py` + batch) |
+
+This lane is closed per prior WFO evidence. New work must target a different primitive (cross-venue basis dislocation ranked highest in research-reset-2026-06-06).
 | agent_sol_sparse | SOLUSDT | 4h | trend_pullback sparse paper |
 | agent_sol_panic_block_paper | SOLUSDT | 4h | panic block paper |
 

--- a/docs/reports/rbi-loop-basis-premium-filter-v0.md
+++ b/docs/reports/rbi-loop-basis-premium-filter-v0.md
@@ -1,0 +1,34 @@
+# RBI Loop Decision — basis-premium-filter-v0
+
+| Field | Value |
+|---|---|
+| Generated at | 2026-06-09T16:37:11.233960+00:00 |
+| Action | `ITERATE_OR_CLOSE` |
+| Allowed | False |
+| Execute requested | False |
+| Selected command | `` |
+
+## Reasons
+
+- autoresearch result did not pass the standard gate
+
+## Evidence
+
+| Field | Value |
+|---|---|
+| lane_brief | docs/specs/basis-premium-risk-filter-surface-v0.md |
+| probe_verdict | HAS_PULSE |
+| last_result_status | keep |
+| gate_profile | filter_wfo_ab |
+| bootstrap |  |
+| passes_standard_gate | False |
+| eligible_for_bootstrap_1000 | False |
+| promotion_candidate_failures | `["insufficient_blocks", "no_risk_improvement", "oos_return_not_better"]` |
+
+## Execution
+
+No command execution was recorded.
+
+## Next Action
+
+ITERATE_OR_CLOSE

--- a/docs/reports/rbi-loop-completion-audit-2026-06-09.md
+++ b/docs/reports/rbi-loop-completion-audit-2026-06-09.md
@@ -1,0 +1,86 @@
+# RBI Loop Completion Audit — 2026-06-09
+
+## Objective
+
+Design and implement a solid automated system loop for `crypto-trading-agent` that keeps
+profitability as the original goal and supports RBI: Research, Backtest, Implement,
+including autoresearch.
+
+## Verdict
+
+**Complete for supervised automation.**
+
+The repo now has a documented and executable RBI control plane:
+
+1. A runbook defining the profitability-first loop, gates, roles, and stop rules.
+2. A deterministic guard that decides the next allowed action from artifacts.
+3. A one-step runner that persists decisions and only executes with explicit `--execute`.
+4. A report renderer that creates reviewable lane artifacts.
+5. A manifest runner for repeatable lane control files.
+6. A batch supervisor for multiple lane manifests.
+7. A dry systemd scheduling path for daily supervision.
+
+The implementation intentionally does **not** provide unattended production deployment or
+unreviewed live-risk changes. Those remain human approval points by design.
+
+## Requirement Audit
+
+| Requirement | Evidence | Status |
+|---|---|---|
+| Keep profitability as the goal | `docs/RBI_AUTORESEARCH_LOOP.md` starts from portfolio truth, blocks weak lanes, and keeps count secondary to edge quality | Complete |
+| Include Research | Gate 0 lane brief and Gate 1 cheap probe require falsifiable thesis and `HAS_PULSE` before sweeps | Complete |
+| Include Backtest | Gate 2 uses bounded autoresearch with WFO/bootstrap; Gates 3-5 require promotion pre-filter, bootstrap=1000, and overlap | Complete |
+| Include Implement | Implementation rules require minimal code/config, focused tests, exact validation rerun, and ledger update only after gates pass | Complete |
+| Include autoresearch | Existing `scripts/autoresearch_loop.py` remains the search engine; new RBI scripts gate and orchestrate its use | Complete |
+| Closed-loop artifacts | Runner writes `research/rbi_loop/<lane>/decision.json`; report writer writes `docs/reports/rbi-loop-<lane>.md`; batch writes summaries | Complete |
+| Multi-lane supervision | `scripts/rbi_loop_batch.py` processes lane manifests and writes batch JSON/Markdown summaries | Complete |
+| Repeatable lane config | `config/autoresearch/rbi_loop.example.yaml` defines the manifest shape for artifact paths and commands | Complete |
+| Scheduling | `scripts/run_rbi_loop_batch.sh` plus `ops/systemd/crypto-agent-rbi-loop-batch.{service,timer}` provide daily dry supervision | Complete |
+| Safety gates | Default mode is non-executing; `--execute` is explicit; scheduled systemd path does not include `--execute`; production deploy and live risk changes are banned from automation | Complete |
+| Verification coverage | Focused tests cover guard, runner, report, manifest, batch, and scheduler invariants | Complete |
+
+## Implemented Files
+
+| File | Purpose |
+|---|---|
+| `docs/RBI_AUTORESEARCH_LOOP.md` | Primary runbook and operating model |
+| `scripts/rbi_loop_guard.py` | Deterministic next-action gate |
+| `scripts/rbi_loop_runner.py` | One-step decision/execution wrapper |
+| `scripts/rbi_loop_report.py` | Decision JSON to Markdown report renderer |
+| `scripts/rbi_loop_from_manifest.py` | One-step runner from lane manifest |
+| `scripts/rbi_loop_batch.py` | Multi-lane batch supervisor |
+| `scripts/run_rbi_loop_batch.sh` | Dry batch wrapper for ops/scheduling |
+| `config/autoresearch/rbi_loop.example.yaml` | Lane manifest template |
+| `ops/systemd/crypto-agent-rbi-loop-batch.service` | Dry scheduled supervisor service |
+| `ops/systemd/crypto-agent-rbi-loop-batch.timer` | Daily scheduled supervisor timer |
+| `tests/test_rbi_loop_*.py` | Focused verification suite |
+
+## Verification Commands
+
+Focused verification used:
+
+```bash
+bash -n scripts/run_rbi_loop_batch.sh
+.venv/bin/python -m pytest tests/test_rbi_loop_guard.py tests/test_rbi_loop_runner.py tests/test_rbi_loop_report.py tests/test_rbi_loop_from_manifest.py tests/test_rbi_loop_batch.py tests/test_rbi_loop_scheduler.py -v
+ruff check scripts/rbi_loop_guard.py scripts/rbi_loop_runner.py scripts/rbi_loop_report.py scripts/rbi_loop_from_manifest.py scripts/rbi_loop_batch.py tests/test_rbi_loop_guard.py tests/test_rbi_loop_runner.py tests/test_rbi_loop_report.py tests/test_rbi_loop_from_manifest.py tests/test_rbi_loop_batch.py tests/test_rbi_loop_scheduler.py
+ruff format --check scripts/rbi_loop_guard.py scripts/rbi_loop_runner.py scripts/rbi_loop_report.py scripts/rbi_loop_from_manifest.py scripts/rbi_loop_batch.py tests/test_rbi_loop_guard.py tests/test_rbi_loop_runner.py tests/test_rbi_loop_report.py tests/test_rbi_loop_from_manifest.py tests/test_rbi_loop_batch.py tests/test_rbi_loop_scheduler.py
+```
+
+Smoke verification used temporary manifests under `/tmp` and produced:
+
+- `/tmp/rbi-batch/wrapper-summary.json`
+- `/tmp/rbi-batch/wrapper-summary.md`
+
+## Boundaries
+
+This completion is for a **supervised** automated loop. The following remain explicit
+human approval points:
+
+- `--execute` on any manifest or batch run
+- live config changes
+- production service rebuilds or restarts
+- enabling new paper/live services
+- changing risk limits or order sizes
+- adding credentialed data providers
+
+Those boundaries are part of the design, not missing implementation.

--- a/docs/reports/research-reset-2026-06-06.md
+++ b/docs/reports/research-reset-2026-06-06.md
@@ -5,7 +5,8 @@ what stays live, what is banned, and what kind of idea is allowed next.
 
 **Related:** [autoresearch-candidate-ledger.md](./autoresearch-candidate-ledger.md),
 [autoresearch-next-candidate-path-2026-06-04.md](./autoresearch-next-candidate-path-2026-06-04.md),
-[short-crowding-probe-2026-06-06.md](./short-crowding-probe-2026-06-06.md).
+[short-crowding-probe-2026-06-06.md](./short-crowding-probe-2026-06-06.md),
+and the closed-loop runbook [RBI_AUTORESEARCH_LOOP.md](../RBI_AUTORESEARCH_LOOP.md).
 
 ---
 

--- a/docs/specs/cross-venue-basis-dislocation-brief-v0.md
+++ b/docs/specs/cross-venue-basis-dislocation-brief-v0.md
@@ -1,0 +1,109 @@
+# Cross-Venue Basis / Dislocation — Lane Brief v0
+
+**Status:** Brief created; cheap probe + data ingestion required before any autoresearch or surface.
+**Date:** 2026-06-09
+**Related:** [research-reset-2026-06-06.md](../reports/research-reset-2026-06-06.md), [RBI_AUTORESEARCH_LOOP.md](../RBI_AUTORESEARCH_LOOP.md), prior single-venue basis work (closed).
+
+---
+
+## Edge Thesis
+
+Perp basis and premium reflect **venue-specific supply/demand and crowding**. When the same symbol shows materially different basis (mark vs index, or funding-implied) across exchanges (Binance USDT-M, Bybit, OKX, etc.), the dislocation can be a leading or coincident signal of:
+- Capital flowing to the "cheaper" venue (convergence trades).
+- One venue becoming crowded while another lags (arb or risk-off rotation).
+- Liquidity or margin regime differences that are not visible in any single exchange's OHLCV or its own premium index.
+
+The core hypothesis (HYP-CV-001): Large, persistent cross-venue basis spreads (or sudden dislocations) predict either mean-reverting convergence or accelerated one-sided moves on the lagging venue, with measurable edge after realistic taker fees + slippage, and with better MAE characteristics than baseline entries in the same regime.
+
+This is a **data-first primitive** (multi-venue derivatives microstructure) rather than another OHLCV shape, session label, or single-venue premium filter.
+
+## Why This Differs from Closed Single-Venue Basis Work
+
+The 2026-06 basis-premium v0 work (probe + risk-filter surface) used only `binance_usdm` `perp_basis_metrics` (mark/index/premium on one exchange). That lane produced HAS_PULSE on extreme tails but the resulting long-risk filter on the SOL 1h overlay was rejected at Phase 2 WFO (only 1 block, no risk improvement, OOS not better).
+
+Cross-venue is different because:
+- It compares **relative** dislocation between venues, not absolute level on one venue.
+- It can surface venue-arbitrage or rotation effects that a single-exchange premium (continuation-biased) misses.
+- It has a natural short-side or hedge interpretation (long the cheap venue, short the rich one, or use as a filter/weight).
+- Event density and independence from the existing live SOL overlay are expected to be higher.
+
+Single-venue premium long filters and 1h structure probes are now in the banned/closed set per the research reset. Cross-venue requires new ingestion and is explicitly called out as the #1 allowed next family.
+
+## Data Requirements (v0)
+
+- Per-venue perp basis / mark / index / premium / funding time series at 1h (and optionally 4h).
+- Aligned timestamps across venues for the same symbol.
+- At minimum: Binance USDT-M (already backfilled via `perp_basis_metrics`) + one additional major (Bybit or OKX) for initial dislocation signal.
+- Fields needed: timestamp, symbol, exchange/venue, basis_bps (or mark-index), premium (if available), last_funding_rate or predicted funding, open interest if available.
+- Coverage audit first (≥95% overlap with OHLCV bars after reasonable lag tolerance, similar to `audit_basis_premium_coverage.py`).
+- New ingestion path (REST bulk or websocket backfill) — **not** in scope for the first cheap probe if we can source a minimal public dataset or extend existing scripts.
+
+Out of scope for v0: sub-second, options, spot basis, every altcoin.
+
+## Expected Regimes
+
+- High funding + basis divergence (one venue very rich, another normalizing).
+- Post-liquidation cascades or large OI shifts on one venue.
+- Basis convergence after a multi-venue event (e.g., ETF flows, macro news, exchange-specific incidents).
+- Low-vol range where small dislocations persist long enough for convergence.
+
+Avoid: Strong one-directional trends where all venues move in lockstep (dislocation collapses to noise).
+
+## Failure Modes (Kill Criteria)
+
+- Dislocations are almost always in the same direction (persistent Binance premium, for example) → no tradable edge, just a constant bias.
+- After realistic fees + slippage the forward edge disappears or is concentrated in <5% of events.
+- Events too sparse for 20+ WFO trades on any major symbol even after pooling.
+- High overlap with the live `agent_sol_1h_trend_pullback_overlay_live` or sentiment-macro (adds correlated long bias instead of diversification).
+- MAE control fails (big adverse moves when the "cheap" venue continues to get cheaper).
+- Data quality / timestamp misalignment makes the signal non-reproducible in production.
+
+## Independence Expectations
+
+Target: low entry overlap (<35% Jaccard, <40% pct shared) with the promoted SOL 1h technical stack and with sentiment-macro on the same symbols/timeframe.
+
+Prefer surfaces that can be long one venue / flat or short another, or that act as a **portfolio-level risk allocator** (de-risk all agents when aggregate cross-venue stress is high) rather than another per-symbol entry model.
+
+## Validation Gates (RBI-aligned)
+
+**Gate 0 (this brief):** Done.
+
+**Gate 1 (Cheap Probe):** Read-only script. Must show `HAS_PULSE` on at least one major symbol or pooled:
+- ≥100 dislocation events (or ≥30 per symbol) in a multi-year window.
+- Statistically plausible forward edge after conservative fees/slippage on at least one horizon (e.g. 6h–24h convergence or continuation on the cheap venue).
+- Reasonable concentration (no single week dominates).
+- MAE not materially worse than baseline entries in the same regime.
+
+**Gate 2 (Bounded Autoresearch / Surface):** Only after HAS_PULSE. Config-only or minimal new filter/router code. Standard gates + filter-specific (trade retention ≥70% if used as overlay filter, clear risk improvement on DD/P(loss) or Sharpe).
+
+**Gate 3 (Promotion Candidate):** Stricter pre-filter before bootstrap=1000.
+
+**Gate 4 (bootstrap=1000):** Required for any paper/live consideration.
+
+**Gate 5 (Overlap + Portfolio Impact):** `analyze_entry_overlap.py` against live agents. Must not increase portfolio tail risk.
+
+**Gate 6 (Paper / Forward):** Minimum 20 closed trades in paper shadow (distinct AGENT_ID) before any live notional. Track blocked counts, venue P&L attribution, slippage, etc.
+
+Human approval required before any compose change, risk limit change, or live deployment.
+
+## Current Best Next Commands (until probe exists)
+
+```bash
+# 1. Define / extend a multi-venue coverage + dislocation probe
+#    (see step 6 investigation — likely new script or extension of probe_basis_premium + audit)
+
+# 2. Once probe + data land, run via the RBI manifest (see rbi_loop.cross-venue-basis-v1.yaml)
+uv run python scripts/rbi_loop_from_manifest.py \
+  --manifest config/autoresearch/rbi_loop.cross-venue-basis-v1.yaml
+```
+
+Do not start autoresearch or write strategy code until the cheap probe returns HAS_PULSE and the guard advances the lane.
+
+## Stop / Close Rules (in addition to general RBI stop rules)
+
+- No viable cross-venue data source or coverage audit fails after reasonable effort.
+- Probe returns NO_PULSE or WEAK_EDGE on all major symbols after two different dislocation definitions.
+- Any implementation would require >5 free parameters or heavy per-venue tuning to pass gates.
+- Clear evidence that cross-venue signals are just a noisy proxy for the existing sentiment-macro or single-venue basis already explored.
+
+The goal is still the same: a second independent, gate-passing, profitability-positive agent (or a high-quality risk filter / allocator that improves the existing book). Cross-venue basis is the current best first-principles surface that satisfies the "new primitive" rule from the June 2026 reset.

--- a/ops/systemd/crypto-agent-rbi-loop-batch.service
+++ b/ops/systemd/crypto-agent-rbi-loop-batch.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Run dry RBI autoresearch loop supervisor for crypto-agent
+After=docker.service
+Requires=docker.service
+OnFailure=crypto-agent-telegram-failure@%n.service
+
+[Service]
+Type=oneshot
+User=emilio
+WorkingDirectory=/opt/crypto-agent
+EnvironmentFile=-/etc/default/crypto-agent-rbi-loop-batch
+ExecStart=/bin/bash scripts/run_rbi_loop_batch.sh
+
+[Install]
+WantedBy=multi-user.target

--- a/ops/systemd/crypto-agent-rbi-loop-batch.timer
+++ b/ops/systemd/crypto-agent-rbi-loop-batch.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Run dry crypto-agent RBI loop supervisor daily
+
+[Timer]
+OnCalendar=*-*-* 01:15:00 UTC
+Persistent=true
+Unit=crypto-agent-rbi-loop-batch.service
+
+[Install]
+WantedBy=timers.target

--- a/research/rbi_loop/basis-premium-filter-v0/decision.json
+++ b/research/rbi_loop/basis-premium-filter-v0/decision.json
@@ -1,0 +1,28 @@
+{
+  "generated_at": "2026-06-09T16:37:11.233960+00:00",
+  "lane_name": "basis-premium-filter-v0",
+  "execute": false,
+  "decision": {
+    "action": "ITERATE_OR_CLOSE",
+    "allowed": false,
+    "reasons": [
+      "autoresearch result did not pass the standard gate"
+    ],
+    "evidence": {
+      "lane_brief": "docs/specs/basis-premium-risk-filter-surface-v0.md",
+      "probe_verdict": "HAS_PULSE",
+      "last_result_status": "keep",
+      "gate_profile": "filter_wfo_ab",
+      "bootstrap": null,
+      "passes_standard_gate": false,
+      "eligible_for_bootstrap_1000": false,
+      "promotion_candidate_failures": [
+        "insufficient_blocks",
+        "no_risk_improvement",
+        "oos_return_not_better"
+      ]
+    }
+  },
+  "selected_command": null,
+  "execution": null
+}

--- a/research/rbi_loop/basis-premium-filter-v0/last_wfo_result.json
+++ b/research/rbi_loop/basis-premium-filter-v0/last_wfo_result.json
@@ -1,0 +1,19 @@
+{
+  "status": "keep",
+  "gate_profile": "filter_wfo_ab",
+  "command": ["bash", "scripts/run_basis_filter_wfo_ab.sh"],
+  "summary": {
+    "passes_gates": false,
+    "note": "Phase 2 WFO A/B on SOL 1h overlay: filter blocked only 1 BUY (wiring worked), WFO trades 31 vs baseline 36, OOS return slightly worse, DD and P(loss) not improved. See docs/specs/basis-premium-risk-filter-surface-v0.md Phase 2 Result."
+  },
+  "eligible_for_bootstrap_1000": false,
+  "promotion_candidate_failures": [
+    "insufficient_blocks",
+    "no_risk_improvement",
+    "oos_return_not_better"
+  ],
+  "wfo_trades_baseline": 36,
+  "wfo_trades_filtered": 31,
+  "basis_blocked_buy_count": 1,
+  "description": "basis-premium-filter-v0 Phase2 WFO A/B reject"
+}

--- a/scripts/rbi_loop_batch.py
+++ b/scripts/rbi_loop_batch.py
@@ -76,6 +76,11 @@ def summarize_batch(results: list[dict[str, Any]]) -> dict[str, Any]:
     }
 
 
+def _escape_cell(text: str) -> str:
+    """Escape characters that would break a Markdown table cell."""
+    return text.replace("\\", "\\\\").replace("|", "\\|").replace("\n", "<br>")
+
+
 def render_markdown_summary(summary: dict[str, Any]) -> str:
     lines = [
         "# RBI Loop Batch Summary",
@@ -96,8 +101,10 @@ def render_markdown_summary(summary: dict[str, Any]) -> str:
         record = item["record"]
         decision = record["decision"]
         lines.append(
-            f"| {record['lane_name']} | `{decision['action']}` | {decision['allowed']} | "
-            f"`{item['decision_output']}` | `{item.get('report_output') or ''}` |"
+            f"| {_escape_cell(str(record['lane_name']))} | "
+            f"`{_escape_cell(str(decision['action']))}` | {decision['allowed']} | "
+            f"`{_escape_cell(str(item['decision_output']))}` | "
+            f"`{_escape_cell(str(item.get('report_output') or ''))}` |"
         )
     lines.append("")
     return "\n".join(lines)

--- a/scripts/rbi_loop_batch.py
+++ b/scripts/rbi_loop_batch.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""Run supervised RBI loop steps for multiple lane manifests."""
+
+from __future__ import annotations
+
+import argparse
+import glob
+import json
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from scripts.rbi_loop_from_manifest import read_manifest, run_manifest_step
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run one RBI loop step across manifests.")
+    parser.add_argument(
+        "--glob",
+        default="config/autoresearch/rbi_loop.*.yaml",
+        help="Manifest glob to process.",
+    )
+    parser.add_argument(
+        "--include-example",
+        action="store_true",
+        help="Include rbi_loop.example.yaml in the batch.",
+    )
+    parser.add_argument(
+        "--execute",
+        action="store_true",
+        help="Execute selected commands. Default only records decisions/reports.",
+    )
+    parser.add_argument(
+        "--summary-output",
+        default="research/rbi_loop/batch-summary.json",
+        help="JSON summary output path.",
+    )
+    parser.add_argument(
+        "--markdown-output",
+        default="docs/reports/rbi-loop-batch-summary.md",
+        help="Markdown summary output path.",
+    )
+    return parser.parse_args()
+
+
+def discover_manifests(pattern: str, *, include_example: bool = False) -> list[Path]:
+    paths = sorted(Path(match) for match in glob.glob(pattern))
+    if include_example:
+        return paths
+    return [path for path in paths if path.name != "rbi_loop.example.yaml"]
+
+
+def summarize_batch(results: list[dict[str, Any]]) -> dict[str, Any]:
+    actions: dict[str, int] = {}
+    blocked = 0
+    failed_execution = 0
+    for item in results:
+        decision = item["record"]["decision"]
+        action = str(decision["action"])
+        actions[action] = actions.get(action, 0) + 1
+        if not decision["allowed"]:
+            blocked += 1
+        execution = item["record"].get("execution")
+        if execution and int(execution["returncode"]) != 0:
+            failed_execution += 1
+    return {
+        "generated_at": datetime.now(UTC).isoformat(),
+        "lane_count": len(results),
+        "blocked_count": blocked,
+        "failed_execution_count": failed_execution,
+        "actions": actions,
+        "results": results,
+    }
+
+
+def render_markdown_summary(summary: dict[str, Any]) -> str:
+    lines = [
+        "# RBI Loop Batch Summary",
+        "",
+        "| Field | Value |",
+        "|---|---|",
+        f"| Generated at | {summary['generated_at']} |",
+        f"| Lane count | {summary['lane_count']} |",
+        f"| Blocked count | {summary['blocked_count']} |",
+        f"| Failed execution count | {summary['failed_execution_count']} |",
+        "",
+        "## Lanes",
+        "",
+        "| Lane | Action | Allowed | Decision | Report |",
+        "|---|---|---:|---|---|",
+    ]
+    for item in summary["results"]:
+        record = item["record"]
+        decision = record["decision"]
+        lines.append(
+            f"| {record['lane_name']} | `{decision['action']}` | {decision['allowed']} | "
+            f"`{item['decision_output']}` | `{item.get('report_output') or ''}` |"
+        )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def write_text(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def run_batch(
+    manifests: list[Path],
+    *,
+    execute: bool = False,
+) -> dict[str, Any]:
+    results = []
+    for manifest_path in manifests:
+        manifest = read_manifest(manifest_path)
+        result = run_manifest_step(manifest, execute=execute, render_markdown=True)
+        result["manifest_path"] = str(manifest_path)
+        results.append(result)
+    return summarize_batch(results)
+
+
+def main() -> None:
+    args = parse_args()
+    manifests = discover_manifests(args.glob, include_example=args.include_example)
+    summary = run_batch(manifests, execute=args.execute)
+    write_json(Path(args.summary_output), summary)
+    write_text(Path(args.markdown_output), render_markdown_summary(summary))
+    print(json.dumps(summary, indent=2))
+    if summary["blocked_count"] or summary["failed_execution_count"]:
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/rbi_loop_from_manifest.py
+++ b/scripts/rbi_loop_from_manifest.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Run one RBI loop step from a lane manifest."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from scripts.rbi_loop_guard import _read_json, decide_loop_action
+from scripts.rbi_loop_report import render_report, write_report
+from scripts.rbi_loop_runner import (
+    _default_decision_output,
+    _run_command,
+    build_decision_record,
+    write_decision_record,
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run one RBI loop step from a YAML manifest.")
+    parser.add_argument("--manifest", required=True, help="YAML lane manifest path.")
+    parser.add_argument(
+        "--execute",
+        action="store_true",
+        help="Execute the selected command from the manifest. Default only records decision/report.",
+    )
+    parser.add_argument(
+        "--no-report",
+        action="store_true",
+        help="Skip Markdown report rendering.",
+    )
+    return parser.parse_args()
+
+
+def read_manifest(path: Path) -> dict[str, Any]:
+    payload = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    if not isinstance(payload, dict):
+        raise ValueError(f"Expected mapping in {path}")
+    return payload
+
+
+def _optional_json(path: str | None) -> dict[str, Any] | None:
+    return _read_json(Path(path)) if path else None
+
+
+def _required_str(manifest: dict[str, Any], key: str) -> str:
+    value = manifest.get(key)
+    if not value:
+        raise ValueError(f"manifest missing required field: {key}")
+    return str(value)
+
+
+def _commands(manifest: dict[str, Any]) -> dict[str, str]:
+    raw = manifest.get("commands", {})
+    if not isinstance(raw, dict):
+        raise ValueError("manifest.commands must be a mapping")
+    return {str(key): str(value) for key, value in raw.items() if value}
+
+
+def _selected_command(action: str, commands: dict[str, str]) -> str | None:
+    return commands.get(action)
+
+
+def _decision_output(manifest: dict[str, Any], lane_name: str) -> Path:
+    return Path(str(manifest.get("decision_output") or _default_decision_output(lane_name)))
+
+
+def _report_output(manifest: dict[str, Any], lane_name: str) -> Path:
+    return Path(
+        str(manifest.get("report_output") or Path("docs/reports") / f"rbi-loop-{lane_name}.md")
+    )
+
+
+def run_manifest_step(
+    manifest: dict[str, Any],
+    *,
+    execute: bool = False,
+    render_markdown: bool = True,
+) -> dict[str, Any]:
+    lane_name = _required_str(manifest, "lane_name")
+    lane_brief = manifest.get("lane_brief")
+    probe_verdict = manifest.get("probe_verdict")
+    last_result = (
+        _optional_json(str(manifest["last_result"])) if manifest.get("last_result") else None
+    )
+    overlap_report = (
+        _optional_json(str(manifest["overlap_report"])) if manifest.get("overlap_report") else None
+    )
+
+    decision = decide_loop_action(
+        lane_brief=str(lane_brief) if lane_brief else None,
+        probe_verdict=str(probe_verdict) if probe_verdict else None,
+        last_result=last_result,
+        overlap_report=overlap_report,
+    )
+    command = _selected_command(decision.action, _commands(manifest))
+    execution = None
+    if execute and decision.allowed and command:
+        timeout_seconds = int(manifest.get("timeout_seconds", 1800))
+        execution = _run_command(command, timeout_seconds=timeout_seconds)
+
+    record = build_decision_record(
+        lane_name=lane_name,
+        decision=decision,
+        execute=execute,
+        command=command,
+        execution=execution,
+    )
+    decision_output = _decision_output(manifest, lane_name)
+    write_decision_record(decision_output, record)
+
+    report_output = None
+    if render_markdown:
+        report_output = _report_output(manifest, lane_name)
+        write_report(report_output, render_report(record))
+
+    result = {
+        "decision_output": str(decision_output),
+        "report_output": str(report_output) if report_output else None,
+        "record": record,
+    }
+    return result
+
+
+def main() -> None:
+    args = parse_args()
+    result = run_manifest_step(
+        read_manifest(Path(args.manifest)),
+        execute=args.execute,
+        render_markdown=not args.no_report,
+    )
+    print(json.dumps(result, indent=2))
+    decision = result["record"]["decision"]
+    if not decision["allowed"]:
+        raise SystemExit(1)
+    execution = result["record"].get("execution")
+    if execution and int(execution["returncode"]) != 0:
+        raise SystemExit(int(execution["returncode"]))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/rbi_loop_guard.py
+++ b/scripts/rbi_loop_guard.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python3
+"""Decide the next allowed RBI/autoresearch loop action from artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+ACTION_WRITE_LANE_BRIEF = "WRITE_LANE_BRIEF"
+ACTION_RUN_CHEAP_PROBE = "RUN_CHEAP_PROBE"
+ACTION_CLOSE_LANE = "CLOSE_LANE"
+ACTION_RUN_AUTORESEARCH = "RUN_AUTORESEARCH"
+ACTION_ITERATE_OR_CLOSE = "ITERATE_OR_CLOSE"
+ACTION_RUN_BOOTSTRAP_1000 = "RUN_BOOTSTRAP_1000"
+ACTION_CHECK_OVERLAP = "CHECK_OVERLAP"
+ACTION_READY_FOR_PAPER_REVIEW = "READY_FOR_PAPER_REVIEW"
+
+PASSING_PROBE_VERDICT = "HAS_PULSE"
+HIGH_OVERLAP_JACCARD = 0.35
+HIGH_OVERLAP_PCT = 40.0
+
+
+@dataclass(frozen=True)
+class LoopDecision:
+    """Deterministic supervisor decision for one RBI lane."""
+
+    action: str
+    allowed: bool
+    reasons: list[str]
+    evidence: dict[str, Any]
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Read RBI loop artifacts and print the next allowed action as JSON."
+    )
+    parser.add_argument(
+        "--lane-brief",
+        help="Path to lane brief/spec/report that states the edge thesis.",
+    )
+    parser.add_argument(
+        "--probe-verdict",
+        choices=("HAS_PULSE", "WEAK_EDGE", "NO_PULSE"),
+        help="Cheap-probe verdict for the lane.",
+    )
+    parser.add_argument(
+        "--last-result",
+        help="Path to autoresearch last_result.json.",
+    )
+    parser.add_argument(
+        "--overlap-report",
+        help="Path to analyze_entry_overlap.py JSON output.",
+    )
+    parser.add_argument(
+        "--pretty",
+        action="store_true",
+        help="Pretty-print JSON output.",
+    )
+    return parser.parse_args()
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"Expected JSON object in {path}")
+    return payload
+
+
+def _brief_exists(path: str | None) -> bool:
+    return bool(path) and Path(path).is_file()
+
+
+def _last_result_bootstrap(last_result: dict[str, Any]) -> int | None:
+    command = last_result.get("command")
+    if isinstance(command, list):
+        for index, part in enumerate(command):
+            if part == "--bootstrap" and index + 1 < len(command):
+                try:
+                    return int(command[index + 1])
+                except (TypeError, ValueError):
+                    return None
+    return None
+
+
+def _summary_passes_standard_gate(last_result: dict[str, Any]) -> bool:
+    summary = last_result.get("summary")
+    return isinstance(summary, dict) and bool(summary.get("passes_gates"))
+
+
+def _promotion_eligible(last_result: dict[str, Any]) -> bool:
+    return bool(last_result.get("eligible_for_bootstrap_1000"))
+
+
+def _high_overlap_pairs(overlap_report: dict[str, Any]) -> list[dict[str, Any]]:
+    high_pairs: list[dict[str, Any]] = []
+    pairwise = overlap_report.get("pairwise_oos")
+    if not isinstance(pairwise, list):
+        return high_pairs
+    for item in pairwise:
+        if not isinstance(item, dict):
+            continue
+        jaccard = float(item.get("jaccard", 0.0))
+        pct_left = float(item.get("pct_of_left_also_in_right", 0.0))
+        pct_right = float(item.get("pct_of_right_also_in_left", 0.0))
+        if jaccard >= HIGH_OVERLAP_JACCARD or max(pct_left, pct_right) >= HIGH_OVERLAP_PCT:
+            high_pairs.append(item)
+    return high_pairs
+
+
+def decide_loop_action(
+    *,
+    lane_brief: str | None = None,
+    probe_verdict: str | None = None,
+    last_result: dict[str, Any] | None = None,
+    overlap_report: dict[str, Any] | None = None,
+) -> LoopDecision:
+    """Return the next allowed action for a lane without running external commands."""
+    evidence: dict[str, Any] = {
+        "lane_brief": lane_brief,
+        "probe_verdict": probe_verdict,
+    }
+    if not _brief_exists(lane_brief):
+        return LoopDecision(
+            action=ACTION_WRITE_LANE_BRIEF,
+            allowed=False,
+            reasons=["missing lane brief"],
+            evidence=evidence,
+        )
+
+    if probe_verdict is None:
+        return LoopDecision(
+            action=ACTION_RUN_CHEAP_PROBE,
+            allowed=True,
+            reasons=["lane brief exists; cheap-probe verdict missing"],
+            evidence=evidence,
+        )
+
+    if probe_verdict != PASSING_PROBE_VERDICT:
+        return LoopDecision(
+            action=ACTION_CLOSE_LANE,
+            allowed=False,
+            reasons=[f"cheap probe verdict is {probe_verdict}, not HAS_PULSE"],
+            evidence=evidence,
+        )
+
+    if last_result is None:
+        return LoopDecision(
+            action=ACTION_RUN_AUTORESEARCH,
+            allowed=True,
+            reasons=["cheap probe passed; autoresearch result missing"],
+            evidence=evidence,
+        )
+
+    bootstrap = _last_result_bootstrap(last_result)
+    passes_standard = _summary_passes_standard_gate(last_result)
+    promotion_eligible = _promotion_eligible(last_result)
+    evidence.update(
+        {
+            "last_result_status": last_result.get("status"),
+            "gate_profile": last_result.get("gate_profile"),
+            "bootstrap": bootstrap,
+            "passes_standard_gate": passes_standard,
+            "eligible_for_bootstrap_1000": promotion_eligible,
+            "promotion_candidate_failures": last_result.get("promotion_candidate_failures", []),
+        }
+    )
+
+    if not passes_standard:
+        return LoopDecision(
+            action=ACTION_ITERATE_OR_CLOSE,
+            allowed=False,
+            reasons=["autoresearch result did not pass the standard gate"],
+            evidence=evidence,
+        )
+
+    if bootstrap is None or bootstrap < 1000:
+        if not promotion_eligible:
+            return LoopDecision(
+                action=ACTION_ITERATE_OR_CLOSE,
+                allowed=False,
+                reasons=["standard pass is not promotion-candidate eligible"],
+                evidence=evidence,
+            )
+        return LoopDecision(
+            action=ACTION_RUN_BOOTSTRAP_1000,
+            allowed=True,
+            reasons=["standard pass is promotion-candidate eligible at discovery bootstrap"],
+            evidence=evidence,
+        )
+
+    if overlap_report is None:
+        return LoopDecision(
+            action=ACTION_CHECK_OVERLAP,
+            allowed=True,
+            reasons=["bootstrap=1000 passed; overlap report missing"],
+            evidence=evidence,
+        )
+
+    high_pairs = _high_overlap_pairs(overlap_report)
+    evidence["high_overlap_pairs"] = high_pairs
+    if high_pairs:
+        return LoopDecision(
+            action=ACTION_ITERATE_OR_CLOSE,
+            allowed=False,
+            reasons=["overlap report contains high-overlap pairs"],
+            evidence=evidence,
+        )
+
+    return LoopDecision(
+        action=ACTION_READY_FOR_PAPER_REVIEW,
+        allowed=True,
+        reasons=["lane passed bootstrap=1000 and overlap gates"],
+        evidence=evidence,
+    )
+
+
+def main() -> None:
+    args = parse_args()
+    last_result = _read_json(Path(args.last_result)) if args.last_result else None
+    overlap_report = _read_json(Path(args.overlap_report)) if args.overlap_report else None
+    decision = decide_loop_action(
+        lane_brief=args.lane_brief,
+        probe_verdict=args.probe_verdict,
+        last_result=last_result,
+        overlap_report=overlap_report,
+    )
+    indent = 2 if args.pretty else None
+    print(json.dumps(asdict(decision), indent=indent))
+    if not decision.allowed:
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/rbi_loop_guard.py
+++ b/scripts/rbi_loop_guard.py
@@ -94,6 +94,16 @@ def _promotion_eligible(last_result: dict[str, Any]) -> bool:
     return bool(last_result.get("eligible_for_bootstrap_1000"))
 
 
+def _safe_float(value: Any, default: float = 0.0) -> float:
+    """Coerce value to float, treating None/missing/bad as default (hardens overlap JSON)."""
+    if value is None:
+        return default
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
 def _high_overlap_pairs(overlap_report: dict[str, Any]) -> list[dict[str, Any]]:
     high_pairs: list[dict[str, Any]] = []
     pairwise = overlap_report.get("pairwise_oos")
@@ -102,9 +112,9 @@ def _high_overlap_pairs(overlap_report: dict[str, Any]) -> list[dict[str, Any]]:
     for item in pairwise:
         if not isinstance(item, dict):
             continue
-        jaccard = float(item.get("jaccard", 0.0))
-        pct_left = float(item.get("pct_of_left_also_in_right", 0.0))
-        pct_right = float(item.get("pct_of_right_also_in_left", 0.0))
+        jaccard = _safe_float(item.get("jaccard"), 0.0)
+        pct_left = _safe_float(item.get("pct_of_left_also_in_right"), 0.0)
+        pct_right = _safe_float(item.get("pct_of_right_also_in_left"), 0.0)
         if jaccard >= HIGH_OVERLAP_JACCARD or max(pct_left, pct_right) >= HIGH_OVERLAP_PCT:
             high_pairs.append(item)
     return high_pairs

--- a/scripts/rbi_loop_report.py
+++ b/scripts/rbi_loop_report.py
@@ -26,6 +26,11 @@ def _read_decision(path: Path) -> dict[str, Any]:
     return payload
 
 
+def _escape_cell(text: str) -> str:
+    """Escape characters that would break a Markdown table cell."""
+    return text.replace("\\", "\\\\").replace("|", "\\|").replace("\n", "<br>")
+
+
 def _default_output_path(record: dict[str, Any]) -> Path:
     lane_name = str(record.get("lane_name", "unknown-lane"))
     return Path("docs") / "reports" / f"rbi-loop-{lane_name}.md"
@@ -35,12 +40,12 @@ def _table_rows(mapping: dict[str, Any]) -> list[str]:
     rows = []
     for key, value in mapping.items():
         if isinstance(value, (dict, list)):
-            rendered = f"`{json.dumps(value, sort_keys=True)}`"
+            rendered = f"`{_escape_cell(json.dumps(value, sort_keys=True))}`"
         elif value is None:
             rendered = ""
         else:
-            rendered = str(value)
-        rows.append(f"| {key} | {rendered} |")
+            rendered = _escape_cell(str(value))
+        rows.append(f"| {_escape_cell(str(key))} | {rendered} |")
     return rows
 
 
@@ -60,10 +65,10 @@ def render_report(record: dict[str, Any]) -> str:
         "| Field | Value |",
         "|---|---|",
         f"| Generated at | {generated_at} |",
-        f"| Action | `{decision.get('action', '')}` |",
+        f"| Action | `{_escape_cell(str(decision.get('action', '')))}` |",
         f"| Allowed | {decision.get('allowed', False)} |",
         f"| Execute requested | {record.get('execute', False)} |",
-        f"| Selected command | `{record.get('selected_command') or ''}` |",
+        f"| Selected command | `{_escape_cell(str(record.get('selected_command') or ''))}` |",
         "",
         "## Reasons",
         "",

--- a/scripts/rbi_loop_report.py
+++ b/scripts/rbi_loop_report.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Render an RBI loop decision JSON as a lane report."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Render an RBI loop decision report.")
+    parser.add_argument("--decision", required=True, help="Path to rbi_loop_runner decision JSON.")
+    parser.add_argument(
+        "--output",
+        help="Markdown output path. Defaults to docs/reports/rbi-loop-<lane>.md.",
+    )
+    return parser.parse_args()
+
+
+def _read_decision(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"Expected JSON object in {path}")
+    return payload
+
+
+def _default_output_path(record: dict[str, Any]) -> Path:
+    lane_name = str(record.get("lane_name", "unknown-lane"))
+    return Path("docs") / "reports" / f"rbi-loop-{lane_name}.md"
+
+
+def _table_rows(mapping: dict[str, Any]) -> list[str]:
+    rows = []
+    for key, value in mapping.items():
+        if isinstance(value, (dict, list)):
+            rendered = f"`{json.dumps(value, sort_keys=True)}`"
+        elif value is None:
+            rendered = ""
+        else:
+            rendered = str(value)
+        rows.append(f"| {key} | {rendered} |")
+    return rows
+
+
+def render_report(record: dict[str, Any]) -> str:
+    lane_name = str(record.get("lane_name", "unknown-lane"))
+    generated_at = str(record.get("generated_at", ""))
+    decision = record.get("decision")
+    if not isinstance(decision, dict):
+        raise ValueError("decision record missing decision object")
+    evidence = decision.get("evidence") if isinstance(decision.get("evidence"), dict) else {}
+    reasons = decision.get("reasons") if isinstance(decision.get("reasons"), list) else []
+    execution = record.get("execution")
+
+    lines = [
+        f"# RBI Loop Decision — {lane_name}",
+        "",
+        "| Field | Value |",
+        "|---|---|",
+        f"| Generated at | {generated_at} |",
+        f"| Action | `{decision.get('action', '')}` |",
+        f"| Allowed | {decision.get('allowed', False)} |",
+        f"| Execute requested | {record.get('execute', False)} |",
+        f"| Selected command | `{record.get('selected_command') or ''}` |",
+        "",
+        "## Reasons",
+        "",
+    ]
+    if reasons:
+        lines.extend(f"- {reason}" for reason in reasons)
+    else:
+        lines.append("- (none recorded)")
+
+    lines.extend(["", "## Evidence", "", "| Field | Value |", "|---|---|"])
+    lines.extend(_table_rows(evidence))
+
+    lines.extend(["", "## Execution", ""])
+    if isinstance(execution, dict):
+        lines.extend(["| Field | Value |", "|---|---|"])
+        lines.extend(_table_rows(execution))
+    else:
+        lines.append("No command execution was recorded.")
+
+    lines.extend(
+        [
+            "",
+            "## Next Action",
+            "",
+            str(decision.get("action", "UNKNOWN")),
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def write_report(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def main() -> None:
+    args = parse_args()
+    record = _read_decision(Path(args.decision))
+    output = Path(args.output) if args.output else _default_output_path(record)
+    write_report(output, render_report(record))
+    print(output)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/rbi_loop_runner.py
+++ b/scripts/rbi_loop_runner.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""Run one supervised RBI loop step from guard artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shlex
+import subprocess
+import sys
+import time
+from dataclasses import asdict
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from scripts.rbi_loop_guard import (
+    ACTION_CHECK_OVERLAP,
+    ACTION_RUN_AUTORESEARCH,
+    ACTION_RUN_BOOTSTRAP_1000,
+    ACTION_RUN_CHEAP_PROBE,
+    LoopDecision,
+    _read_json,
+    decide_loop_action,
+)
+
+EXECUTABLE_ACTIONS = {
+    ACTION_RUN_CHEAP_PROBE: "probe_command",
+    ACTION_RUN_AUTORESEARCH: "autoresearch_command",
+    ACTION_RUN_BOOTSTRAP_1000: "bootstrap_command",
+    ACTION_CHECK_OVERLAP: "overlap_command",
+}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Persist an RBI guard decision and optionally execute the next command."
+    )
+    parser.add_argument("--lane-name", required=True, help="Stable lane slug used in artifacts.")
+    parser.add_argument("--lane-brief", help="Path to lane brief/spec/report.")
+    parser.add_argument(
+        "--probe-verdict",
+        choices=("HAS_PULSE", "WEAK_EDGE", "NO_PULSE"),
+        help="Cheap-probe verdict for the lane.",
+    )
+    parser.add_argument("--last-result", help="Path to autoresearch last_result.json.")
+    parser.add_argument("--overlap-report", help="Path to overlap report JSON.")
+    parser.add_argument(
+        "--decision-output",
+        help="Path for decision JSON. Defaults to research/rbi_loop/<lane-name>/decision.json.",
+    )
+    parser.add_argument(
+        "--execute",
+        action="store_true",
+        help="Execute the command mapped to the guard action. Default only writes decision.",
+    )
+    parser.add_argument("--probe-command", help="Command for RUN_CHEAP_PROBE.")
+    parser.add_argument("--autoresearch-command", help="Command for RUN_AUTORESEARCH.")
+    parser.add_argument("--bootstrap-command", help="Command for RUN_BOOTSTRAP_1000.")
+    parser.add_argument("--overlap-command", help="Command for CHECK_OVERLAP.")
+    parser.add_argument("--timeout-seconds", type=int, default=1800)
+    return parser.parse_args()
+
+
+def _default_decision_output(lane_name: str) -> Path:
+    return Path("research") / "rbi_loop" / lane_name / "decision.json"
+
+
+def _command_for_decision(args: argparse.Namespace, decision: LoopDecision) -> str | None:
+    attr = EXECUTABLE_ACTIONS.get(decision.action)
+    if attr is None:
+        return None
+    value = getattr(args, attr)
+    return str(value) if value else None
+
+
+def _tail(text: str, *, limit: int = 40) -> list[str]:
+    return text.strip().splitlines()[-limit:]
+
+
+def _run_command(command: str, *, timeout_seconds: int) -> dict[str, Any]:
+    started = time.monotonic()
+    try:
+        completed = subprocess.run(
+            shlex.split(command),
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=timeout_seconds,
+        )
+    except subprocess.TimeoutExpired as exc:
+        duration = round(time.monotonic() - started, 3)
+        stdout = exc.stdout if isinstance(exc.stdout, str) else ""
+        stderr = exc.stderr if isinstance(exc.stderr, str) else ""
+        return {
+            "status": "timeout",
+            "returncode": 124,
+            "duration_seconds": duration,
+            "command": command,
+            "stdout_tail": _tail(stdout),
+            "stderr_tail": _tail(stderr),
+        }
+
+    duration = round(time.monotonic() - started, 3)
+    return {
+        "status": "completed" if completed.returncode == 0 else "failed",
+        "returncode": completed.returncode,
+        "duration_seconds": duration,
+        "command": command,
+        "stdout_tail": _tail(completed.stdout),
+        "stderr_tail": _tail(completed.stderr),
+    }
+
+
+def build_decision_record(
+    *,
+    lane_name: str,
+    decision: LoopDecision,
+    execute: bool,
+    command: str | None,
+    execution: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    return {
+        "generated_at": datetime.now(UTC).isoformat(),
+        "lane_name": lane_name,
+        "execute": execute,
+        "decision": asdict(decision),
+        "selected_command": command,
+        "execution": execution,
+    }
+
+
+def write_decision_record(path: Path, record: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(record, indent=2) + "\n", encoding="utf-8")
+
+
+def main() -> None:
+    args = parse_args()
+    last_result = _read_json(Path(args.last_result)) if args.last_result else None
+    overlap_report = _read_json(Path(args.overlap_report)) if args.overlap_report else None
+    decision = decide_loop_action(
+        lane_brief=args.lane_brief,
+        probe_verdict=args.probe_verdict,
+        last_result=last_result,
+        overlap_report=overlap_report,
+    )
+    command = _command_for_decision(args, decision)
+    execution = None
+    if args.execute and decision.allowed and command:
+        execution = _run_command(command, timeout_seconds=args.timeout_seconds)
+
+    output_path = (
+        Path(args.decision_output)
+        if args.decision_output
+        else _default_decision_output(args.lane_name)
+    )
+    record = build_decision_record(
+        lane_name=args.lane_name,
+        decision=decision,
+        execute=args.execute,
+        command=command,
+        execution=execution,
+    )
+    write_decision_record(output_path, record)
+    print(json.dumps(record, indent=2))
+
+    if not decision.allowed:
+        raise SystemExit(1)
+    if args.execute and command is None and decision.action in EXECUTABLE_ACTIONS:
+        raise SystemExit(2)
+    if execution and int(execution["returncode"]) != 0:
+        raise SystemExit(int(execution["returncode"]))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_rbi_loop_batch.sh
+++ b/scripts/run_rbi_loop_batch.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Run a dry RBI loop supervisor pass over lane manifests.
+set -euo pipefail
+
+MANIFEST_GLOB="${MANIFEST_GLOB:-config/autoresearch/rbi_loop.*.yaml}"
+SUMMARY_OUTPUT="${SUMMARY_OUTPUT:-research/rbi_loop/batch-summary.json}"
+MARKDOWN_OUTPUT="${MARKDOWN_OUTPUT:-docs/reports/rbi-loop-batch-summary.md}"
+
+python scripts/rbi_loop_batch.py \
+  --glob "${MANIFEST_GLOB}" \
+  --summary-output "${SUMMARY_OUTPUT}" \
+  --markdown-output "${MARKDOWN_OUTPUT}"

--- a/tests/test_rbi_loop_batch.py
+++ b/tests/test_rbi_loop_batch.py
@@ -85,6 +85,29 @@ def test_render_markdown_summary_lists_lanes() -> None:
     assert "| basis-v0 | `RUN_CHEAP_PROBE` | True |" in markdown
 
 
+def test_render_markdown_summary_escapes_pipes_in_lane_name() -> None:
+    markdown = render_markdown_summary(
+        {
+            "generated_at": "2026-06-09T00:00:00+00:00",
+            "lane_count": 1,
+            "blocked_count": 0,
+            "failed_execution_count": 0,
+            "results": [
+                {
+                    "decision_output": "decision.json",
+                    "report_output": "report.md",
+                    "record": {
+                        "lane_name": "basis | v0",
+                        "decision": {"action": "RUN_CHEAP_PROBE", "allowed": True},
+                    },
+                }
+            ],
+        }
+    )
+
+    assert "| basis \\| v0 | `RUN_CHEAP_PROBE` | True |" in markdown
+
+
 def test_run_batch_processes_multiple_manifests(tmp_path: Path) -> None:
     brief = tmp_path / "brief.md"
     brief.write_text("# Brief\n", encoding="utf-8")

--- a/tests/test_rbi_loop_batch.py
+++ b/tests/test_rbi_loop_batch.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+from scripts.rbi_loop_batch import (
+    discover_manifests,
+    render_markdown_summary,
+    run_batch,
+    summarize_batch,
+)
+
+
+def _write_manifest(path: Path, *, lane_name: str, brief: Path) -> None:
+    payload = {
+        "lane_name": lane_name,
+        "lane_brief": str(brief),
+        "decision_output": str(path.parent / f"{lane_name}.decision.json"),
+        "report_output": str(path.parent / f"{lane_name}.md"),
+        "commands": {"RUN_CHEAP_PROBE": "python scripts/probe_basis_premium.py"},
+    }
+    path.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
+
+
+def test_discover_manifests_skips_example_by_default(tmp_path: Path) -> None:
+    (tmp_path / "rbi_loop.example.yaml").write_text("lane_name: example\n", encoding="utf-8")
+    wanted = tmp_path / "rbi_loop.basis.yaml"
+    wanted.write_text("lane_name: basis\n", encoding="utf-8")
+
+    assert discover_manifests(str(tmp_path / "rbi_loop.*.yaml")) == [wanted]
+    assert len(discover_manifests(str(tmp_path / "rbi_loop.*.yaml"), include_example=True)) == 2
+
+
+def test_summarize_batch_counts_actions_and_blocks() -> None:
+    summary = summarize_batch(
+        [
+            {
+                "record": {
+                    "decision": {
+                        "action": "RUN_CHEAP_PROBE",
+                        "allowed": True,
+                    },
+                    "execution": None,
+                }
+            },
+            {
+                "record": {
+                    "decision": {
+                        "action": "CLOSE_LANE",
+                        "allowed": False,
+                    },
+                    "execution": None,
+                }
+            },
+        ]
+    )
+
+    assert summary["lane_count"] == 2
+    assert summary["blocked_count"] == 1
+    assert summary["actions"] == {"RUN_CHEAP_PROBE": 1, "CLOSE_LANE": 1}
+
+
+def test_render_markdown_summary_lists_lanes() -> None:
+    markdown = render_markdown_summary(
+        {
+            "generated_at": "2026-06-09T00:00:00+00:00",
+            "lane_count": 1,
+            "blocked_count": 0,
+            "failed_execution_count": 0,
+            "results": [
+                {
+                    "decision_output": "decision.json",
+                    "report_output": "report.md",
+                    "record": {
+                        "lane_name": "basis-v0",
+                        "decision": {"action": "RUN_CHEAP_PROBE", "allowed": True},
+                    },
+                }
+            ],
+        }
+    )
+
+    assert "# RBI Loop Batch Summary" in markdown
+    assert "| basis-v0 | `RUN_CHEAP_PROBE` | True |" in markdown
+
+
+def test_run_batch_processes_multiple_manifests(tmp_path: Path) -> None:
+    brief = tmp_path / "brief.md"
+    brief.write_text("# Brief\n", encoding="utf-8")
+    first = tmp_path / "rbi_loop.first.yaml"
+    second = tmp_path / "rbi_loop.second.yaml"
+    _write_manifest(first, lane_name="first", brief=brief)
+    _write_manifest(second, lane_name="second", brief=brief)
+
+    summary = run_batch([first, second])
+
+    assert summary["lane_count"] == 2
+    assert summary["blocked_count"] == 0
+    assert summary["actions"] == {"RUN_CHEAP_PROBE": 2}
+    assert (tmp_path / "first.decision.json").is_file()
+    assert (tmp_path / "second.md").is_file()

--- a/tests/test_rbi_loop_from_manifest.py
+++ b/tests/test_rbi_loop_from_manifest.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import yaml
+
+from scripts.rbi_loop_from_manifest import read_manifest, run_manifest_step
+
+
+def test_read_manifest_requires_mapping(tmp_path: Path) -> None:
+    manifest = tmp_path / "manifest.yaml"
+    manifest.write_text("lane_name: basis-v0\n", encoding="utf-8")
+
+    assert read_manifest(manifest) == {"lane_name": "basis-v0"}
+
+
+def test_run_manifest_step_writes_decision_and_report(tmp_path: Path) -> None:
+    brief = tmp_path / "brief.md"
+    brief.write_text("# Brief\n", encoding="utf-8")
+    decision_output = tmp_path / "decision.json"
+    report_output = tmp_path / "report.md"
+    manifest = {
+        "lane_name": "basis-v0",
+        "lane_brief": str(brief),
+        "decision_output": str(decision_output),
+        "report_output": str(report_output),
+        "commands": {
+            "RUN_CHEAP_PROBE": "python scripts/probe_basis_premium.py",
+        },
+    }
+
+    result = run_manifest_step(manifest)
+
+    assert result["decision_output"] == str(decision_output)
+    assert result["report_output"] == str(report_output)
+    record = json.loads(decision_output.read_text(encoding="utf-8"))
+    assert record["lane_name"] == "basis-v0"
+    assert record["decision"]["action"] == "RUN_CHEAP_PROBE"
+    assert record["selected_command"] == "python scripts/probe_basis_premium.py"
+    assert "# RBI Loop Decision" in report_output.read_text(encoding="utf-8")
+
+
+def test_example_manifest_is_valid_yaml() -> None:
+    path = Path("config/autoresearch/rbi_loop.example.yaml")
+    payload = yaml.safe_load(path.read_text(encoding="utf-8"))
+
+    assert payload["lane_name"] == "example-data-first-lane"
+    assert "RUN_AUTORESEARCH" in payload["commands"]

--- a/tests/test_rbi_loop_guard.py
+++ b/tests/test_rbi_loop_guard.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.rbi_loop_guard import (
+    ACTION_CHECK_OVERLAP,
+    ACTION_CLOSE_LANE,
+    ACTION_ITERATE_OR_CLOSE,
+    ACTION_READY_FOR_PAPER_REVIEW,
+    ACTION_RUN_BOOTSTRAP_1000,
+    ACTION_RUN_CHEAP_PROBE,
+    ACTION_WRITE_LANE_BRIEF,
+    decide_loop_action,
+)
+
+
+def _brief(tmp_path: Path) -> str:
+    path = tmp_path / "lane.md"
+    path.write_text("# Lane\n", encoding="utf-8")
+    return str(path)
+
+
+def _last_result(
+    *,
+    bootstrap: int,
+    passes_gates: bool = True,
+    eligible_for_bootstrap_1000: bool = True,
+) -> dict[str, object]:
+    return {
+        "status": "keep",
+        "gate_profile": "standard",
+        "command": ["python", "scripts/experiment_autopilot.py", "--bootstrap", str(bootstrap)],
+        "summary": {"passes_gates": passes_gates},
+        "eligible_for_bootstrap_1000": eligible_for_bootstrap_1000,
+        "promotion_candidate_failures": [] if eligible_for_bootstrap_1000 else ["max_drawdown_pct"],
+    }
+
+
+def test_missing_lane_brief_blocks_loop() -> None:
+    decision = decide_loop_action(lane_brief="missing.md")
+
+    assert decision.action == ACTION_WRITE_LANE_BRIEF
+    assert decision.allowed is False
+
+
+def test_existing_brief_without_probe_allows_probe(tmp_path: Path) -> None:
+    decision = decide_loop_action(lane_brief=_brief(tmp_path))
+
+    assert decision.action == ACTION_RUN_CHEAP_PROBE
+    assert decision.allowed is True
+
+
+def test_weak_probe_closes_lane(tmp_path: Path) -> None:
+    decision = decide_loop_action(lane_brief=_brief(tmp_path), probe_verdict="WEAK_EDGE")
+
+    assert decision.action == ACTION_CLOSE_LANE
+    assert decision.allowed is False
+
+
+def test_discovery_pass_that_is_promotion_candidate_schedules_b1000(tmp_path: Path) -> None:
+    decision = decide_loop_action(
+        lane_brief=_brief(tmp_path),
+        probe_verdict="HAS_PULSE",
+        last_result=_last_result(bootstrap=100),
+    )
+
+    assert decision.action == ACTION_RUN_BOOTSTRAP_1000
+    assert decision.allowed is True
+
+
+def test_standard_pass_without_promotion_candidate_stops_before_b1000(tmp_path: Path) -> None:
+    decision = decide_loop_action(
+        lane_brief=_brief(tmp_path),
+        probe_verdict="HAS_PULSE",
+        last_result=_last_result(bootstrap=100, eligible_for_bootstrap_1000=False),
+    )
+
+    assert decision.action == ACTION_ITERATE_OR_CLOSE
+    assert decision.allowed is False
+
+
+def test_b1000_pass_requires_overlap_report(tmp_path: Path) -> None:
+    decision = decide_loop_action(
+        lane_brief=_brief(tmp_path),
+        probe_verdict="HAS_PULSE",
+        last_result=_last_result(bootstrap=1000, eligible_for_bootstrap_1000=False),
+    )
+
+    assert decision.action == ACTION_CHECK_OVERLAP
+    assert decision.allowed is True
+
+
+def test_high_overlap_blocks_paper_review(tmp_path: Path) -> None:
+    decision = decide_loop_action(
+        lane_brief=_brief(tmp_path),
+        probe_verdict="HAS_PULSE",
+        last_result=_last_result(bootstrap=1000, eligible_for_bootstrap_1000=False),
+        overlap_report={
+            "pairwise_oos": [
+                {
+                    "left": "live",
+                    "right": "candidate",
+                    "jaccard": 0.5,
+                    "pct_of_left_also_in_right": 45.0,
+                    "pct_of_right_also_in_left": 50.0,
+                }
+            ]
+        },
+    )
+
+    assert decision.action == ACTION_ITERATE_OR_CLOSE
+    assert decision.allowed is False
+
+
+def test_low_overlap_allows_paper_review(tmp_path: Path) -> None:
+    decision = decide_loop_action(
+        lane_brief=_brief(tmp_path),
+        probe_verdict="HAS_PULSE",
+        last_result=_last_result(bootstrap=1000, eligible_for_bootstrap_1000=False),
+        overlap_report={
+            "pairwise_oos": [
+                {
+                    "left": "live",
+                    "right": "candidate",
+                    "jaccard": 0.05,
+                    "pct_of_left_also_in_right": 5.0,
+                    "pct_of_right_also_in_left": 8.0,
+                }
+            ]
+        },
+    )
+
+    assert decision.action == ACTION_READY_FOR_PAPER_REVIEW
+    assert decision.allowed is True

--- a/tests/test_rbi_loop_guard.py
+++ b/tests/test_rbi_loop_guard.py
@@ -132,3 +132,54 @@ def test_low_overlap_allows_paper_review(tmp_path: Path) -> None:
 
     assert decision.action == ACTION_READY_FOR_PAPER_REVIEW
     assert decision.allowed is True
+
+
+def test_high_overlap_handles_null_values(tmp_path: Path) -> None:
+    """Null/missing metrics in overlap items must not crash; treated as 0 (low overlap here)."""
+    decision = decide_loop_action(
+        lane_brief=_brief(tmp_path),
+        probe_verdict="HAS_PULSE",
+        last_result=_last_result(bootstrap=1000, eligible_for_bootstrap_1000=False),
+        overlap_report={
+            "pairwise_oos": [
+                {
+                    "left": "live",
+                    "right": "candidate",
+                    "jaccard": None,
+                    "pct_of_left_also_in_right": None,
+                    "pct_of_right_also_in_left": 12.0,
+                },
+                {
+                    "left": "other",
+                    "right": "candidate2",
+                    # all null/missing -> 0s, low overlap
+                },
+            ]
+        },
+    )
+
+    assert decision.action == ACTION_READY_FOR_PAPER_REVIEW
+    assert decision.allowed is True
+
+
+def test_high_pct_null_jaccard_still_blocks(tmp_path: Path) -> None:
+    """High pct metric triggers block even if jaccard is null."""
+    decision = decide_loop_action(
+        lane_brief=_brief(tmp_path),
+        probe_verdict="HAS_PULSE",
+        last_result=_last_result(bootstrap=1000, eligible_for_bootstrap_1000=False),
+        overlap_report={
+            "pairwise_oos": [
+                {
+                    "left": "live",
+                    "right": "candidate",
+                    "jaccard": None,
+                    "pct_of_left_also_in_right": 55.0,
+                    "pct_of_right_also_in_left": None,
+                }
+            ]
+        },
+    )
+
+    assert decision.action == ACTION_ITERATE_OR_CLOSE
+    assert decision.allowed is False

--- a/tests/test_rbi_loop_guard.py
+++ b/tests/test_rbi_loop_guard.py
@@ -183,3 +183,39 @@ def test_high_pct_null_jaccard_still_blocks(tmp_path: Path) -> None:
 
     assert decision.action == ACTION_ITERATE_OR_CLOSE
     assert decision.allowed is False
+
+
+def test_malformed_partial_overlap_rows_are_ignored(tmp_path: Path) -> None:
+    """Non-dict rows, bad types, and partial rows must not crash; only valid numeric pairs are considered."""
+    decision = decide_loop_action(
+        lane_brief=_brief(tmp_path),
+        probe_verdict="HAS_PULSE",
+        last_result=_last_result(bootstrap=1000, eligible_for_bootstrap_1000=False),
+        overlap_report={
+            "pairwise_oos": [
+                "not a dict",
+                None,
+                {
+                    "left": "live",
+                    "right": "bad",
+                    "jaccard": "not-a-number",
+                    "pct_of_left_also_in_right": 99.0,
+                },  # bad jaccard but high pct
+                {
+                    "left": "live",
+                    "right": "candidate",
+                    "jaccard": 0.9,
+                    "pct_of_left_also_in_right": None,
+                },
+                {"foo": "bar"},  # missing keys -> treated as 0
+            ]
+        },
+    )
+
+    # The high-pct bad-jaccard row and the high-jaccard row should trigger block
+    assert decision.action == ACTION_ITERATE_OR_CLOSE
+    assert decision.allowed is False
+    # Evidence should only contain the rows that passed the numeric threshold checks
+    high = decision.evidence.get("high_overlap_pairs", [])
+    assert any(p.get("right") == "bad" for p in high)
+    assert any(p.get("right") == "candidate" for p in high)

--- a/tests/test_rbi_loop_report.py
+++ b/tests/test_rbi_loop_report.py
@@ -38,6 +38,25 @@ def test_render_report_includes_decision_reasons_and_evidence() -> None:
     assert "No command execution was recorded." in report
 
 
+def test_render_report_escapes_pipes_in_command_cell() -> None:
+    record = _record()
+    record["selected_command"] = "probe.py --a 1 | tee log"
+
+    report = render_report(record)
+
+    assert "| Selected command | `probe.py --a 1 \\| tee log` |" in report
+    assert "1 | tee" not in report
+
+
+def test_render_report_escapes_pipes_in_evidence_cell() -> None:
+    record = _record()
+    record["decision"]["evidence"]["lane_brief"] = "a | b"
+
+    report = render_report(record)
+
+    assert "| lane_brief | a \\| b |" in report
+
+
 def test_write_report_creates_parent_directories(tmp_path: Path) -> None:
     output = tmp_path / "docs" / "reports" / "rbi-loop-basis-v0.md"
 

--- a/tests/test_rbi_loop_report.py
+++ b/tests/test_rbi_loop_report.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.rbi_loop_report import _default_output_path, render_report, write_report
+
+
+def _record() -> dict[str, object]:
+    return {
+        "generated_at": "2026-06-09T00:00:00+00:00",
+        "lane_name": "basis-v0",
+        "execute": False,
+        "decision": {
+            "action": "RUN_CHEAP_PROBE",
+            "allowed": True,
+            "reasons": ["lane brief exists; cheap-probe verdict missing"],
+            "evidence": {
+                "lane_brief": "docs/specs/basis-v0.md",
+                "probe_verdict": None,
+            },
+        },
+        "selected_command": None,
+        "execution": None,
+    }
+
+
+def test_default_output_path_uses_lane_name() -> None:
+    assert _default_output_path(_record()) == Path("docs/reports/rbi-loop-basis-v0.md")
+
+
+def test_render_report_includes_decision_reasons_and_evidence() -> None:
+    report = render_report(_record())
+
+    assert "# RBI Loop Decision — basis-v0" in report
+    assert "| Action | `RUN_CHEAP_PROBE` |" in report
+    assert "- lane brief exists; cheap-probe verdict missing" in report
+    assert "| lane_brief | docs/specs/basis-v0.md |" in report
+    assert "No command execution was recorded." in report
+
+
+def test_write_report_creates_parent_directories(tmp_path: Path) -> None:
+    output = tmp_path / "docs" / "reports" / "rbi-loop-basis-v0.md"
+
+    write_report(output, "report\n")
+
+    assert output.read_text(encoding="utf-8") == "report\n"

--- a/tests/test_rbi_loop_runner.py
+++ b/tests/test_rbi_loop_runner.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from scripts.rbi_loop_guard import ACTION_RUN_AUTORESEARCH, LoopDecision
+from scripts.rbi_loop_runner import (
+    _command_for_decision,
+    _default_decision_output,
+    _run_command,
+    build_decision_record,
+    write_decision_record,
+)
+
+
+def test_default_decision_output_is_lane_scoped() -> None:
+    assert _default_decision_output("basis-v0") == Path("research/rbi_loop/basis-v0/decision.json")
+
+
+def test_command_for_decision_selects_matching_action_command() -> None:
+    args = argparse.Namespace(
+        probe_command=None,
+        autoresearch_command="python scripts/autoresearch_loop.py --dry-run",
+        bootstrap_command=None,
+        overlap_command=None,
+    )
+    decision = LoopDecision(
+        action=ACTION_RUN_AUTORESEARCH,
+        allowed=True,
+        reasons=[],
+        evidence={},
+    )
+
+    assert _command_for_decision(args, decision) == "python scripts/autoresearch_loop.py --dry-run"
+
+
+def test_build_decision_record_keeps_decision_and_execution() -> None:
+    decision = LoopDecision(
+        action=ACTION_RUN_AUTORESEARCH,
+        allowed=True,
+        reasons=["cheap probe passed"],
+        evidence={"probe_verdict": "HAS_PULSE"},
+    )
+    execution = {
+        "status": "completed",
+        "returncode": 0,
+        "duration_seconds": 0.01,
+        "command": "python -V",
+        "stdout_tail": ["Python 3.11.14"],
+        "stderr_tail": [],
+    }
+
+    record = build_decision_record(
+        lane_name="basis-v0",
+        decision=decision,
+        execute=True,
+        command="python -V",
+        execution=execution,
+    )
+
+    assert record["lane_name"] == "basis-v0"
+    assert record["decision"]["action"] == ACTION_RUN_AUTORESEARCH
+    assert record["selected_command"] == "python -V"
+    assert record["execution"] == execution
+
+
+def test_write_decision_record_creates_parent_directories(tmp_path: Path) -> None:
+    output = tmp_path / "research" / "rbi_loop" / "lane" / "decision.json"
+    record = {"lane_name": "lane", "decision": {"action": "RUN_CHEAP_PROBE"}}
+
+    write_decision_record(output, record)
+
+    assert json.loads(output.read_text(encoding="utf-8")) == record
+
+
+def test_run_command_returns_completion_result() -> None:
+    result = _run_command(
+        f"{sys.executable} -c \"print('ok')\"",
+        timeout_seconds=10,
+    )
+
+    assert result["status"] == "completed"
+    assert result["returncode"] == 0
+    assert result["stdout_tail"] == ["ok"]

--- a/tests/test_rbi_loop_scheduler.py
+++ b/tests/test_rbi_loop_scheduler.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_rbi_loop_batch_wrapper_does_not_execute_commands() -> None:
+    script = Path("scripts/run_rbi_loop_batch.sh").read_text(encoding="utf-8")
+
+    assert "scripts/rbi_loop_batch.py" in script
+    assert "--execute" not in script
+
+
+def test_rbi_loop_batch_systemd_service_uses_dry_wrapper() -> None:
+    service = Path("ops/systemd/crypto-agent-rbi-loop-batch.service").read_text(encoding="utf-8")
+
+    assert "ExecStart=/bin/bash scripts/run_rbi_loop_batch.sh" in service
+    assert "--execute" not in service
+    assert "OnFailure=crypto-agent-telegram-failure@%n.service" in service
+
+
+def test_rbi_loop_batch_timer_is_daily() -> None:
+    timer = Path("ops/systemd/crypto-agent-rbi-loop-batch.timer").read_text(encoding="utf-8")
+
+    assert "OnCalendar=*-*-* 01:15:00 UTC" in timer
+    assert "Persistent=true" in timer


### PR DESCRIPTION
## Summary
Adds a supervised, dry-by-default RBI (Research/Backtest/Implement) autoresearch loop:
guard (next-allowed-action), one-step + manifest runners, multi-lane batch supervisor,
report renderer, example manifest, and a dry systemd timer.

## Boundary
Supervised automation. Scheduled/batch mode is dry — writes decisions/reports only.
Any `--execute`, production rebuild, live config change, risk change, or sizing change
stays approval-gated.

## Verification
- RBI pytest suite: 29 passed
- `ruff check` / `ruff format --check`: clean
- `bash -n scripts/run_rbi_loop_batch.sh`: OK
- Guard schema cross-checked against real producers: `run_autoresearch.py`
  (`last_result.json`) and `analyze_entry_overlap.py` (overlap keys + jaccard>=0.35 /
  pct>=40 thresholds). `autoresearch_loop.py` invokes `run_autoresearch.py` per child,
  so the latest `research/last_result.json` is in the schema the guard reads.

## Hardening included
- Escape `|` / backslash / newline in Markdown table cells (`rbi_loop_report.py`,
  `rbi_loop_batch.py`) so operator-authored commands or lane names cannot break tables.
- Manifest comment clarifying where to point `last_result` for the iterate->bootstrap pass.

## Follow-ups (non-blocking)
- Optional: harden `float()` casts in `_high_overlap_pairs` against null values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
