### PR TITLE
feat(backtest): implement cross-venue dislocation probe (step 5)

### DIFF
--- a/config/autoresearch/rbi_loop.cross-venue-basis-v1.yaml
+++ b/config/autoresearch/rbi_loop.cross-venue-basis-v1.yaml
@@ -25,16 +25,17 @@ report_output: docs/reports/rbi-loop-cross-venue-basis-v1.md
 timeout_seconds: 3600
 
 commands:
-  # Cheap probe / coverage + dislocation signal (read-only).
-  # Does not exist yet; will be a new or extended script (see investigation of
-  # probe_basis_premium.py + audit_basis_premium_coverage.py + funding probes).
-  # Must support at least two venues and compute relative dislocation metrics.
+  # Cheap probe: cross-venue spread extremes gated on forward price returns/MAE
+  # (read-only; reuses probe_basis_premium machinery). Venues limited to those
+  # with real importers/backfill — add okx only once an OKX importer exists.
+  # After reviewing the written verdict JSON, set probe_verdict above to advance.
   RUN_CHEAP_PROBE: >-
     uv run python scripts/probe_cross_venue_basis.py
-    --venues binance_usdm,bybit,okx
+    --venues binance_usdm,bybit
     --symbols BTCUSDT,ETHUSDT,SOLUSDT
     --timeframe 1h
     --start 2024-01-01
+    --verdict-output research/rbi_loop/cross-venue-basis-v1/probe-verdict.json
 
   # Bounded autoresearch only after HAS_PULSE + guard allows.
   # Families will be new (dislocation / venue-regime / cross-basis filters), not

--- a/scripts/probe_cross_venue_basis.py
+++ b/scripts/probe_cross_venue_basis.py
@@ -2,79 +2,71 @@
 """
 Cheap feasibility probe for *cross-venue* perp basis / dislocation primitives.
 
-This is the missing cheap probe referenced by the cross-venue RBI lane
+This is the cheap probe referenced by the cross-venue RBI lane
 (config/autoresearch/rbi_loop.cross-venue-basis-v1.yaml).
 
-Design goals (v0):
-- Support multiple venues (e.g. binance_usdm, bybit, okx).
-- Compute relative dislocation signals (basis spread, premium difference, etc.)
-  across venues for the same symbol/time.
-- Apply similar gates to the single-venue probe (event count, forward edge,
-  MAE characteristics, concentration).
-- Output a structured report + verdict that can feed the RBI guard
-  (HAS_PULSE / WEAK_EDGE / NO_PULSE) and be pointed at via last_result.
+Methodology (v1): for each (symbol, venue pair), build a *spread series*
+(basis_bps and premium_index differences between the two venues) joined with
+OHLCV close/low at the same timestamps, then run the exact single-venue
+machinery from scripts/probe_basis_premium.py on it:
 
-Current status: Skeleton + multi-venue loading. Full dislocation metrics
-and gate logic are TODO / partial (see _compute_dislocation_scenarios).
+- events = tail-percentile extremes of the spread (both sides) + normalization
+- edge   = forward *price* returns at 12/24 bars and MAE vs baseline MAE
+- gates  = min event counts, mean forward, MAE improvement, concentration
+- verdict = HAS_PULSE / WEAK_EDGE / SPARSE / NO_PULSE (same semantics)
 
-It will run against whatever is backfilled in perp_basis_metrics (the table
-already supports multiple exchanges via the `exchange` column).
+Measuring forward price returns (not spread self-convergence) is deliberate:
+cross-venue spreads on the same underlying always mean-revert, so spread
+convergence alone is a tautology, not an edge.
 
 Usage (dry / guard-driven):
   uv run python scripts/probe_cross_venue_basis.py \
-    --venues binance_usdm,bybit,okx \
+    --venues binance_usdm,bybit \
     --symbols BTCUSDT,ETHUSDT,SOLUSDT \
     --timeframe 1h \
-    --start 2024-01-01
+    --start 2024-01-01 \
+    --verdict-output research/rbi_loop/cross-venue-basis-v1/probe-verdict.json
 
-See:
-- docs/specs/cross-venue-basis-dislocation-brief-v0.md
-- The RBI guard will treat a successful probe run as the trigger to advance
-  the lane (once a real verdict + last_result artifact exists).
+See docs/specs/cross-venue-basis-dislocation-brief-v0.md.
 """
 
 from __future__ import annotations
 
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
 import argparse
 import asyncio
 import json
-import os
-from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass
 from datetime import UTC, datetime
-from enum import StrEnum
-from pathlib import Path
 from typing import Any
 
-# DB and logger imports are done lazily inside the non-smoke path so that
-# --smoke works without a full project environment / PYTHONPATH.
-# This also keeps the cheap smoke test truly cheap.
-
-# --- Minimal schema assumption (matches migration 010) ---
-# perp_basis_metrics has: time, exchange, symbol, timeframe, basis_bps, premium_index, ...
+# Heavy imports (src.db, scripts.probe_basis_premium -> asyncpg) are done lazily
+# so that --smoke works without a full project environment.
 
 PROBE_QUERY = """
     SELECT
-        time,
-        exchange,
-        symbol,
-        timeframe,
-        basis_bps,
-        premium_index
-    FROM perp_basis_metrics
-    WHERE exchange = ANY($1)
-      AND symbol = ANY($2)
-      AND timeframe = $3
-      AND time >= $4::timestamptz
-      AND time <= $5::timestamptz
-    ORDER BY time ASC, exchange ASC
+        p.time,
+        p.exchange,
+        p.basis_bps,
+        p.premium_index,
+        o.close_price,
+        o.low_price
+    FROM perp_basis_metrics p
+    INNER JOIN ohlcv o
+        ON p.time = o.time
+        AND p.symbol = o.symbol
+        AND p.timeframe = o.timeframe
+    WHERE p.exchange = ANY($1)
+      AND p.symbol = $2
+      AND p.timeframe = $3
+      AND p.time >= $4
+      AND p.time <= $5
+    ORDER BY p.time ASC
 """
-
-
-class DislocationKind(StrEnum):
-    BASIS_SPREAD = "basis_spread"  # basis_venueA - basis_venueB
-    PREMIUM_SPREAD = "premium_spread"  # premium_venueA - premium_venueB
-    # Future: normalized_funding_diff, oi_pressure, etc.
 
 
 @dataclass(frozen=True)
@@ -84,100 +76,162 @@ class CrossVenueProbeConfig:
     timeframe: str
     start: str
     end: str
+    tail_pcts: tuple[int, ...]
+    forward_bars_12h: int
+    forward_bars_24h: int
+    min_events_per_pair: int
     min_events_pooled: int
     min_mean_forward_pct: float
     min_mae_improvement_pct: float
     max_concentration_pct: float
 
 
-# NOTE: The following dataclasses are prepared for the full implementation.
-# They are kept for the v0 skeleton but currently unused in the smoke/no-data path
-# (to be activated when multi-venue backfill + dislocation logic land).
-# Ruff F401 unused-import warnings are expected until then; they document the intended shape.
-
-
 @dataclass(frozen=True)
-class DislocationEvent:
-    time: datetime
-    symbol: str
-    kind: str
-    venue_pair: str
-    dislocation: float
-    forward_12h_pct: float
-    forward_24h_pct: float
-    mae_12h_pct: float
-    mae_24h_pct: float
-
-
-@dataclass(frozen=True)
-class VenuePairSummary:
-    venue_pair: str
-    kind: str
-    event_count: int
-    mean_forward_pct: float
-    mean_mae_pct: float
-    mae_improvement_pct: float
-    concentration_pct: float
-
-
-@dataclass(frozen=True)
-class CrossVenueProbeReport:
-    config: CrossVenueProbeConfig
-    venue_pairs: tuple[VenuePairSummary, ...]
+class SmokeReport:
     verdict: str
-    passing_pairs: tuple[str, ...]
-    note: str = ""
+    note: str
 
 
-def build_db_config(env: Mapping[str, str] | None = None) -> dict[str, object]:
-    source = env or os.environ
-    return {
-        "host": source.get("DB_HOST", source.get("POSTGRES_HOST", "localhost")),
-        "port": int(source.get("DB_PORT", source.get("POSTGRES_PORT", 5432))),
-        "name": source.get("DB_NAME", source.get("POSTGRES_DB", "marketdata")),
-        "user": source.get("DB_USER", source.get("POSTGRES_USER", "trading")),
-        "password": source.get("DB_PASSWORD", source.get("POSTGRES_PASSWORD", "change_me")),
+def _cheap_smoke_test() -> SmokeReport:
+    """No-DB, no-network safe default used by --smoke and tests."""
+    return SmokeReport(
+        verdict="NO_PULSE",
+        note=(
+            "SMOKE: no data path exercised. "
+            "This is the expected safe default before multi-venue backfill."
+        ),
+    )
+
+
+def build_pair_spread_bars(
+    rows: list[dict[str, Any]],
+    venues: tuple[str, ...],
+) -> dict[str, list[Any]]:
+    """Turn per-venue rows for one symbol into per-venue-pair spread bars.
+
+    Returns {"venueA-venueB": [PremiumBar, ...]} where the bar's basis_bps and
+    premium_index hold the *spread* (A minus B) and close/low come from the
+    joined OHLCV (identical across venues at the same time/symbol/timeframe).
+    """
+    from scripts.probe_basis_premium import PremiumBar
+
+    by_time: dict[datetime, dict[str, dict[str, Any]]] = {}
+    for row in rows:
+        by_time.setdefault(row["time"], {})[row["exchange"]] = row
+
+    pairs = [(venues[i], venues[j]) for i in range(len(venues)) for j in range(i + 1, len(venues))]
+    out: dict[str, list[Any]] = {f"{a}-{b}": [] for a, b in pairs}
+    for t in sorted(by_time):
+        venue_rows = by_time[t]
+        for a, b in pairs:
+            row_a = venue_rows.get(a)
+            row_b = venue_rows.get(b)
+            if row_a is None or row_b is None:
+                continue
+            out[f"{a}-{b}"].append(
+                PremiumBar(
+                    time=t,
+                    basis_bps=float(row_a["basis_bps"]) - float(row_b["basis_bps"]),
+                    premium_index=float(row_a["premium_index"]) - float(row_b["premium_index"]),
+                    close_price=float(row_a["close_price"]),
+                    low_price=float(row_a["low_price"]),
+                )
+            )
+    return out
+
+
+def analyze_cross_venue(
+    rows_by_symbol: dict[str, list[dict[str, Any]]],
+    config: CrossVenueProbeConfig,
+) -> Any:
+    """Run the single-venue probe machinery on per-pair spread series.
+
+    Returns a scripts.probe_basis_premium.ProbeReport whose "symbols" are
+    "<symbol>|<venueA>-<venueB>" entries; metric labels basis_bps /
+    premium_index refer to the cross-venue *spreads* of those metrics.
+    """
+    from scripts.probe_basis_premium import (
+        ProbeConfig,
+        ProbeReport,
+        evaluate_report,
+        probe_symbol,
+    )
+
+    spb_config = ProbeConfig(
+        symbols=config.symbols,
+        timeframe=config.timeframe,
+        exchange="+".join(config.venues),
+        start=config.start,
+        end=config.end,
+        tail_pcts=config.tail_pcts,
+        forward_bars_12h=config.forward_bars_12h,
+        forward_bars_24h=config.forward_bars_24h,
+        min_events_per_symbol=config.min_events_per_pair,
+        min_events_pooled=config.min_events_pooled,
+        min_mean_forward_pct=config.min_mean_forward_pct,
+        min_mae_improvement_pct=config.min_mae_improvement_pct,
+        max_concentration_pct=config.max_concentration_pct,
+    )
+
+    summaries = []
+    for symbol, rows in rows_by_symbol.items():
+        for pair_label, bars in build_pair_spread_bars(rows, config.venues).items():
+            summaries.append(probe_symbol(bars, f"{symbol}|{pair_label}", spb_config))
+
+    preliminary = ProbeReport(
+        config=spb_config, symbols=tuple(summaries), verdict="", passing_scenarios=()
+    )
+    verdict, passing = evaluate_report(preliminary)
+    return ProbeReport(
+        config=spb_config,
+        symbols=tuple(summaries),
+        verdict=verdict,
+        passing_scenarios=passing,
+    )
+
+
+def print_cross_venue_report(report: Any, config: CrossVenueProbeConfig) -> None:
+    print("Cross-venue basis dislocation probe")
+    print(f"Venues:    {', '.join(config.venues)}")
+    print(f"Symbols:   {', '.join(config.symbols)}")
+    print(f"Timeframe: {config.timeframe}")
+    print(f"Window:    {config.start} -> {config.end}")
+    for summary in report.symbols:
+        event_total = sum(len(s.events) for s in summary.scenarios)
+        print(f"  {summary.symbol}: bars={summary.bar_count} events_total={event_total}")
+    print(f"Verdict:   {report.verdict}")
+    if report.passing_scenarios:
+        print("Passing scenarios (metric = cross-venue spread):")
+        for label in report.passing_scenarios:
+            print(f"  {label}")
+
+
+def _write_verdict(
+    verdict: str,
+    note: str,
+    passing: tuple[str, ...],
+    config: CrossVenueProbeConfig,
+    path: str | None,
+) -> None:
+    if not path:
+        return
+    payload = {
+        "verdict": verdict,
+        "note": note,
+        "passing_scenarios": list(passing),
+        "generated_at": datetime.now(UTC).isoformat(),
+        "config": {
+            "venues": list(config.venues),
+            "symbols": list(config.symbols),
+            "timeframe": config.timeframe,
+            "start": config.start,
+            "end": config.end,
+        },
     }
-
-
-def _mean(values: Iterable[float]) -> float:
-    materialized = list(values)
-    if not materialized:
-        return 0.0
-    return sum(materialized) / len(materialized)
-
-
-def _percentile(values: Sequence[float], pct: float) -> float:
-    if not values:
-        return 0.0
-    ordered = sorted(values)
-    if len(ordered) == 1:
-        return ordered[0]
-    rank = (len(ordered) - 1) * pct / 100.0
-    low = int(rank)
-    high = min(low + 1, len(ordered) - 1)
-    return ordered[low] + (ordered[high] - ordered[low]) * (rank - low)
-
-
-async def load_multi_venue_data(
-    pool: Any,
-    venues: list[str],
-    symbols: list[str],
-    timeframe: str,
-    start: str,
-    end: str,
-) -> list[dict[str, Any]]:
-    """Load basis data for multiple venues/symbols."""
-    async with pool.acquire() as conn:
-        rows = await conn.fetch(
-            PROBE_QUERY,
-            venues,
-            symbols,
-            timeframe,
-            start,
-            end,
-        )
-    return [dict(r) for r in rows]
+    out = Path(path)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(payload, indent=2) + "\n")
+    print(f"Wrote guard-consumable verdict to {path}")
 
 
 async def check_multi_venue_coverage(
@@ -209,252 +263,105 @@ async def check_multi_venue_coverage(
     print(f"  Total: {total} rows across {len(rows)} venue(s)")
 
 
-def _align_and_compute_dislocations(
-    rows: list[dict[str, Any]],
-    venues: list[str],
-) -> list[DislocationEvent]:
-    """
-    Group rows by (time, symbol), then for each group compute pairwise
-    dislocations between venues.
-
-    This is the core new logic vs single-venue probe_basis_premium.py.
-    Currently a skeleton: returns empty list until full forward/MAE
-    calculation + data alignment is implemented.
-    """
-    from collections import defaultdict
-
-    by_key: dict[tuple[datetime, str], dict[str, dict]] = defaultdict(dict)
-    for r in rows:
-        key = (r["time"], r["symbol"])
-        by_key[key][r["exchange"]] = r
-
-    events: list[DislocationEvent] = []
-    # TODO: implement real forward returns + MAE using joined OHLCV
-    # For now we emit nothing so the probe reports low coverage (safe default).
-    # When backfilled data + forward logic land, populate DislocationEvent
-    # with realistic values and return them.
-    return events
-
-
-def _evaluate_dislocation_scenarios(
-    events: list[DislocationEvent],
-    config: CrossVenueProbeConfig,
-) -> list[VenuePairSummary]:
-    """Group events and apply gates. Skeleton returns empty summaries."""
-    # TODO: implement tail analysis on |dislocation|, forward edge, MAE, concentration.
-    return []
-
-
-def run_cross_venue_probe(
-    rows: list[dict[str, Any]],
-    config: CrossVenueProbeConfig,
-) -> CrossVenueProbeReport:
-    events = _align_and_compute_dislocations(rows, list(config.venues))
-    summaries = _evaluate_dislocation_scenarios(events, config)
-
-    if not summaries:
-        return CrossVenueProbeReport(
-            config=config,
-            venue_pairs=(),
-            verdict="NO_PULSE",
-            passing_pairs=(),
-            note="No dislocation events computed (skeleton or insufficient multi-venue data). "
-            "Backfill additional venues and implement _compute_dislocation_scenarios.",
-        )
-
-    # TODO: real verdict logic
-    verdict = "WEAK_EDGE"
-    passing = []
-    return CrossVenueProbeReport(
-        config=config,
-        venue_pairs=tuple(summaries),
-        verdict=verdict,
-        passing_pairs=tuple(passing),
-    )
-
-
-def print_report(report: CrossVenueProbeReport) -> None:
-    print("Cross-venue basis dislocation probe")
-    print(f"Venues:    {', '.join(report.config.venues)}")
-    print(f"Symbols:   {', '.join(report.config.symbols)}")
-    print(f"Timeframe: {report.config.timeframe}")
-    print(f"Window:    {report.config.start} → {report.config.end}")
-    print(f"Verdict:   {report.verdict}")
-    if report.note:
-        print(f"Note:      {report.note}")
-    if report.venue_pairs:
-        print("\nVenue-pair summaries (top):")
-        for s in report.venue_pairs[:5]:
-            print(
-                f"  {s.venue_pair} [{s.kind}]: events={s.event_count} "
-                f"fwd={s.mean_forward_pct:.3f}% mae_imp={s.mae_improvement_pct:.1f}%"
-            )
-    else:
-        print("\nNo venue-pair summaries (see note).")
-
-
-def _write_verdict(report: CrossVenueProbeReport, path: str | None) -> None:
-    """Write a guard-consumable verdict JSON (used by both --smoke and real paths)."""
-    if not path:
-        return
-    payload = {
-        "verdict": report.verdict,
-        "note": report.note,
-        "generated_at": datetime.now(UTC).isoformat(),
-        "config": {
-            "venues": list(report.config.venues),
-            "symbols": list(report.config.symbols),
-        },
-    }
-    Path(path).parent.mkdir(parents=True, exist_ok=True)
-    Path(path).write_text(json.dumps(payload, indent=2) + "\n")
-    print(f"Wrote guard-consumable verdict to {path}")
-
-
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="Cross-venue perp basis dislocation probe (RBI cheap probe)."
     )
-    parser.add_argument(
-        "--venues", default="binance_usdm", help="Comma-separated list of exchanges/venues"
-    )
+    parser.add_argument("--venues", default="binance_usdm,bybit")
     parser.add_argument("--symbols", default="BTCUSDT,ETHUSDT,SOLUSDT")
     parser.add_argument("--timeframe", default="1h")
     parser.add_argument("--start", default="2024-01-01")
     parser.add_argument("--end", default=None)
-    parser.add_argument("--min-events", type=int, default=100)
+    # Gate defaults mirror scripts/probe_basis_premium.py.
+    parser.add_argument("--tail-pcts", default="5,10")
+    parser.add_argument("--min-events-per-pair", type=int, default=30)
+    parser.add_argument("--min-events-pooled", type=int, default=100)
     parser.add_argument("--min-forward-pct", type=float, default=0.15)
     parser.add_argument("--min-mae-imp-pct", type=float, default=10.0)
     parser.add_argument("--max-conc-pct", type=float, default=50.0)
     parser.add_argument(
-        "--verdict-output",
-        default=None,
-        help="Path to write a guard-consumable verdict JSON (e.g. for last_result or manifest).",
-    )
-    parser.add_argument(
         "--smoke",
         action="store_true",
-        help="Run a cheap smoke test for empty/no-data behavior (no DB required).",
+        help="No-DB safe default path (always NO_PULSE); used by tests",
     )
     parser.add_argument(
         "--check-coverage",
         action="store_true",
-        help="Run multi-venue coverage / backfill audit (row counts per venue) and exit. "
-        "Dry diagnostic only; does not compute dislocation or require full probe logic.",
+        help="Only audit per-venue row counts, then exit (no probe, no verdict)",
+    )
+    parser.add_argument(
+        "--verdict-output",
+        default=None,
+        help="Write guard-consumable verdict JSON to this path",
     )
     return parser.parse_args()
 
 
-async def main_async() -> None:
-    args = parse_args()
-
-    # Make configure_logger optional so --smoke works in a bare python environment
-    # (the real project run via `uv run` will get the full logger).
-    try:
-        from src.utils.logger import configure_logger  # type: ignore
-    except Exception:
-
-        def configure_logger(level: str) -> None:  # type: ignore
-            import logging
-
-            logging.basicConfig(level=getattr(logging, level, logging.INFO))
-
-    configure_logger("INFO")
-
+def _config_from_args(args: argparse.Namespace) -> CrossVenueProbeConfig:
     venues = tuple(v.strip() for v in args.venues.split(",") if v.strip())
     symbols = tuple(s.strip() for s in args.symbols.split(",") if s.strip())
+    tail_pcts = tuple(int(p) for p in args.tail_pcts.split(",") if p.strip())
     end = args.end or datetime.now(UTC).date().isoformat()
-
-    config = CrossVenueProbeConfig(
+    return CrossVenueProbeConfig(
         venues=venues,
         symbols=symbols,
         timeframe=args.timeframe,
         start=args.start,
         end=end,
-        min_events_pooled=args.min_events,
+        tail_pcts=tail_pcts,
+        forward_bars_12h=12,
+        forward_bars_24h=24,
+        min_events_per_pair=args.min_events_per_pair,
+        min_events_pooled=args.min_events_pooled,
         min_mean_forward_pct=args.min_forward_pct,
         min_mae_improvement_pct=args.min_mae_imp_pct,
         max_concentration_pct=args.max_conc_pct,
     )
 
+
+async def main_async() -> None:
+    args = parse_args()
+    config = _config_from_args(args)
+
     if args.smoke:
-        # Cheap smoke test for empty/no-data behavior (no DB, no network)
         report = _cheap_smoke_test()
-        print_report(report)
-        if args.verdict_output:
-            _write_verdict(report, args.verdict_output)
+        print(f"Verdict:   {report.verdict}")
+        print(f"Note:      {report.note}")
+        _write_verdict(report.verdict, report.note, (), config, args.verdict_output)
         return
 
-    # Lazy imports for the real path (requires project env)
+    from scripts.probe_basis_premium import build_db_config
     from src.db import close_pool, init_pool
+    from src.utils.logger import configure_logger
 
-    db_cfg = build_db_config()
-    pool = await init_pool(db_cfg)
-
-    if args.check_coverage:
-        await check_multi_venue_coverage(pool, list(venues), list(symbols), args.timeframe)
-        await close_pool()
-        return
-
-    report = None
+    configure_logger("WARNING")
+    pool = await init_pool(build_db_config())
     try:
-        rows = await load_multi_venue_data(
-            pool, list(venues), list(symbols), args.timeframe, args.start, end
-        )
-        report = run_cross_venue_probe(rows, config)
-    except Exception as exc:  # noqa: BLE001
-        # Safe fallback on error in the real path (init_pool errors will still surface as non-zero, which is acceptable for the guard).
-        report = CrossVenueProbeReport(
-            config=config,
-            venue_pairs=(),
-            verdict="NO_PULSE",
-            passing_pairs=(),
-            note=f"Safe fallback due to error during probe: {exc}. "
-            "This is the expected behavior before data backfill and full implementation.",
-        )
+        if args.check_coverage:
+            await check_multi_venue_coverage(
+                pool, list(config.venues), list(config.symbols), config.timeframe
+            )
+            return
+
+        start = datetime.fromisoformat(config.start).replace(tzinfo=UTC)
+        end = datetime.fromisoformat(config.end).replace(tzinfo=UTC)
+        rows_by_symbol: dict[str, list[dict[str, Any]]] = {}
+        for symbol in config.symbols:
+            fetched = await pool.fetch(
+                PROBE_QUERY, list(config.venues), symbol, config.timeframe, start, end
+            )
+            rows_by_symbol[symbol] = [dict(r) for r in fetched]
     finally:
         await close_pool()
 
-    print_report(report)
-
-    if args.verdict_output:
-        _write_verdict(report, args.verdict_output)
-
-    # For RBI guard consumption, a caller can write a last_result.json
-    # containing verdict, passing scenarios, etc.
-    # The guard itself only cares about the *existence* of a positive verdict
-    # for advancing past the cheap-probe gate.
+    report = analyze_cross_venue(rows_by_symbol, config)
+    print_cross_venue_report(report, config)
+    note = "Forward price-return/MAE gates on cross-venue spread extremes (see brief)."
+    _write_verdict(report.verdict, note, report.passing_scenarios, config, args.verdict_output)
 
 
 def main() -> None:
     asyncio.run(main_async())
-
-
-def _cheap_smoke_test() -> CrossVenueProbeReport:
-    """Cheap smoke test for empty/no-data behavior (callable from pytest or directly).
-    Returns the report so the CLI and tests can use it (e.g. for --verdict-output).
-    """
-    # Simulate the smoke path without DB or asyncio
-    config = CrossVenueProbeConfig(
-        venues=("binance_usdm", "bybit"),
-        symbols=("BTCUSDT",),
-        timeframe="1h",
-        start="2024-01-01",
-        end="2024-01-02",
-        min_events_pooled=100,
-        min_mean_forward_pct=0.15,
-        min_mae_improvement_pct=10.0,
-        max_concentration_pct=50.0,
-    )
-    report = CrossVenueProbeReport(
-        config=config,
-        venue_pairs=(),
-        verdict="NO_PULSE",
-        passing_pairs=(),
-        note="SMOKE: no data path exercised. This is the expected safe default before multi-venue backfill.",
-    )
-    print("Cheap smoke test for no-data behavior: PASSED")
-    return report
 
 
 if __name__ == "__main__":

--- a/tests/test_probe_cross_venue_basis.py
+++ b/tests/test_probe_cross_venue_basis.py
@@ -1,15 +1,142 @@
-"""Tests for the cross-venue basis probe skeleton.
+"""Tests for the cross-venue basis probe.
 
-Focus on --smoke and --verdict-output (guard-consumable output).
-These must work without DB or full data (per RBI dry-run rules).
+Covers --smoke / --verdict-output (guard-consumable output) plus the
+dislocation analysis with hand-computed expectations. No DB or network.
 """
 
 import json
 import subprocess
 import sys
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
-from scripts.probe_cross_venue_basis import _cheap_smoke_test
+import pytest
+
+from scripts.probe_cross_venue_basis import (
+    CrossVenueProbeConfig,
+    _cheap_smoke_test,
+    analyze_cross_venue,
+    build_pair_spread_bars,
+)
+
+T0 = datetime(2024, 1, 1, tzinfo=UTC)
+
+
+def _row(
+    hour: int, exchange: str, basis: float, close: float, low: float, premium: float = 0.0
+) -> dict:
+    return {
+        "time": T0 + timedelta(hours=hour),
+        "exchange": exchange,
+        "basis_bps": basis,
+        "premium_index": premium,
+        "close_price": close,
+        "low_price": low,
+    }
+
+
+def _gate_config(**overrides) -> CrossVenueProbeConfig:
+    defaults = {
+        "venues": ("va", "vb"),
+        "symbols": ("SOLUSDT",),
+        "timeframe": "1h",
+        "start": "2024-01-01",
+        "end": "2024-01-04",
+        "tail_pcts": (5,),
+        "forward_bars_12h": 12,
+        "forward_bars_24h": 24,
+        "min_events_per_pair": 2,
+        "min_events_pooled": 2,
+        "min_mean_forward_pct": 0.15,
+        "min_mae_improvement_pct": 10.0,
+        "max_concentration_pct": 50.0,
+    }
+    defaults.update(overrides)
+    return CrossVenueProbeConfig(**defaults)
+
+
+def _spread_fixture_rows(closes: list[float], lows: list[float]) -> list[dict]:
+    """60 hourly bars; venue vb flat, venue va = i*0.1 bps except spikes 50 at bars 10/30.
+
+    Hand-computed: tail-5 high threshold over the 60 spread values is 5.805
+    (interpolated between the two largest non-spike values 5.8 and 5.9), so the
+    extreme-positive events with a valid 12/24-bar forward window are exactly
+    bars 10 and 30 (bar 59 qualifies but has no forward window).
+    """
+    rows: list[dict] = []
+    for i in range(60):
+        basis_a = 50.0 if i in (10, 30) else i * 0.1
+        rows.append(_row(i, "va", basis_a, closes[i], lows[i]))
+        rows.append(_row(i, "vb", 0.0, closes[i], lows[i]))
+    return rows
+
+
+def test_build_pair_spread_bars_signs_and_alignment():
+    """Spread is A-minus-B per pair; times missing a venue are skipped."""
+    rows = [
+        _row(0, "va", 10.0, 100.0, 99.0, premium=0.002),
+        _row(0, "vb", 3.0, 100.0, 99.0, premium=0.0005),
+        _row(1, "va", 7.0, 100.0, 99.0),  # vb missing at hour 1 -> skipped
+        _row(2, "vb", 4.0, 100.0, 99.0),  # va missing at hour 2 -> skipped
+    ]
+    pairs = build_pair_spread_bars(rows, ("va", "vb"))
+    assert list(pairs.keys()) == ["va-vb"]
+    bars = pairs["va-vb"]
+    assert len(bars) == 1
+    assert bars[0].basis_bps == 7.0  # 10.0 - 3.0
+    assert bars[0].premium_index == 0.0015  # 0.002 - 0.0005
+    assert bars[0].close_price == 100.0
+
+
+def test_analyze_has_pulse_on_real_price_edge():
+    """Spread spikes followed by +1% price moves must pass the forward gate.
+
+    Hand-computed: events at bars 10 and 30; closes[22] = closes[42] = 101.0 so
+    forward_12h is exactly +1.0% for both events (24h forward is 0%). Mean
+    forward 1.0% > 0.15% gate; concentration = max/sum = 50% <= 50% gate.
+    """
+    closes = [100.0] * 60
+    closes[22] = 101.0
+    closes[42] = 101.0
+    lows = [99.0] * 60
+    rows_by_symbol = {"SOLUSDT": _spread_fixture_rows(closes, lows)}
+
+    report = analyze_cross_venue(rows_by_symbol, _gate_config())
+
+    assert report.verdict == "HAS_PULSE"
+    assert "SOLUSDT|va-vb:extreme_positive:basis_bps:tail5" in report.passing_scenarios
+
+    summary = next(s for s in report.symbols if s.symbol == "SOLUSDT|va-vb")
+    scenario = next(
+        s
+        for s in summary.scenarios
+        if s.metric == "basis_bps" and s.tail_pct == 5 and str(s.kind) == "extreme_positive"
+    )
+    assert len(scenario.events) == 2
+    assert [e.forward_12h_pct for e in scenario.events] == pytest.approx([1.0, 1.0])
+
+
+def test_analyze_weak_edge_when_prices_flat():
+    """Anti-tautology: spread extremes with no price edge must NOT fire.
+
+    Same spread spikes as the HAS_PULSE fixture, but flat prices: every forward
+    return is 0%, MAE improvement is 0, so all gates fail -> WEAK_EDGE (events
+    exist but show no edge), never HAS_PULSE from spread convergence alone.
+    """
+    closes = [100.0] * 60
+    lows = [100.0] * 60
+    rows_by_symbol = {"SOLUSDT": _spread_fixture_rows(closes, lows)}
+
+    report = analyze_cross_venue(rows_by_symbol, _gate_config())
+
+    assert report.verdict == "WEAK_EDGE"
+    assert report.passing_scenarios == ()
+
+
+def test_analyze_no_pulse_on_empty_rows():
+    report = analyze_cross_venue({"SOLUSDT": []}, _gate_config())
+    assert report.verdict == "NO_PULSE"
+    assert report.passing_scenarios == ()
 
 
 def test_cheap_smoke_helper():


### PR DESCRIPTION
## Summary

Step 5 of the cross-venue roadmap (#62 foundation → #63 skeleton → #64 Bybit importer → **this**): the real dislocation math, the `sys.path` fix, and the manifest wiring. This is the clean redo after the reverted contaminated round — implemented per the brief and the single-venue methodology, not by analogy.

## Design: maximal reuse of the validated single-venue pipeline

For each (symbol, venue pair), the probe builds a **spread series** — `basis_bps` and `premium_index` differences between the two venues — joined with OHLCV close/low at the same timestamps, then runs `probe_basis_premium.py`'s machinery **unchanged** on it: tail-percentile extreme/normalization events, forward 12/24-bar **price** returns, MAE vs baseline, and the same min-events / forward / MAE-improvement / concentration gates and HAS_PULSE / WEAK_EDGE / SPARSE / NO_PULSE verdicts. ~120 lines of new adapter code; zero reimplemented statistics.

**Forward price returns by design**: cross-venue spreads on the same underlying always mean-revert, so spread self-convergence is a tautology, not an edge. The probe gates on whether spread extremes predict *price* behavior.

## Fixes

- `sys.path` bootstrap added — the DB paths (`--check-coverage` and the manifest's `RUN_CHEAP_PROBE` command) previously crashed with `ModuleNotFoundError: No module named 'src'`
- Manifest: `--verdict-output` wired (writes `research/rbi_loop/cross-venue-basis-v1/probe-verdict.json`), venues trimmed to those with real importers (`binance_usdm,bybit`; okx returns when an OKX importer exists), no `--check-coverage` in the probe command (it exits before writing a verdict)
- `probe_verdict:` in the manifest stays empty — a human reviews the written verdict JSON and sets it; the supervised flow is unchanged

## Tests (hand-computed expectations)

- Fixture with interpolated tail threshold computed by hand (5.805), events at exactly bars 10/30, forward returns exactly +1.0% → asserts HAS_PULSE with the precise scenario label
- **Anti-tautology test**: identical spread spikes with flat prices → all gates fail → `WEAK_EDGE`, proving spread extremes alone can never fire
- Empty data → `NO_PULSE`; pair alignment/sign tests; existing smoke/verdict-format tests retained
- Full suite: **906 passed, 1 skipped**; ruff check + format clean; pre-commit hooks passed

## Real-data evidence (local DB, both venues backfilled per #64 evidence)

```
SOLUSDT|binance_usdm-bybit: bars=18817
Verdict: HAS_PULSE
(20 passing scenarios incl. POOLED:extreme_positive:basis_bps:tail5)
```

Drift sanity check: unconditional SOLUSDT forward returns are +0.033%/12h and +0.062%/24h — far below the 0.15% gate, so HAS_PULSE reflects conditional edge over baseline, not trend artifact. Whether it survives WFO is precisely what the lane's next stage (`RUN_AUTORESEARCH`) exists to decide.

Note: local OHLCV ends 2026-02-23, so the join caps the analysis window there; refreshing OHLCV extends it but doesn't block the lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)