### PR TITLE
chore(backtest): record cross-venue-basis-v1 HAS_PULSE verdict and lane advance

### DIFF
--- a/config/autoresearch/rbi_loop.cross-venue-basis-v1.yaml
+++ b/config/autoresearch/rbi_loop.cross-venue-basis-v1.yaml
@@ -14,7 +14,12 @@
 
 lane_name: cross-venue-basis-v1
 lane_brief: docs/specs/cross-venue-basis-dislocation-brief-v0.md
-probe_verdict:   # Empty on purpose — first step is cheap probe after data lands
+# 2026-06-10 human review: probe run on full 3-symbol, 2-venue data (~21,365 joined
+# bars/symbol, 2024-01-01 → 2026-06-10) → HAS_PULSE with 27 passing scenarios
+# (SOL 9, ETH 8, BTC 5, pooled 5); unconditional drift 0.013–0.036%/12h vs the
+# 0.15% gate, so the edge is conditional on dislocation events.
+# Evidence: research/rbi_loop/cross-venue-basis-v1/probe-verdict.json
+probe_verdict: HAS_PULSE
 
 # last_result and overlap_report will be populated by prior steps once the lane advances.
 last_result:

--- a/docs/reports/rbi-loop-cross-venue-basis-v1.md
+++ b/docs/reports/rbi-loop-cross-venue-basis-v1.md
@@ -1,0 +1,28 @@
+# RBI Loop Decision — cross-venue-basis-v1
+
+| Field | Value |
+|---|---|
+| Generated at | 2026-06-10T15:20:27.900672+00:00 |
+| Action | `RUN_AUTORESEARCH` |
+| Allowed | True |
+| Execute requested | False |
+| Selected command | `uv run python scripts/autoresearch_loop.py --config config/settings.autoresearch.yaml --symbol SOLUSDT --timeframe 1h --train-months 3 --test-months 2 --gate-profile standard --families cross_venue_dislocation,venue_basis_filter --max-runs 30` |
+
+## Reasons
+
+- cheap probe passed; autoresearch result missing
+
+## Evidence
+
+| Field | Value |
+|---|---|
+| lane_brief | docs/specs/cross-venue-basis-dislocation-brief-v0.md |
+| probe_verdict | HAS_PULSE |
+
+## Execution
+
+No command execution was recorded.
+
+## Next Action
+
+RUN_AUTORESEARCH

--- a/research/rbi_loop/cross-venue-basis-v1/decision.json
+++ b/research/rbi_loop/cross-venue-basis-v1/decision.json
@@ -1,0 +1,18 @@
+{
+  "generated_at": "2026-06-10T15:20:27.900672+00:00",
+  "lane_name": "cross-venue-basis-v1",
+  "execute": false,
+  "decision": {
+    "action": "RUN_AUTORESEARCH",
+    "allowed": true,
+    "reasons": [
+      "cheap probe passed; autoresearch result missing"
+    ],
+    "evidence": {
+      "lane_brief": "docs/specs/cross-venue-basis-dislocation-brief-v0.md",
+      "probe_verdict": "HAS_PULSE"
+    }
+  },
+  "selected_command": "uv run python scripts/autoresearch_loop.py --config config/settings.autoresearch.yaml --symbol SOLUSDT --timeframe 1h --train-months 3 --test-months 2 --gate-profile standard --families cross_venue_dislocation,venue_basis_filter --max-runs 30",
+  "execution": null
+}

--- a/research/rbi_loop/cross-venue-basis-v1/probe-verdict.json
+++ b/research/rbi_loop/cross-venue-basis-v1/probe-verdict.json
@@ -1,0 +1,48 @@
+{
+  "verdict": "HAS_PULSE",
+  "note": "Forward price-return/MAE gates on cross-venue spread extremes (see brief).",
+  "passing_scenarios": [
+    "BTCUSDT|binance_usdm-bybit:extreme_positive:premium_index:tail10",
+    "BTCUSDT|binance_usdm-bybit:extreme_positive:premium_index:tail5",
+    "BTCUSDT|binance_usdm-bybit:normalization:basis_bps:tail5",
+    "BTCUSDT|binance_usdm-bybit:normalization:premium_index:tail10",
+    "BTCUSDT|binance_usdm-bybit:normalization:premium_index:tail5",
+    "ETHUSDT|binance_usdm-bybit:extreme_negative:basis_bps:tail10",
+    "ETHUSDT|binance_usdm-bybit:extreme_negative:basis_bps:tail5",
+    "ETHUSDT|binance_usdm-bybit:extreme_negative:premium_index:tail10",
+    "ETHUSDT|binance_usdm-bybit:extreme_negative:premium_index:tail5",
+    "ETHUSDT|binance_usdm-bybit:extreme_positive:basis_bps:tail10",
+    "ETHUSDT|binance_usdm-bybit:extreme_positive:basis_bps:tail5",
+    "ETHUSDT|binance_usdm-bybit:extreme_positive:premium_index:tail5",
+    "ETHUSDT|binance_usdm-bybit:normalization:basis_bps:tail5",
+    "POOLED:extreme_positive:basis_bps:tail5",
+    "POOLED:extreme_positive:premium_index:tail10",
+    "POOLED:extreme_positive:premium_index:tail5",
+    "POOLED:normalization:premium_index:tail10",
+    "POOLED:normalization:premium_index:tail5",
+    "SOLUSDT|binance_usdm-bybit:extreme_negative:basis_bps:tail10",
+    "SOLUSDT|binance_usdm-bybit:extreme_negative:basis_bps:tail5",
+    "SOLUSDT|binance_usdm-bybit:extreme_positive:basis_bps:tail10",
+    "SOLUSDT|binance_usdm-bybit:extreme_positive:basis_bps:tail5",
+    "SOLUSDT|binance_usdm-bybit:extreme_positive:premium_index:tail10",
+    "SOLUSDT|binance_usdm-bybit:extreme_positive:premium_index:tail5",
+    "SOLUSDT|binance_usdm-bybit:normalization:basis_bps:tail5",
+    "SOLUSDT|binance_usdm-bybit:normalization:premium_index:tail10",
+    "SOLUSDT|binance_usdm-bybit:normalization:premium_index:tail5"
+  ],
+  "generated_at": "2026-06-10T14:46:20.003043+00:00",
+  "config": {
+    "venues": [
+      "binance_usdm",
+      "bybit"
+    ],
+    "symbols": [
+      "BTCUSDT",
+      "ETHUSDT",
+      "SOLUSDT"
+    ],
+    "timeframe": "1h",
+    "start": "2024-01-01",
+    "end": "2026-06-10"
+  }
+}


### PR DESCRIPTION
Archival lane-state PR — no code changes. Records the human-reviewed cheap-probe verdict for the cross-venue-basis-v1 RBI lane and the guard advance to RUN_AUTORESEARCH.

- probe-verdict.json: genuine probe output, 3 symbols x 2 venues, ~21,365 joined 1h bars/symbol (2024-01-01 → 2026-06-10) → HAS_PULSE, 27 passing scenarios (SOL 9, ETH 8, BTC 5, pooled 5) — all three symbols pass independently.
- Drift baseline: unconditional 12-bar forward 0.013–0.036%/symbol vs the 0.15% gate → edge is conditional on dislocation events.
- Manifest: probe_verdict: HAS_PULSE with evidence inline.
- decision.json + report: dry guard tick → RUN_AUTORESEARCH.

⚠️ Do not --execute yet: the families cross_venue_dislocation / venue_basis_filter are not implemented in autoresearch_loop.py — the loud _parse_families error is the correct guard until the engine actually consumes cross-venue spreads (next PR; no inert placeholders).

🤖 Generated with [Claude Code](https://claude.com/claude-code)