### PR TITLE
feat(backtest): implement cross_venue_dislocation + venue_basis_filter autoresearch families

### DIFF
--- a/scripts/autoresearch_loop.py
+++ b/scripts/autoresearch_loop.py
@@ -41,6 +41,11 @@ DEFAULT_FAMILIES = (
     "funding_primary_standalone",
     "funding_normalization_standalone",
 )
+CV_FAMILIES = (
+    "cross_venue_dislocation",
+    "venue_basis_filter",
+)
+ALL_FAMILIES = DEFAULT_FAMILIES + CV_FAMILIES
 
 BASE_STRATEGY_CONFIGS: tuple[dict[str, Any], ...] = (
     {
@@ -99,8 +104,7 @@ def parse_args() -> argparse.Namespace:
         "--families",
         default=",".join(DEFAULT_FAMILIES),
         help=(
-            "Comma-separated candidate families to sample. Supported: "
-            + ", ".join(DEFAULT_FAMILIES)
+            "Comma-separated candidate families to sample. Supported: " + ", ".join(ALL_FAMILIES)
         ),
     )
     parser.add_argument(
@@ -244,7 +248,7 @@ def _parse_families(raw: str) -> tuple[str, ...]:
     families = tuple(part.strip() for part in raw.split(",") if part.strip())
     if not families:
         raise ValueError("At least one candidate family is required")
-    invalid = sorted(set(families) - set(DEFAULT_FAMILIES))
+    invalid = sorted(set(families) - set(ALL_FAMILIES))
     if invalid:
         raise ValueError(f"Unsupported candidate families: {', '.join(invalid)}")
     return families
@@ -715,6 +719,89 @@ def generate_candidate(
             f"funding-extreme-overlay entry={funding_rate['config']['entry_threshold']:.5f} "
             f"buy={buy:.2f}"
         )
+    elif family == "cross_venue_dislocation":
+        # Real sampler for cross-venue (require mode: enter only on dislocation)
+        # min_spread_bps from real p90-p99 of |binance-bybit basis spread| on SOL 1h.
+        buy = _round(rng.uniform(0.85, 1.15), 2)
+        buy_uptrend = _round(rng.uniform(0.80, min(1.05, buy)), 2)
+        sell = _round(-rng.uniform(0.70, 0.85), 2)
+        stack = _sol_winner_stack_params(rng)
+        min_bps = _round(rng.uniform(3.45, 7.08), 2)
+        overlay = {
+            "trading_execution": {
+                "sl_atr_multiplier": _round(rng.uniform(2.0, 2.5), 2),
+                "tp_atr_multiplier": _round(rng.uniform(3.4, 4.2), 2),
+                "trailing_activate_atr": _round(rng.uniform(1.5, 2.0), 2),
+                "trailing_offset_atr": _round(rng.uniform(0.80, 1.05), 2),
+            },
+            "strategy": {
+                "strategies": [
+                    *_strategy_configs_with_overrides(**stack),
+                ],
+                "aggregator": {
+                    "buy_threshold": buy,
+                    "buy_threshold_uptrend": buy_uptrend,
+                    "sell_threshold": sell,
+                    "min_confidence": _round(rng.uniform(0.0, 0.30), 2),
+                },
+                "per_symbol_aggregator_config": _per_symbol_aggregator_config(
+                    trading_symbol,
+                    buy=buy,
+                    sell=sell,
+                    buy_uptrend=buy_uptrend,
+                    sell_min_agreement=1,
+                ),
+                "cross_venue_dislocation": {
+                    "enabled": True,
+                    "metric": "basis_spread",
+                    "mode": "require",
+                    "min_spread_bps": min_bps,
+                    "side": rng.choice(["positive", "both"]),
+                },
+            },
+        }
+        desc = f"cross-venue-dislocation min_bps={min_bps:.2f} buy={buy:.2f}"
+    elif family == "venue_basis_filter":
+        # Real sampler for venue basis filter (block mode during high dislocation).
+        buy = _round(rng.uniform(0.85, 1.15), 2)
+        buy_uptrend = _round(rng.uniform(0.80, min(1.05, buy)), 2)
+        sell = _round(-rng.uniform(0.70, 0.85), 2)
+        stack = _sol_winner_stack_params(rng)
+        min_bps = _round(rng.uniform(4.49, 7.08), 2)
+        overlay = {
+            "trading_execution": {
+                "sl_atr_multiplier": _round(rng.uniform(2.0, 2.5), 2),
+                "tp_atr_multiplier": _round(rng.uniform(3.4, 4.2), 2),
+                "trailing_activate_atr": _round(rng.uniform(1.5, 2.0), 2),
+                "trailing_offset_atr": _round(rng.uniform(0.80, 1.05), 2),
+            },
+            "strategy": {
+                "strategies": [
+                    *_strategy_configs_with_overrides(**stack),
+                ],
+                "aggregator": {
+                    "buy_threshold": buy,
+                    "buy_threshold_uptrend": buy_uptrend,
+                    "sell_threshold": sell,
+                    "min_confidence": _round(rng.uniform(0.0, 0.30), 2),
+                },
+                "per_symbol_aggregator_config": _per_symbol_aggregator_config(
+                    trading_symbol,
+                    buy=buy,
+                    sell=sell,
+                    buy_uptrend=buy_uptrend,
+                    sell_min_agreement=1,
+                ),
+                "cross_venue_dislocation": {
+                    "enabled": True,
+                    "metric": "basis_spread",
+                    "mode": "block",
+                    "min_spread_bps": min_bps,
+                    "side": "both",
+                },
+            },
+        }
+        desc = f"venue-basis-filter min_bps={min_bps:.2f} buy={buy:.2f}"
     elif family == "regime_gated_pullback_overlay":
         buy = _round(rng.uniform(1.15, 1.40), 2)
         buy_uptrend = _round(rng.uniform(1.00, min(1.20, buy)), 2)

--- a/scripts/experiment_autopilot.py
+++ b/scripts/experiment_autopilot.py
@@ -137,7 +137,7 @@ def _build_backtest_config(
     replay_sentiment_path: str | None,
     replay_sentiment_max_age_hours: float | None,
     basis_calibrated_threshold: float | None = None,
-    cross_venue_dislocation: CrossVenueDislocationConfig = None,
+    cross_venue_dislocation: CrossVenueDislocationConfig | None = None,
 ) -> BacktestConfig:
     trading_exec = raw_config.get("trading_execution", {})
     if not isinstance(trading_exec, dict):
@@ -272,6 +272,9 @@ def _render_markdown(
     lines.append(f"| Profit concentration | {summary.profit_concentration_pct:.2f}% |")
     lines.append(f"| Blocked BUY (session router) | {summary.blocked_buy_count} |")
     lines.append(f"| Blocked BUY (basis filter) | {summary.basis_blocked_buy_count} |")
+    lines.append(
+        f"| Blocked BUY (cross-venue dislocation) | {summary.dislocation_blocked_buy_count} |"
+    )
     lines.append("")
 
     if windows:
@@ -462,6 +465,7 @@ async def main() -> None:
             profit_concentration_pct=profit_concentration_pct(oos_returns),
             blocked_buy_count=baseline.blocked_buy_count,
             basis_blocked_buy_count=baseline.basis_blocked_buy_count,
+            dislocation_blocked_buy_count=getattr(baseline, "dislocation_blocked_buy_count", 0),
             passes_gates=False,
             failure_reasons=[],
         )
@@ -521,6 +525,7 @@ async def main() -> None:
     print(f"Profit concentration: {summary.profit_concentration_pct:.2f}%")
     print(f"Blocked BUY (session router): {summary.blocked_buy_count}")
     print(f"Blocked BUY (basis filter): {summary.basis_blocked_buy_count}")
+    print(f"Blocked BUY (cross-venue dislocation): {summary.dislocation_blocked_buy_count}")
     if summary.failure_reasons:
         print("Failures:")
         for reason in summary.failure_reasons:

--- a/scripts/experiment_autopilot.py
+++ b/scripts/experiment_autopilot.py
@@ -38,6 +38,10 @@ from src.strategy.basis_premium_filter import (
     parse_basis_premium_filter,
     with_calibrated_threshold,
 )
+from src.strategy.cross_venue_dislocation import (
+    CrossVenueDislocationConfig,
+    parse_cross_venue_dislocation,
+)
 from src.strategy.session_liquidity import parse_session_liquidity_router
 from src.utils.logger import configure_logger  # noqa: E402
 
@@ -133,6 +137,7 @@ def _build_backtest_config(
     replay_sentiment_path: str | None,
     replay_sentiment_max_age_hours: float | None,
     basis_calibrated_threshold: float | None = None,
+    cross_venue_dislocation: CrossVenueDislocationConfig = None,
 ) -> BacktestConfig:
     trading_exec = raw_config.get("trading_execution", {})
     if not isinstance(trading_exec, dict):
@@ -170,6 +175,7 @@ def _build_backtest_config(
             parse_basis_premium_filter(raw_config.get("strategy", {}).get("basis_premium_filter")),
             basis_calibrated_threshold,
         ),
+        cross_venue_dislocation=cross_venue_dislocation or CrossVenueDislocationConfig(),
         allow_short=False,
         use_executor_exit_model=bool(exit_rules.get("backtest_use_executor_exit_model", False)),
         ignore_signal_sells=bool(exit_rules.get("backtest_ignore_signal_sells", False)),
@@ -340,6 +346,9 @@ async def main() -> None:
         basis_filter = parse_basis_premium_filter(
             raw_config.get("strategy", {}).get("basis_premium_filter")
         )
+        cross_venue_disloc = parse_cross_venue_dislocation(
+            raw_config.get("strategy", {}).get("cross_venue_dislocation")
+        )
 
         windows = build_wfo_windows(
             start=start,
@@ -373,6 +382,7 @@ async def main() -> None:
             replay_sentiment_path=args.replay_sentiment_log,
             replay_sentiment_max_age_hours=args.replay_sentiment_max_age_hours,
             basis_calibrated_threshold=baseline_threshold,
+            cross_venue_dislocation=cross_venue_disloc,
         )
 
         reader = IndicatorReader(db_config)
@@ -405,6 +415,7 @@ async def main() -> None:
                     replay_sentiment_path=args.replay_sentiment_log,
                     replay_sentiment_max_age_hours=args.replay_sentiment_max_age_hours,
                     basis_calibrated_threshold=window_threshold,
+                    cross_venue_dislocation=cross_venue_disloc,
                 )
                 window_backtest = await _run_backtest(reader, window_config)
                 window_results.append(

--- a/scripts/run_backtest.py
+++ b/scripts/run_backtest.py
@@ -16,6 +16,7 @@ from src.db import close_pool, init_pool
 from src.features.reader import IndicatorReader
 from src.main import _resolve_strategy_config, load_settings
 from src.strategy.basis_premium_filter import parse_basis_premium_filter
+from src.strategy.cross_venue_dislocation import parse_cross_venue_dislocation
 from src.strategy.session_liquidity import parse_session_liquidity_router
 from src.utils.logger import configure_logger
 
@@ -139,6 +140,9 @@ async def main():
         ),
         basis_premium_filter=parse_basis_premium_filter(
             raw_config.get("strategy", {}).get("basis_premium_filter")
+        ),
+        cross_venue_dislocation=parse_cross_venue_dislocation(
+            raw_config.get("strategy", {}).get("cross_venue_dislocation")
         ),
         time_stop_minutes=float(exit_rules.get("time_stop_minutes", 0)),
         use_executor_exit_model=bool(exit_rules.get("backtest_use_executor_exit_model", False)),

--- a/scripts/run_backtest.py
+++ b/scripts/run_backtest.py
@@ -217,6 +217,7 @@ async def main():
     print(f"Total Trades: {result.total_trades}")
     print(f"Blocked BUY (session router): {result.blocked_buy_count}")
     print(f"Blocked BUY (basis filter): {result.basis_blocked_buy_count}")
+    print(f"Blocked BUY (cross-venue dislocation): {result.dislocation_blocked_buy_count}")
     print(f"Win Rate:     {result.win_rate:.2f}%")
     print(f"Total Return: ${result.total_return:.2f} ({result.total_return_pct:.2f}%)")
     print(f"Max Drawdown: {result.max_drawdown * 100:.2f}%")

--- a/src/backtest/engine.py
+++ b/src/backtest/engine.py
@@ -15,6 +15,7 @@ from src.strategy.basis_premium_filter import (
 )
 from src.strategy.cross_venue_dislocation import (
     CrossVenueDislocationConfig,
+    apply_cross_venue_dislocation_gate,
 )
 from src.strategy.sentiment_mean_reversion import SentimentMeanReversionStrategy
 from src.strategy.session_liquidity import (
@@ -104,6 +105,7 @@ class BacktestResult:
     avg_win_loss_ratio: float
     blocked_buy_count: int = 0
     basis_blocked_buy_count: int = 0
+    dislocation_blocked_buy_count: int = 0
 
 
 class BacktestEngine:
@@ -130,6 +132,7 @@ class BacktestEngine:
         self._trades: list[Trade] = []
         self._blocked_buy_count = 0
         self._basis_blocked_buy_count = 0
+        self._dislocation_blocked_buy_count = 0
 
     @staticmethod
     def _get_required_timeframes(strategy: BaseStrategy) -> dict[str, str]:
@@ -285,6 +288,20 @@ class BacktestEngine:
                     self._basis_blocked_buy_count += 1
                     self._logger.info(
                         "Blocked by Basis Premium Filter at %s: %s",
+                        current_time,
+                        final_signal.reason,
+                    )
+
+            if final_signal.type == SignalType.BUY:
+                final_signal, disloc_blocked = apply_cross_venue_dislocation_gate(
+                    final_signal,
+                    row,
+                    self._config.cross_venue_dislocation,
+                )
+                if disloc_blocked:
+                    self._dislocation_blocked_buy_count += 1
+                    self._logger.info(
+                        "Blocked by Cross Venue Dislocation Filter at %s: %s",
                         current_time,
                         final_signal.reason,
                     )
@@ -750,6 +767,7 @@ class BacktestEngine:
             avg_win_loss_ratio=avg_win_loss_ratio,
             blocked_buy_count=self._blocked_buy_count,
             basis_blocked_buy_count=self._basis_blocked_buy_count,
+            dislocation_blocked_buy_count=self._dislocation_blocked_buy_count,
         )
 
     def _create_empty_result(self) -> BacktestResult:
@@ -767,4 +785,5 @@ class BacktestEngine:
             avg_win_loss_ratio=0.0,
             blocked_buy_count=self._blocked_buy_count,
             basis_blocked_buy_count=self._basis_blocked_buy_count,
+            dislocation_blocked_buy_count=self._dislocation_blocked_buy_count,
         )

--- a/src/backtest/engine.py
+++ b/src/backtest/engine.py
@@ -13,6 +13,9 @@ from src.strategy.basis_premium_filter import (
     BasisPremiumFilterConfig,
     apply_basis_premium_gate,
 )
+from src.strategy.cross_venue_dislocation import (
+    CrossVenueDislocationConfig,
+)
 from src.strategy.sentiment_mean_reversion import SentimentMeanReversionStrategy
 from src.strategy.session_liquidity import (
     SessionLiquidityRouterConfig,
@@ -48,6 +51,9 @@ class BacktestConfig:
         default_factory=SessionLiquidityRouterConfig
     )
     basis_premium_filter: BasisPremiumFilterConfig = field(default_factory=BasisPremiumFilterConfig)
+    cross_venue_dislocation: CrossVenueDislocationConfig = field(
+        default_factory=CrossVenueDislocationConfig
+    )
     allow_short: bool = False
     use_executor_exit_model: bool = False
     ignore_signal_sells: bool = False

--- a/src/backtest/experiment_autopilot.py
+++ b/src/backtest/experiment_autopilot.py
@@ -67,6 +67,7 @@ class ExperimentSummary:
     failure_reasons: list[str] = field(default_factory=list)
     blocked_buy_count: int = 0
     basis_blocked_buy_count: int = 0
+    dislocation_blocked_buy_count: int = 0
 
 
 def add_months(base: datetime, months: int) -> datetime:

--- a/src/features/reader.py
+++ b/src/features/reader.py
@@ -116,6 +116,8 @@ class IndicatorReader:
                 fr.funding_rate,
                 pbm.basis_bps,
                 pbm.premium_index,
+                (pbm.basis_bps - pbm2.basis_bps) AS cross_venue_basis_spread_bps,
+                (pbm.premium_index - pbm2.premium_index) AS cross_venue_premium_spread,
                 o.high_price,
                 o.low_price
             FROM indicators i
@@ -128,6 +130,11 @@ class IndicatorReader:
                 AND pbm.symbol = i.symbol
                 AND pbm.timeframe = i.timeframe
                 AND pbm.exchange = 'binance_usdm'
+            LEFT JOIN perp_basis_metrics pbm2
+                ON pbm2.time = i.time
+                AND pbm2.symbol = i.symbol
+                AND pbm2.timeframe = i.timeframe
+                AND pbm2.exchange = 'bybit'
             LEFT JOIN LATERAL (
                 SELECT funding_rate
                 FROM funding_rates
@@ -226,10 +233,22 @@ class IndicatorReader:
                         float(row["funding_rate"]) if row["funding_rate"] is not None else None
                     ),
                     "basis_bps": (
-                        float(row["basis_bps"]) if row["basis_bps"] is not None else None
+                        float(row.get("basis_bps")) if row.get("basis_bps") is not None else None
                     ),
                     "premium_index": (
-                        float(row["premium_index"]) if row["premium_index"] is not None else None
+                        float(row.get("premium_index"))
+                        if row.get("premium_index") is not None
+                        else None
+                    ),
+                    "cross_venue_basis_spread_bps": (
+                        float(row.get("cross_venue_basis_spread_bps"))
+                        if row.get("cross_venue_basis_spread_bps") is not None
+                        else None
+                    ),
+                    "cross_venue_premium_spread": (
+                        float(row.get("cross_venue_premium_spread"))
+                        if row.get("cross_venue_premium_spread") is not None
+                        else None
                     ),
                     "high_price": (
                         float(high_price) if high_price is not None else float(row["close_price"])
@@ -278,6 +297,10 @@ class IndicatorReader:
                 i.rsi_slope,
                 i.trend_consistency,
                 fr.funding_rate,
+                pbm.basis_bps,
+                pbm.premium_index,
+                (pbm.basis_bps - pbm2.basis_bps) AS cross_venue_basis_spread_bps,
+                (pbm.premium_index - pbm2.premium_index) AS cross_venue_premium_spread,
                 o.high_price,
                 o.low_price
             FROM indicators i
@@ -285,6 +308,16 @@ class IndicatorReader:
                 ON i.time = o.time
                 AND i.symbol = o.symbol
                 AND i.timeframe = o.timeframe
+            LEFT JOIN perp_basis_metrics pbm
+                ON pbm.time = i.time
+                AND pbm.symbol = i.symbol
+                AND pbm.timeframe = i.timeframe
+                AND pbm.exchange = 'binance_usdm'
+            LEFT JOIN perp_basis_metrics pbm2
+                ON pbm2.time = i.time
+                AND pbm2.symbol = i.symbol
+                AND pbm2.timeframe = i.timeframe
+                AND pbm2.exchange = 'bybit'
             LEFT JOIN LATERAL (
                 SELECT funding_rate
                 FROM funding_rates
@@ -377,6 +410,24 @@ class IndicatorReader:
                     ),
                     "funding_rate": (
                         float(row["funding_rate"]) if row["funding_rate"] is not None else None
+                    ),
+                    "basis_bps": (
+                        float(row.get("basis_bps")) if row.get("basis_bps") is not None else None
+                    ),
+                    "premium_index": (
+                        float(row.get("premium_index"))
+                        if row.get("premium_index") is not None
+                        else None
+                    ),
+                    "cross_venue_basis_spread_bps": (
+                        float(row.get("cross_venue_basis_spread_bps"))
+                        if row.get("cross_venue_basis_spread_bps") is not None
+                        else None
+                    ),
+                    "cross_venue_premium_spread": (
+                        float(row.get("cross_venue_premium_spread"))
+                        if row.get("cross_venue_premium_spread") is not None
+                        else None
                     ),
                     "high_price": (
                         float(high_price) if high_price is not None else float(row["close_price"])

--- a/src/strategy/cross_venue_dislocation.py
+++ b/src/strategy/cross_venue_dislocation.py
@@ -1,0 +1,147 @@
+"""Cross-venue dislocation filter for backtest entry gating (v0).
+
+Mirrors src/strategy/basis_premium_filter.py structure exactly:
+- Config dataclass
+- parse_... with safe defaults + clamping
+- apply_..._gate(signal, row, config) -> (Signal, blocked: bool)
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+from src.strategy.signals import Signal, SignalType
+
+CROSS_VENUE_DISLOCATION_BLOCK_REASON = "Blocked by Cross Venue Dislocation Filter"
+
+
+@dataclass(frozen=True)
+class CrossVenueDislocationConfig:
+    enabled: bool = False
+    metric: str = "basis_spread"  # "basis_spread" | "premium_spread"
+    mode: str = "require"  # "require" (enter only on dislocation) | "block" (block on dislocation)
+    min_spread_bps: float = 5.0
+    side: str = "both"  # "positive" | "negative" | "both"
+    missing_data_policy: str = "allow"
+
+
+def parse_cross_venue_dislocation(raw: object) -> CrossVenueDislocationConfig:
+    """Parse strategy.cross_venue_dislocation from YAML (safe defaults)."""
+    if raw is None:
+        return CrossVenueDislocationConfig()
+    if not isinstance(raw, Mapping):
+        return CrossVenueDislocationConfig()
+
+    metric = str(raw.get("metric", "basis_spread")).strip()
+    if metric not in {"basis_spread", "premium_spread"}:
+        metric = "basis_spread"
+
+    mode = str(raw.get("mode", "require")).strip().lower()
+    if mode not in {"require", "block"}:
+        mode = "require"
+
+    side = str(raw.get("side", "both")).strip().lower()
+    if side not in {"positive", "negative", "both"}:
+        side = "both"
+
+    missing_policy = str(raw.get("missing_data_policy", "allow")).strip().lower()
+    if missing_policy not in {"allow", "block"}:
+        missing_policy = "allow"
+
+    min_bps = float(raw.get("min_spread_bps", 5.0))
+    if min_bps < 0:
+        min_bps = 0.0
+
+    return CrossVenueDislocationConfig(
+        enabled=bool(raw.get("enabled", False)),
+        metric=metric,
+        mode=mode,
+        min_spread_bps=min_bps,
+        side=side,
+        missing_data_policy=missing_policy,
+    )
+
+
+def _get_spread_value(row: Mapping[str, object], metric: str) -> float | None:
+    key = (
+        "cross_venue_basis_spread_bps" if metric == "basis_spread" else "cross_venue_premium_spread"
+    )
+    raw = row.get(key)
+    if raw is None:
+        return None
+    return float(raw)
+
+
+def should_block_buy(
+    *,
+    spread: float | None,
+    config: CrossVenueDislocationConfig,
+) -> tuple[bool, str]:
+    """Return (blocked, reason). Mirrors basis filter missing policy (default allow)."""
+    if not config.enabled:
+        return False, ""
+
+    if spread is None:
+        if config.missing_data_policy == "block":
+            return (
+                True,
+                f"{CROSS_VENUE_DISLOCATION_BLOCK_REASON}: missing spread (policy=block)",
+            )
+        return False, ""
+
+    abs_spread = abs(spread)
+    if abs_spread < config.min_spread_bps:
+        is_dislocated = False
+    else:
+        if config.side == "positive":
+            is_dislocated = spread > 0
+        elif config.side == "negative":
+            is_dislocated = spread < 0
+        else:
+            is_dislocated = True
+
+    if config.mode == "require":
+        # block if NOT dislocated (i.e. require the dislocation to allow BUY)
+        if not is_dislocated:
+            return (
+                True,
+                f"{CROSS_VENUE_DISLOCATION_BLOCK_REASON}: |spread|={abs_spread:.2f} < {config.min_spread_bps:.2f} or wrong side for require",
+            )
+        return False, ""
+    else:
+        # block mode: block BUY when dislocated
+        if is_dislocated:
+            return (
+                True,
+                f"{CROSS_VENUE_DISLOCATION_BLOCK_REASON}: |spread|={abs_spread:.2f} >= {config.min_spread_bps:.2f}",
+            )
+        return False, ""
+
+
+def apply_cross_venue_dislocation_gate(
+    signal: Signal,
+    row: Mapping[str, object],
+    config: CrossVenueDislocationConfig,
+) -> tuple[Signal, bool]:
+    """Return (signal, blocked). blocked=True when BUY converted to HOLD."""
+    if signal.type != SignalType.BUY:
+        return signal, False
+
+    spread = _get_spread_value(row, config.metric)
+    blocked, reason = should_block_buy(spread=spread, config=config)
+    if not blocked:
+        return signal, False
+
+    return (
+        Signal(
+            type=SignalType.HOLD,
+            symbol=signal.symbol,
+            price=signal.price,
+            confidence=0.0,
+            reason=reason,
+            indicators=signal.indicators,
+            trading_mode=signal.trading_mode,
+        ),
+        True,
+    )

--- a/tests/test_cross_venue_dislocation.py
+++ b/tests/test_cross_venue_dislocation.py
@@ -1,0 +1,385 @@
+"""Tests for cross-venue dislocation gate (mirrors test patterns for basis_premium_filter and other gates).
+
+Per CLAUDE.md: assertions in it/test, no .only/.skip in committed, etc.
+"""
+
+from src.strategy.base import BaseStrategy
+from src.strategy.cross_venue_dislocation import (
+    CrossVenueDislocationConfig,
+    apply_cross_venue_dislocation_gate,
+    parse_cross_venue_dislocation,
+)
+from src.strategy.signals import Signal, SignalType
+
+
+def _mk_buy(price: float = 100.0) -> Signal:
+    return Signal(
+        type=SignalType.BUY,
+        symbol="SOLUSDT",
+        price=price,
+        confidence=0.8,
+        reason="test",
+        indicators={},
+        trading_mode="paper",
+    )
+
+
+def _mk_row(basis_spread: float | None = None, premium_spread: float | None = None) -> dict:
+    return {
+        "cross_venue_basis_spread_bps": basis_spread,
+        "cross_venue_premium_spread": premium_spread,
+        "time": "2024-01-01T00:00:00+00:00",
+        "close_price": 100.0,
+        # minimal other keys the engine may touch in synthetic paths
+        "atr_14": 1.0,
+        "high_price": 101.0,
+        "low_price": 99.0,
+    }
+
+
+class _DummyStrategy(BaseStrategy):
+    REQUIRED_TIMEFRAMES = {}
+
+    def __init__(self, symbol: str = "SOLUSDT", **kwargs):
+        self.symbol = symbol
+
+    async def generate_signals(self, *a, **k):
+        return []
+
+
+def test_require_mode_blocks_below_threshold_both_metrics():
+    cfg = CrossVenueDislocationConfig(
+        enabled=True, metric="basis_spread", mode="require", min_spread_bps=5.0, side="both"
+    )
+    # below
+    sig, blocked = apply_cross_venue_dislocation_gate(_mk_buy(), _mk_row(basis_spread=3.0), cfg)
+    assert blocked is True
+    assert sig.type == SignalType.HOLD
+    # at/above
+    sig, blocked = apply_cross_venue_dislocation_gate(_mk_buy(), _mk_row(basis_spread=5.0), cfg)
+    assert blocked is False
+    assert sig.type == SignalType.BUY
+
+    cfg2 = CrossVenueDislocationConfig(
+        enabled=True, metric="premium_spread", mode="require", min_spread_bps=5.0, side="both"
+    )
+    sig, blocked = apply_cross_venue_dislocation_gate(_mk_buy(), _mk_row(premium_spread=3.0), cfg2)
+    assert blocked is True
+
+
+def test_block_mode_blocks_at_or_above_threshold():
+    cfg = CrossVenueDislocationConfig(
+        enabled=True, metric="basis_spread", mode="block", min_spread_bps=5.0, side="both"
+    )
+    sig, blocked = apply_cross_venue_dislocation_gate(_mk_buy(), _mk_row(basis_spread=6.0), cfg)
+    assert blocked is True
+    assert sig.type == SignalType.HOLD
+    sig, blocked = apply_cross_venue_dislocation_gate(_mk_buy(), _mk_row(basis_spread=4.0), cfg)
+    assert blocked is False
+
+
+def test_side_positive_ignores_negative():
+    cfg = CrossVenueDislocationConfig(
+        enabled=True, metric="basis_spread", mode="require", min_spread_bps=5.0, side="positive"
+    )
+    # negative spread (binance < bybit) should not count as positive dislocation
+    sig, blocked = apply_cross_venue_dislocation_gate(_mk_buy(), _mk_row(basis_spread=-6.0), cfg)
+    assert blocked is True  # require not met
+    # positive does
+    sig, blocked = apply_cross_venue_dislocation_gate(_mk_buy(), _mk_row(basis_spread=6.0), cfg)
+    assert blocked is False
+
+
+def test_sign_convention_binance_minus_bybit():
+    # row built as binance=10, bybit=3 -> +7
+    row = _mk_row(basis_spread=7.0)
+    cfg = CrossVenueDislocationConfig(
+        enabled=True, metric="basis_spread", mode="require", min_spread_bps=5.0, side="both"
+    )
+    sig, blocked = apply_cross_venue_dislocation_gate(_mk_buy(), row, cfg)
+    assert blocked is False  # 7 >=5 , require met -> not blocked
+
+
+def test_missing_data_matches_basis_filter_default_allow():
+    cfg = CrossVenueDislocationConfig(
+        enabled=True, metric="basis_spread", mode="require", min_spread_bps=5.0
+    )
+    sig, blocked = apply_cross_venue_dislocation_gate(_mk_buy(), _mk_row(basis_spread=None), cfg)
+    # default missing=allow -> not blocked (per basis_premium_filter behavior)
+    assert blocked is False
+    assert sig.type == SignalType.BUY
+
+
+def test_parse_defaults_and_clamping():
+    cfg = parse_cross_venue_dislocation(None)
+    assert cfg.enabled is False
+    assert cfg.metric == "basis_spread"
+    assert cfg.mode == "require"
+    assert cfg.min_spread_bps == 5.0
+    assert cfg.side == "both"
+    assert cfg.missing_data_policy == "allow"
+
+    raw = {
+        "enabled": True,
+        "metric": "premium_spread",
+        "mode": "block",
+        "min_spread_bps": -3,
+        "side": "positive",
+    }
+    cfg = parse_cross_venue_dislocation(raw)
+    assert cfg.enabled is True
+    assert cfg.metric == "premium_spread"
+    assert cfg.mode == "block"
+    assert cfg.min_spread_bps == 0.0  # clamped
+    assert cfg.side == "positive"
+
+    raw_bad = {"metric": "foo", "mode": "foo", "side": "foo", "missing_data_policy": "foo"}
+    cfg = parse_cross_venue_dislocation(raw_bad)
+    assert cfg.metric == "basis_spread"
+    assert cfg.mode == "require"
+    assert cfg.side == "both"
+    assert cfg.missing_data_policy == "allow"
+
+
+def test_sampler_emits_config_block_in_range(monkeypatch):
+    # Use the generate_candidate with seeded to hit our families
+    from scripts.autoresearch_loop import generate_candidate
+
+    c = generate_candidate(0, seed=42, families=("cross_venue_dislocation",))
+    ov = c.overlay
+    # now nested under strategy per wiring fix
+    assert "cross_venue_dislocation" in ov.get("strategy", {})
+    dis = ov["strategy"]["cross_venue_dislocation"]
+    assert dis["enabled"] is True
+    assert dis["min_spread_bps"] > 3.0  # from our p90+ range
+    assert dis["mode"] in ("require", "block")
+
+    c2 = generate_candidate(1, seed=99, families=("venue_basis_filter",))
+    ov2 = c2.overlay
+    assert "cross_venue_dislocation" in ov2.get("strategy", {})
+    dis2 = ov2["strategy"]["cross_venue_dislocation"]
+    assert dis2["mode"] == "block"
+
+
+def test_ab_behavioral_differs_on_min_spread(monkeypatch):
+    """A/B: tiny threshold vs huge threshold on same synthetic rows/signals -> different blocked counts."""
+    # We drive the gate directly (synthetic "engine input" = repeated rows + buy signals)
+    # tiny threshold -> more blocks in require mode
+    # huge -> fewer blocks
+    rows = [_mk_row(basis_spread=4.0) for _ in range(10)]  # |4| <5 but >1
+    buys = [_mk_buy() for _ in range(10)]
+
+    cfg_tiny = CrossVenueDislocationConfig(
+        enabled=True, metric="basis_spread", mode="require", min_spread_bps=1.0, side="both"
+    )
+    cfg_huge = CrossVenueDislocationConfig(
+        enabled=True, metric="basis_spread", mode="require", min_spread_bps=500.0, side="both"
+    )
+
+    blocked_tiny = 0
+    for r, b in zip(rows, buys, strict=True):
+        _, blk = apply_cross_venue_dislocation_gate(b, r, cfg_tiny)
+        if blk:
+            blocked_tiny += 1
+
+    blocked_huge = 0
+    for r, b in zip(rows, buys, strict=True):
+        _, blk = apply_cross_venue_dislocation_gate(b, r, cfg_huge)
+        if blk:
+            blocked_huge += 1
+
+    print(
+        f"A/B counts from synthetic engine input: tiny(1.0)={blocked_tiny} huge(500.0)={blocked_huge}"
+    )
+    assert blocked_tiny != blocked_huge, (
+        "A/B must produce different block counts for tiny vs huge min_spread_bps"
+    )
+    # With |4| spread, tiny=1 requires it (so few blocks), huge=500 does not (all blocked in require)
+    assert blocked_huge > blocked_tiny
+
+
+def test_regression_candidate_merges_and_enables_via_autopilot_parse_path():
+    """Regression: candidate from sampler, merged like run_autoresearch, parsed via autopilot path, enabled=True."""
+    from scripts.autoresearch_loop import generate_candidate
+
+    # minimal deep merge (mirrors run_autoresearch._deep_merge behavior for this key)
+    def _deep_merge(base, overlay):
+        if isinstance(base, dict) and isinstance(overlay, dict):
+            result = dict(base)
+            for k, v in overlay.items():
+                if k in result and isinstance(result[k], dict) and isinstance(v, dict):
+                    result[k] = _deep_merge(result[k], v)
+                else:
+                    result[k] = v
+            return result
+        return overlay or base
+
+    cand = generate_candidate(0, seed=42, families=("cross_venue_dislocation",), symbol="SOLUSDT")
+    base = {"strategy": {"aggregator": {"buy_threshold": 0.8}}}
+    merged = _deep_merge(base, cand.overlay)
+
+    # parse like in experiment_autopilot main
+    parsed = parse_cross_venue_dislocation(
+        merged.get("strategy", {}).get("cross_venue_dislocation")
+    )
+    assert parsed.enabled is True
+    assert parsed.min_spread_bps >= 3.0  # from our sampler range
+
+    # also test via _build_backtest_config path (strengthened)
+    from types import SimpleNamespace
+
+    from scripts.experiment_autopilot import _build_backtest_config
+
+    raw_for_build = merged
+    # minimal settings obj
+    settings = SimpleNamespace(
+        trading_execution=SimpleNamespace(
+            stop_loss_pct=0.05,
+            take_profit_pct=0.1,
+            use_atr_sizing=False,
+            atr_multiplier=1.5,
+            risk_per_trade_pct=0.02,
+        ),
+        trading_pairs=["SOLUSDT"],
+        timeframe="1h",
+    )
+    cross_venue_disloc = parse_cross_venue_dislocation(
+        raw_for_build.get("strategy", {}).get("cross_venue_dislocation")
+    )
+    built = _build_backtest_config(
+        settings=settings,
+        raw_config=raw_for_build,
+        symbol="SOLUSDT",
+        timeframe="1h",
+        start="2024-01-01",
+        end="2024-01-02",
+        strategy_classes=[],
+        strategy_configs=[],
+        aggregator_config={},
+        initial_capital=10000.0,
+        disable_trend_filter=True,
+        replay_sentiment_path=None,
+        replay_sentiment_max_age_hours=None,
+        basis_calibrated_threshold=None,
+        cross_venue_dislocation=cross_venue_disloc,
+    )
+    # since _build uses the raw parse now, it should have enabled
+    assert built.cross_venue_dislocation.enabled is True
+
+
+def test_ab_uses_real_build_path_for_different_counts():
+    """Strengthened A/B using _build_backtest_config to get config, then gate on synthetic input."""
+    from types import SimpleNamespace
+
+    from scripts.experiment_autopilot import _build_backtest_config
+
+    def _mk_row(spread=4.0):
+        return {"cross_venue_basis_spread_bps": spread, "close_price": 100.0}
+
+    def _mk_buy():
+        from src.strategy.signals import Signal, SignalType
+
+        return Signal(
+            type=SignalType.BUY,
+            symbol="SOLUSDT",
+            price=100.0,
+            confidence=0.8,
+            reason="",
+            indicators={},
+            trading_mode="paper",
+        )
+
+    settings = SimpleNamespace(
+        trading_execution=SimpleNamespace(
+            stop_loss_pct=0.05,
+            take_profit_pct=0.1,
+            use_atr_sizing=False,
+            atr_multiplier=1.5,
+            risk_per_trade_pct=0.02,
+        ),
+        trading_pairs=["SOLUSDT"],
+        timeframe="1h",
+    )
+    raw_tiny = {
+        "strategy": {
+            "cross_venue_dislocation": {
+                "enabled": True,
+                "metric": "basis_spread",
+                "mode": "require",
+                "min_spread_bps": 1.0,
+                "side": "both",
+            }
+        }
+    }
+    raw_huge = {
+        "strategy": {
+            "cross_venue_dislocation": {
+                "enabled": True,
+                "metric": "basis_spread",
+                "mode": "require",
+                "min_spread_bps": 500.0,
+                "side": "both",
+            }
+        }
+    }
+
+    cfg_tiny = _build_backtest_config(
+        settings=settings,
+        raw_config=raw_tiny,
+        symbol="SOLUSDT",
+        timeframe="1h",
+        start="2024-01-01",
+        end="2024-01-02",
+        strategy_classes=[],
+        strategy_configs=[],
+        aggregator_config={},
+        initial_capital=10000.0,
+        disable_trend_filter=True,
+        replay_sentiment_path=None,
+        replay_sentiment_max_age_hours=None,
+        basis_calibrated_threshold=None,
+        cross_venue_dislocation=parse_cross_venue_dislocation(
+            raw_tiny.get("strategy", {}).get("cross_venue_dislocation")
+        ),
+    ).cross_venue_dislocation
+
+    cfg_huge = _build_backtest_config(
+        settings=settings,
+        raw_config=raw_huge,
+        symbol="SOLUSDT",
+        timeframe="1h",
+        start="2024-01-01",
+        end="2024-01-02",
+        strategy_classes=[],
+        strategy_configs=[],
+        aggregator_config={},
+        initial_capital=10000.0,
+        disable_trend_filter=True,
+        replay_sentiment_path=None,
+        replay_sentiment_max_age_hours=None,
+        basis_calibrated_threshold=None,
+        cross_venue_dislocation=parse_cross_venue_dislocation(
+            raw_huge.get("strategy", {}).get("cross_venue_dislocation")
+        ),
+    ).cross_venue_dislocation
+
+    rows = [_mk_row(4.0) for _ in range(10)]
+    buys = [_mk_buy() for _ in range(10)]
+
+    from src.strategy.cross_venue_dislocation import apply_cross_venue_dislocation_gate
+
+    blocked_tiny = sum(
+        1
+        for r, b in zip(rows, buys, strict=True)
+        if apply_cross_venue_dislocation_gate(b, r, cfg_tiny)[1]
+    )
+    blocked_huge = sum(
+        1
+        for r, b in zip(rows, buys, strict=True)
+        if apply_cross_venue_dislocation_gate(b, r, cfg_huge)[1]
+    )
+
+    print(
+        f"Strengthened A/B via _build path: tiny(1.0) blocked={blocked_tiny} huge(500.0) blocked={blocked_huge}"
+    )
+    assert blocked_tiny != blocked_huge

--- a/tests/test_cross_venue_dislocation.py
+++ b/tests/test_cross_venue_dislocation.py
@@ -3,6 +3,10 @@
 Per CLAUDE.md: assertions in it/test, no .only/.skip in committed, etc.
 """
 
+import pytest
+
+from src.backtest.engine import BacktestConfig, BacktestEngine
+from src.features.reader import IndicatorReader
 from src.strategy.base import BaseStrategy
 from src.strategy.cross_venue_dislocation import (
     CrossVenueDislocationConfig,
@@ -383,3 +387,100 @@ def test_ab_uses_real_build_path_for_different_counts():
         f"Strengthened A/B via _build path: tiny(1.0) blocked={blocked_tiny} huge(500.0) blocked={blocked_huge}"
     )
     assert blocked_tiny != blocked_huge
+
+
+class _AlwaysBuyStrategy(BaseStrategy):
+    """Strategy that emits BUY on every bar for gate consumption tests."""
+
+    def get_name(self) -> str:
+        return "AlwaysBuy"
+
+    async def evaluate(self, symbol: str, indicators: dict[str, float]) -> Signal:
+        price = indicators["close_price"]
+        return Signal(SignalType.BUY, symbol, price, 1.0, "always buy", indicators)
+
+
+def _build_mock_reader(rows: list[dict[str, object]]) -> IndicatorReader:
+    """Build an IndicatorReader whose fetch_range returns the provided synthetic rows."""
+    reader = IndicatorReader({})
+    # Mark as connected for any internal checks (pattern from basis premium backtest test)
+    reader._connected = True  # type: ignore[attr-defined]
+
+    async def _mock_fetch_range(*_args: object, **_kwargs: object) -> list[dict[str, object]]:
+        return rows
+
+    reader.fetch_range = _mock_fetch_range  # type: ignore[method-assign]
+    return reader
+
+
+def _synth_row(cross_basis_spread: float | None = None, close: float = 100.0) -> dict[str, object]:
+    """Synthetic indicator row containing the cross-venue columns the gate reads."""
+    return {
+        "time": "2024-06-03T12:00:00",
+        "close_price": close,
+        "high_price": close + 1.0,
+        "low_price": close - 1.0,
+        "ema_200": 50.0,
+        "atr_14": 1.0,
+        "cross_venue_basis_spread_bps": cross_basis_spread,
+        "cross_venue_premium_spread": None,
+    }
+
+
+@pytest.mark.asyncio
+async def test_backtest_engine_applies_cross_venue_dislocation_gate_ab() -> None:
+    """Engine-level A/B: identical data, tiny vs huge min_spread_bps -> different blocked/trade counts.
+
+    This exercises the full path: BacktestConfig -> reader rows with cross_venue_* keys ->
+    engine gate call after basis -> counters in BacktestResult. Mirrors test_basis_premium_backtest.
+    """
+    # 10 bars, spreads alternate around the 5bps example range (p90-p99 was 3.45-7)
+    # Tiny threshold (0.1) in require mode with side=both: most/all will be "dislocated" -> allow BUY
+    # Huge (1000): almost none dislocated -> block BUY (require mode)
+    # Use spreads that are |4-6| so tiny allows, huge blocks.
+    spreads = [4.0, 5.5, 3.2, 6.1, 4.8, 5.0, 3.8, 6.5, 4.2, 5.9]
+    rows = [_synth_row(s) for s in spreads]
+
+    base_kwargs = {
+        "symbol": "SOLUSDT",
+        "timeframe": "1h",
+        "start_date": "2024-06-01",
+        "end_date": "2024-06-04",
+        "initial_capital": 10000.0,
+        "fee_rate": 0.0,
+        "slippage_pct": 0.0,
+        "apply_global_trend_filter": False,
+        "strategy_classes": [_AlwaysBuyStrategy],
+        "aggregator_config": {"min_agreement": 1, "buy_threshold": 0.5},
+    }
+
+    tiny_cfg = CrossVenueDislocationConfig(
+        enabled=True, metric="basis_spread", mode="require", min_spread_bps=0.1, side="both"
+    )
+    huge_cfg = CrossVenueDislocationConfig(
+        enabled=True, metric="basis_spread", mode="require", min_spread_bps=1000.0, side="both"
+    )
+
+    reader_tiny = _build_mock_reader(rows)
+    res_tiny = await BacktestEngine(
+        BacktestConfig(**base_kwargs, cross_venue_dislocation=tiny_cfg),
+        reader_tiny,
+    ).run()
+
+    reader_huge = _build_mock_reader(rows)
+    res_huge = await BacktestEngine(
+        BacktestConfig(**base_kwargs, cross_venue_dislocation=huge_cfg),
+        reader_huge,
+    ).run()
+
+    # With tiny: spreads ~4-6 >0.1 -> dislocated -> require allows -> more trades, 0 (or low) blocked
+    # With huge: |spread| <<1000 -> not dislocated -> require blocks -> fewer trades, high blocked count
+    print(
+        f"Engine A/B: tiny blocked={res_tiny.dislocation_blocked_buy_count} trades={res_tiny.total_trades}; "
+        f"huge blocked={res_huge.dislocation_blocked_buy_count} trades={res_huge.total_trades}"
+    )
+    assert res_tiny.dislocation_blocked_buy_count != res_huge.dislocation_blocked_buy_count
+    assert res_tiny.total_trades != res_huge.total_trades
+    # Sanity: tiny should have blocked near 0 for this data
+    assert res_tiny.dislocation_blocked_buy_count == 0
+    assert res_huge.dislocation_blocked_buy_count > 0


### PR DESCRIPTION
## Summary

Implements the two autoresearch families required by the `cross-venue-basis-v1` lane's `RUN_AUTORESEARCH` stage (see PR #67 for the lane-state archival and probe evidence: HAS_PULSE, 27 passing scenarios across BTC/ETH/SOL).

End-to-end wiring so candidate parameters demonstrably change backtest behavior:

- **`src/features/reader.py`** — second `perp_basis_metrics` LEFT JOIN (`bybit`); exposes `cross_venue_basis_spread_bps` / `cross_venue_premium_spread` (binance_usdm − bybit, NULL-propagating) on both the range (backtest) and latest query paths.
- **`src/strategy/cross_venue_dislocation.py`** (new) — config dataclass, safe-default parser, and BUY gate mirroring `basis_premium_filter`. Modes: `require` (enter only during dislocation) and `block`; sides positive/negative/both; absolute-bps thresholds only (no percentile lookahead); missing-data policy defaults to allow.
- **`src/backtest/engine.py`** — config field, gate applied on BUY after the basis-premium gate, `dislocation_blocked_buy_count` in both result paths.
- **`scripts/experiment_autopilot.py`** — parses `strategy.cross_venue_dislocation` and threads it into both `_build_backtest_config` call sites (the autoresearch/WFO execution path).
- **`scripts/run_backtest.py`** — parses the key for manual CLI backtests and prints the blocked count.
- **`scripts/autoresearch_loop.py`** — both families added (separate `CV_FAMILIES` tuple; defaults unchanged), real samplers nesting the config under `strategy`, thresholds sampled from the measured p90–p99 of |binance−bybit| SOL 1h basis spread (3.45–7.08 bps).
- **`tests/test_cross_venue_dislocation.py`** (new, 11 tests) — gate semantics, sign convention, missing data, parser clamping, sampler ranges, candidate→merge→parse regression via the autopilot path, and an **engine-level A/B test**: `BacktestEngine.run()` twice on identical synthetic data, `min_spread_bps` 0.1 vs 1000 → blocked counts and trade counts differ (0 vs >0). This is the anti-inertness proof.

## Verification

- Full suite: **919 passed, 1 skipped**; `ruff check` + `ruff format --check` clean (verified independently on the pushed branch in a throwaway worktree).
- Sampler smoke: `--families cross_venue_dislocation,venue_basis_filter --max-runs 2 --dry-run` emits candidates with the config block under `strategy` and in-range thresholds.

## Notes

- Default behavior unchanged: family is `enabled: False` by default and not in `DEFAULT_FAMILIES`, so existing autoresearch runs are unaffected.
- Authored by Grok (commits b9bcfaa, c013391) with review fixes; final CLI parse gap fixed in 91cf329.
- After merge (and PR #67): the lane guard's `RUN_AUTORESEARCH` stage becomes executable. `--execute` still requires explicit human go-ahead per lane protocol.

🤖 Generated with [Claude Code](https://claude.com/claude-code)