### PR TITLE
feat(research): standalone cross-venue dislocation event probe (Gate 1, cross-venue-dislocation-event-v0)

### DIFF
--- a/scripts/probe_dislocation_event_strategy.py
+++ b/scripts/probe_dislocation_event_strategy.py
@@ -1,0 +1,703 @@
+#!/usr/bin/env python3
+"""
+Cheap feasibility probe for standalone *cross-venue dislocation event strategy*.
+
+This is the sharpened cheap probe for the cross-venue dislocation event lane
+(config/autoresearch/rbi_loop.cross-venue-dislocation-event-v0.yaml).
+
+It measures whether entering on no-lookahead cross-venue spread extremes
+(or normalization) and exiting at fixed horizon produces positive expectancy
+net of fees+slippage, with sufficient event density after deduplication+cooldown,
+and acceptable concentration/win-rate, using only trailing or fixed-grid
+thresholds (no full-sample lookahead).
+
+See docs/specs/cross-venue-dislocation-event-strategy-v0.md for Gate 1.
+
+Usage (dry / guard-driven, via manifest only after merge + human go-ahead):
+  uv run python scripts/probe_dislocation_event_strategy.py \
+    --venues binance_usdm,bybit \
+    --symbols BTCUSDT,ETHUSDT,SOLUSDT \
+    --timeframe 1h \
+    --start 2024-01-01 \
+    --fee-pct 0.08 \
+    --slippage-pct 0.02 \
+    --verdict-output research/rbi_loop/cross-venue-dislocation-event-v0/probe-verdict.json
+
+--smoke for tests (no DB). Never pass --execute here; real execution is post-merge
+via rbi_loop_from_manifest with explicit user approval. No manifest edits in this change.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import argparse
+import asyncio
+import json
+import statistics
+from collections import defaultdict
+from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from enum import StrEnum
+from typing import Any
+
+# Heavy imports (src.db, build_db_config) are done lazily inside non-smoke paths
+# so --smoke works with zero DB/network surface.
+
+PROBE_QUERY = """
+    SELECT
+        p.time,
+        p.exchange,
+        p.basis_bps,
+        p.premium_index,
+        o.close_price,
+        o.low_price,
+        o.high_price
+    FROM perp_basis_metrics p
+    INNER JOIN ohlcv o
+        ON p.time = o.time
+        AND p.symbol = o.symbol
+        AND p.timeframe = o.timeframe
+    WHERE p.exchange = ANY($1)
+      AND p.symbol = $2
+      AND p.timeframe = $3
+      AND p.time >= $4
+      AND p.time <= $5
+    ORDER BY p.time ASC
+"""
+
+
+class ScenarioKind(StrEnum):
+    EXTREME_POSITIVE = "extreme_positive"
+    EXTREME_NEGATIVE = "extreme_negative"
+    NORMALIZATION = "normalization"
+
+
+@dataclass(frozen=True)
+class EventBar:
+    """Local bar carrying high_price for short-side MAE (PremiumBar only has close/low)."""
+
+    time: datetime
+    basis_bps: float
+    premium_index: float
+    close_price: float
+    low_price: float
+    high_price: float
+
+
+@dataclass(frozen=True)
+class DislocationEventProbeConfig:
+    venues: tuple[str, ...]
+    symbols: tuple[str, ...]
+    timeframe: str
+    start: str
+    end: str
+    fee_pct: float
+    slippage_pct: float
+    horizons: tuple[int, ...]
+    cooldown_mode: str
+    threshold_mode: str  # rolling | fixed | both
+    rolling_days: int
+    abs_bps_grid: tuple[float, ...]
+    tail_pcts: tuple[int, ...]
+
+
+@dataclass(frozen=True)
+class SmokeReport:
+    verdict: str
+    note: str
+
+
+@dataclass(frozen=True)
+class DislocationProbeReport:
+    verdict: str
+    note: str
+    passing_scenarios: tuple[str, ...]
+    per_scenario_stats: dict[str, Any]
+    config: DislocationEventProbeConfig
+
+
+def _cheap_smoke_test() -> SmokeReport:
+    """No-DB, no-network safe default used by --smoke and tests."""
+    return SmokeReport(
+        verdict="NO_PULSE",
+        note=(
+            "SMOKE: no data path exercised. "
+            "This is the expected safe default before any real probe execution "
+            "(real run only post-merge via manifest with explicit user go-ahead)."
+        ),
+    )
+
+
+def _mean(values: Sequence[float]) -> float:
+    materialized = list(values)
+    if not materialized:
+        return 0.0
+    return sum(materialized) / len(materialized)
+
+
+def _median(values: Sequence[float]) -> float:
+    materialized = list(values)
+    if not materialized:
+        return 0.0
+    return float(statistics.median(materialized))
+
+
+def _percentile(values: Sequence[float], pct: float) -> float:
+    if not values:
+        return 0.0
+    ordered = sorted(values)
+    if len(ordered) == 1:
+        return ordered[0]
+    rank = (len(ordered) - 1) * pct / 100.0
+    low = int(rank)
+    high = min(low + 1, len(ordered) - 1)
+    weight = rank - low
+    return ordered[low] * (1.0 - weight) + ordered[high] * (weight)
+
+
+def tail_threshold_high(values: Sequence[float], tail_pct: int) -> float:
+    return _percentile(values, 100.0 - tail_pct)
+
+
+def tail_threshold_low(values: Sequence[float], tail_pct: int) -> float:
+    return _percentile(values, float(tail_pct))
+
+
+def _metric_value(bar: EventBar, metric: str) -> float:
+    if metric == "premium_index":
+        return bar.premium_index
+    return bar.basis_bps
+
+
+def build_pair_spread_bars(
+    rows: list[dict[str, Any]],
+    venues: tuple[str, ...],
+) -> dict[str, list[EventBar]]:
+    """Adapted from probe_cross_venue_basis.py:106-141 (local EventBar with high_price)."""
+    by_time: dict[datetime, dict[str, dict[str, Any]]] = {}
+    for row in rows:
+        by_time.setdefault(row["time"], {})[row["exchange"]] = row
+
+    pairs = [(venues[i], venues[j]) for i in range(len(venues)) for j in range(i + 1, len(venues))]
+    out: dict[str, list[EventBar]] = {f"{a}-{b}": [] for a, b in pairs}
+    for t in sorted(by_time):
+        venue_rows = by_time[t]
+        for a, b in pairs:
+            row_a = venue_rows.get(a)
+            row_b = venue_rows.get(b)
+            if row_a is None or row_b is None:
+                continue
+            out[f"{a}-{b}"].append(
+                EventBar(
+                    time=t,
+                    basis_bps=float(row_a["basis_bps"]) - float(row_b["basis_bps"]),
+                    premium_index=float(row_a["premium_index"]) - float(row_b["premium_index"]),
+                    close_price=float(row_a["close_price"]),
+                    low_price=float(row_a["low_price"]),
+                    high_price=float(row_a["high_price"]),
+                )
+            )
+    return out
+
+
+def _get_window_values(bars: list[EventBar], i: int, metric: str, rolling_days: int) -> list[float]:
+    """Values strictly before bar i, within trailing rolling_days window."""
+    if i <= 0:
+        return []
+    t_i = bars[i].time
+    cutoff = t_i - timedelta(days=rolling_days)
+    vals: list[float] = []
+    for j in range(i):
+        if bars[j].time >= cutoff:
+            vals.append(_metric_value(bars[j], metric))
+    return vals
+
+
+def _compute_threshold(
+    bars: list[EventBar],
+    i: int,
+    metric: str,
+    mode: str,
+    spec: float,
+    rolling_days: int,
+    kind: ScenarioKind,
+) -> float:
+    """Return the (signed where appropriate) threshold applicable at bar i. No full-sample ever."""
+    if mode == "fixed":
+        if kind == ScenarioKind.EXTREME_POSITIVE:
+            return float(spec)
+        if kind == ScenarioKind.EXTREME_NEGATIVE:
+            return -float(spec)
+        return float(spec)
+    # rolling: trailing window only
+    win = _get_window_values(bars, i, metric, rolling_days)
+    if len(win) < 2:
+        # insufficient history -> caller must skip
+        return 0.0
+    tail_pct = int(spec)
+    if kind == ScenarioKind.EXTREME_POSITIVE or kind == ScenarioKind.NORMALIZATION:
+        return tail_threshold_high(win, tail_pct)
+    return tail_threshold_low(win, tail_pct)
+
+
+def _first_of_clusters(qual_indices: list[int]) -> list[int]:
+    if not qual_indices:
+        return []
+    heads = [qual_indices[0]]
+    for idx in qual_indices[1:]:
+        if idx > heads[-1] + 1:
+            heads.append(idx)
+    return heads
+
+
+def _apply_cooldown_thin(heads: list[int], cooldown: int) -> list[int]:
+    if not heads:
+        return []
+    selected = [heads[0]]
+    for h in heads[1:]:
+        if h >= selected[-1] + cooldown:
+            selected.append(h)
+    return selected
+
+
+def _collect_extreme_candidate_indices(
+    bars: list[EventBar],
+    metric: str,
+    kind: ScenarioKind,
+    threshold_mode: str,
+    threshold_spec: float,
+    rolling_days: int,
+) -> list[int]:
+    """All bars meeting the (possibly per-bar rolling) threshold. Raw before dedup."""
+    cands: list[int] = []
+    for i in range(len(bars)):
+        val = _metric_value(bars[i], metric)
+        if threshold_mode == "rolling":
+            win = _get_window_values(bars, i, metric, rolling_days)
+            if len(win) < 2:
+                continue
+        th = _compute_threshold(bars, i, metric, threshold_mode, threshold_spec, rolling_days, kind)
+        if kind == ScenarioKind.EXTREME_POSITIVE:
+            if val >= th:
+                cands.append(i)
+        else:
+            if val <= th:
+                cands.append(i)
+    return cands
+
+
+def _collect_normalization_candidate_indices(
+    bars: list[EventBar],
+    metric: str,
+    threshold_mode: str,
+    threshold_spec: float,
+    rolling_days: int,
+) -> list[int]:
+    """State-machine fire points for normalization (pre-cooldown)."""
+    if not bars:
+        return []
+    cands: list[int] = []
+    state = "idle"
+    prior_extreme = 0.0
+    for i, bar in enumerate(bars):
+        val = _metric_value(bar, metric)
+        if threshold_mode == "rolling":
+            win = _get_window_values(bars, i, metric, rolling_days)
+            if len(win) < 2:
+                continue
+            high_entry = tail_threshold_high(win, int(threshold_spec))
+            low_entry = tail_threshold_low(win, int(threshold_spec))
+            abs_win = [abs(v) for v in win]
+            exit_band = _percentile(abs_win, 50.0) if abs_win else 0.0
+        else:
+            high_entry = float(threshold_spec)
+            low_entry = -float(threshold_spec)
+            exit_band = 0.0
+        if state == "idle":
+            if val >= high_entry:
+                state = "extreme_positive"
+                prior_extreme = val
+            elif val <= low_entry:
+                state = "extreme_negative"
+                prior_extreme = val
+            continue
+        if state == "extreme_positive":
+            if val >= high_entry:
+                prior_extreme = max(prior_extreme, val)
+                continue
+            if abs(val) <= exit_band:
+                cands.append(i)
+                state = "idle"
+            elif val <= low_entry:
+                state = "extreme_negative"
+                prior_extreme = val
+            continue
+        if state == "extreme_negative":
+            if val <= low_entry:
+                prior_extreme = min(prior_extreme, val)
+                continue
+            if abs(val) <= exit_band:
+                cands.append(i)
+                state = "idle"
+            elif val >= high_entry:
+                state = "extreme_positive"
+                prior_extreme = val
+    return cands
+
+
+def _compute_directed_event_stats(
+    bars: list[EventBar],
+    dedup_is: list[int],
+    horizon: int,
+    direction: str,
+    fee_pct: float,
+    slippage_pct: float,
+) -> dict[str, Any]:
+    """Return net stats for one direction at one horizon from deduped entry indices."""
+    cost = fee_pct + slippage_pct
+    valid_nets: list[float] = []
+    valid_maes: list[float] = []
+    wins = 0
+    month_nets: dict[str, list[float]] = defaultdict(list)
+    for idx in dedup_is:
+        if idx + horizon >= len(bars):
+            continue
+        bar = bars[idx]
+        entry_p = bar.close_price
+        fut_p = bars[idx + horizon].close_price
+        if entry_p <= 0:
+            continue
+        move = (fut_p / entry_p - 1.0) * 100.0
+        gross = move if direction == "long" else -move
+        net = gross - cost
+        valid_nets.append(net)
+        w_start = idx + 1
+        w_end = idx + horizon + 1
+        if direction == "long":
+            ws = [bars[j].low_price for j in range(w_start, min(w_end, len(bars)))]
+            if ws:
+                mae = (entry_p - min(ws)) / entry_p * 100.0 if entry_p > 0 else 0.0
+                valid_maes.append(mae)
+        else:
+            ws = [bars[j].high_price for j in range(w_start, min(w_end, len(bars)))]
+            if ws:
+                mae = (max(ws) - entry_p) / entry_p * 100.0 if entry_p > 0 else 0.0
+                valid_maes.append(mae)
+        if net > 0:
+            wins += 1
+        mon_key = bar.time.strftime("%Y-%m")
+        month_nets[mon_key].append(net)
+    n = len(valid_nets)
+    if n == 0:
+        return {
+            "deduped_count": 0,
+            "net_mean": 0.0,
+            "net_median": 0.0,
+            "win_rate": 0.0,
+            "mae_mean": 0.0,
+            "monthly_concentration_pct": 0.0,
+        }
+    nmean = _mean(valid_nets)
+    nmed = _median(valid_nets)
+    wr = (wins / n) * 100.0
+    mmean = _mean(valid_maes) if valid_maes else 0.0
+    tnet = sum(valid_nets)
+    msums = [sum(vs) for vs in month_nets.values()]
+    if tnet > 0:
+        pms = [ms for ms in msums if ms > 0]
+        mconc = (max(pms) / tnet * 100.0) if pms else 0.0
+    else:
+        mconc = 0.0
+    return {
+        "deduped_count": n,
+        "net_mean": nmean,
+        "net_median": nmed,
+        "win_rate": wr,
+        "mae_mean": mmean,
+        "monthly_concentration_pct": mconc,
+    }
+
+
+def _probe_bars(
+    bars: list[EventBar],
+    full_symbol: str,
+    config: DislocationEventProbeConfig,
+) -> tuple[list[str], dict[str, Any]]:
+    """Core per-pair computation. Returns (passing_labels, per_scenario_stats_for_pair)."""
+    passing: list[str] = []
+    stats: dict[str, Any] = {}
+    modes: list[str] = []
+    if config.threshold_mode in ("fixed", "both"):
+        modes.append("fixed")
+    if config.threshold_mode in ("rolling", "both"):
+        modes.append("rolling")
+    for mode in modes:
+        thresh_items: list[tuple[float, str]] = []
+        if mode == "fixed":
+            for g in config.abs_bps_grid:
+                thresh_items.append((float(g), f"abs{g}"))
+        else:
+            for tp in config.tail_pcts:
+                thresh_items.append((float(tp), f"tail{tp}"))
+        for metric in ("basis_bps", "premium_index"):
+            for kind in (
+                ScenarioKind.EXTREME_POSITIVE,
+                ScenarioKind.EXTREME_NEGATIVE,
+                ScenarioKind.NORMALIZATION,
+            ):
+                for spec_val, spec_label in thresh_items:
+                    horizon_details: dict[str, Any] = {}
+                    for horizon in config.horizons:
+                        cooldown = horizon  # --cooldown-mode horizon
+                        if kind in (ScenarioKind.EXTREME_POSITIVE, ScenarioKind.EXTREME_NEGATIVE):
+                            qual = _collect_extreme_candidate_indices(
+                                bars, metric, kind, mode, spec_val, config.rolling_days
+                            )
+                            raw_c = len(qual)
+                            heads = _first_of_clusters(qual)
+                            dedup_is = _apply_cooldown_thin(heads, cooldown)
+                        else:
+                            cands = _collect_normalization_candidate_indices(
+                                bars, metric, mode, spec_val, config.rolling_days
+                            )
+                            raw_c = len(cands)
+                            dedup_is = _apply_cooldown_thin(cands, cooldown)
+                        dir_stats: dict[str, Any] = {}
+                        for direction in ("long", "short"):
+                            dst = _compute_directed_event_stats(
+                                bars,
+                                dedup_is,
+                                horizon,
+                                direction,
+                                config.fee_pct,
+                                config.slippage_pct,
+                            )
+                            dir_stats[direction] = dst
+                            n = dst["deduped_count"]
+                            if (
+                                n >= 40
+                                and dst["net_mean"] > 0
+                                and dst["net_median"] > 0
+                                and dst["win_rate"] >= 45.0
+                                and dst["monthly_concentration_pct"] <= 50.0
+                            ):
+                                label = f"{full_symbol}:{kind}:{metric}:{mode}:{spec_label}:{direction}:h{horizon}"
+                                passing.append(label)
+                        horizon_details[str(horizon)] = {
+                            "raw_count": raw_c,
+                            "deduped_count_long": dir_stats["long"]["deduped_count"],
+                            "deduped_count_short": dir_stats["short"]["deduped_count"],
+                            "long": dir_stats["long"],
+                            "short": dir_stats["short"],
+                        }
+                    base_key = f"{full_symbol}:{kind}:{metric}:{mode}:{spec_label}"
+                    stats[base_key] = {
+                        "threshold_mode": mode,
+                        "spec_label": spec_label,
+                        "horizons": horizon_details,
+                    }
+    return passing, stats
+
+
+def analyze_dislocation_events(
+    rows_by_symbol: dict[str, list[dict[str, Any]]],
+    config: DislocationEventProbeConfig,
+) -> DislocationProbeReport:
+    """Build per-pair EventBars then run no-lookahead event probe per symbol/pair."""
+    all_passing: list[str] = []
+    all_stats: dict[str, Any] = {}
+    has_events = False
+    for symbol, rows in rows_by_symbol.items():
+        for pair_label, bars in build_pair_spread_bars(rows, config.venues).items():
+            full = f"{symbol}|{pair_label}"
+            passing, stats = _probe_bars(bars, full, config)
+            all_passing.extend(passing)
+            all_stats.update(stats)
+            for sk in stats.values():
+                for hd in sk.get("horizons", {}).values():
+                    if hd.get("deduped_count_long", 0) + hd.get("deduped_count_short", 0) > 0:
+                        has_events = True
+    if all_passing:
+        verdict = "HAS_PULSE"
+        note = "Dislocation event probe: net-of-cost forward edge after no-lookahead thresholds (see brief)."
+    elif has_events:
+        verdict = "WEAK_EDGE"
+        note = "Events exist but fail net mean/median>0, win>=45%, conc<=50%, or >=40 deduped in no-lookahead modes."
+    else:
+        verdict = "NO_PULSE"
+        note = "No qualifying events under the configured threshold modes."
+    return DislocationProbeReport(
+        verdict=verdict,
+        note=note,
+        passing_scenarios=tuple(sorted(set(all_passing))),
+        per_scenario_stats=all_stats,
+        config=config,
+    )
+
+
+def print_dislocation_report(
+    report: DislocationProbeReport, config: DislocationEventProbeConfig
+) -> None:
+    print("Dislocation Event Strategy Probe (cross-venue standalone)")
+    print(f"Venues:    {', '.join(config.venues)}")
+    print(f"Symbols:   {', '.join(config.symbols)}")
+    print(f"Timeframe: {config.timeframe}")
+    print(f"Window:    {config.start} -> {config.end}")
+    print(f"Fee+slip:  {config.fee_pct + config.slippage_pct:.2f}%")
+    print(f"Horizons:  {config.horizons}")
+    print(
+        f"Threshold: {config.threshold_mode} (rolling_days={config.rolling_days}, grid={config.abs_bps_grid})"
+    )
+    print(f"Verdict:   {report.verdict}")
+    if report.passing_scenarios:
+        print("Passing scenarios (Gate 1 met for >=1 horizon/dir in no-lookahead mode):")
+        for label in report.passing_scenarios:
+            print(f"  {label}")
+    else:
+        print("No scenarios passed Gate 1.")
+
+
+def _write_verdict(
+    verdict: str,
+    note: str,
+    passing: tuple[str, ...],
+    per_scenario_stats: dict[str, Any],
+    config: DislocationEventProbeConfig,
+    path: str | None,
+) -> None:
+    if not path:
+        return
+    payload = {
+        "verdict": verdict,
+        "note": note,
+        "passing_scenarios": list(passing),
+        "per_scenario_stats": per_scenario_stats,
+        "generated_at": datetime.now(UTC).isoformat(),
+        "config": {
+            "venues": list(config.venues),
+            "symbols": list(config.symbols),
+            "timeframe": config.timeframe,
+            "start": config.start,
+            "end": config.end,
+            "fee_pct": config.fee_pct,
+            "slippage_pct": config.slippage_pct,
+            "horizons": list(config.horizons),
+            "cooldown_mode": config.cooldown_mode,
+            "threshold_mode": config.threshold_mode,
+            "rolling_days": config.rolling_days,
+            "abs_bps_grid": list(config.abs_bps_grid),
+            "tail_pcts": list(config.tail_pcts),
+        },
+    }
+    out = Path(path)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(payload, indent=2) + "\n")
+    print(f"Wrote guard-consumable verdict to {path}")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Cross-venue dislocation event standalone strategy probe (RBI cheap probe)."
+    )
+    parser.add_argument("--venues", default="binance_usdm,bybit")
+    parser.add_argument("--symbols", default="BTCUSDT,ETHUSDT,SOLUSDT")
+    parser.add_argument("--timeframe", default="1h")
+    parser.add_argument("--start", default="2024-01-01")
+    parser.add_argument("--end", default=None)
+    parser.add_argument("--fee-pct", type=float, default=0.08)
+    parser.add_argument("--slippage-pct", type=float, default=0.02)
+    parser.add_argument("--horizons", default="6,12,24")
+    parser.add_argument("--cooldown-mode", default="horizon", choices=["horizon"])
+    parser.add_argument("--threshold-mode", default="both", choices=["rolling", "fixed", "both"])
+    parser.add_argument("--rolling-days", type=int, default=90)
+    parser.add_argument("--abs-bps-grid", default="3.5,4.5,5.5,7.0")
+    parser.add_argument("--tail-pcts", default="5,10")
+    parser.add_argument(
+        "--smoke",
+        action="store_true",
+        help="No-DB safe default path (always NO_PULSE); used by tests",
+    )
+    parser.add_argument(
+        "--verdict-output",
+        default=None,
+        help="Write guard-consumable verdict JSON to this path",
+    )
+    return parser.parse_args()
+
+
+def _config_from_args(args: argparse.Namespace) -> DislocationEventProbeConfig:
+    venues = tuple(v.strip() for v in args.venues.split(",") if v.strip())
+    symbols = tuple(s.strip() for s in args.symbols.split(",") if s.strip())
+    horizons = tuple(int(h) for h in args.horizons.split(",") if h.strip())
+    grid = tuple(float(g) for g in args.abs_bps_grid.split(",") if g.strip())
+    tails = tuple(int(t) for t in args.tail_pcts.split(",") if t.strip())
+    end = args.end or datetime.now(UTC).date().isoformat()
+    return DislocationEventProbeConfig(
+        venues=venues,
+        symbols=symbols,
+        timeframe=args.timeframe,
+        start=args.start,
+        end=end,
+        fee_pct=args.fee_pct,
+        slippage_pct=args.slippage_pct,
+        horizons=horizons,
+        cooldown_mode=args.cooldown_mode,
+        threshold_mode=args.threshold_mode,
+        rolling_days=args.rolling_days,
+        abs_bps_grid=grid,
+        tail_pcts=tails,
+    )
+
+
+async def main_async() -> None:
+    args = parse_args()
+    config = _config_from_args(args)
+
+    if args.smoke:
+        report = _cheap_smoke_test()
+        print(f"Verdict:   {report.verdict}")
+        print(f"Note:      {report.note}")
+        _write_verdict(report.verdict, report.note, (), {}, config, args.verdict_output)
+        return
+
+    from scripts.probe_basis_premium import build_db_config
+    from src.db import close_pool, init_pool
+    from src.utils.logger import configure_logger
+
+    configure_logger("WARNING")
+    pool = await init_pool(build_db_config())
+    try:
+        start = datetime.fromisoformat(config.start).replace(tzinfo=UTC)
+        end = datetime.fromisoformat(config.end).replace(tzinfo=UTC)
+        rows_by_symbol: dict[str, list[dict[str, Any]]] = {}
+        for symbol in config.symbols:
+            fetched = await pool.fetch(
+                PROBE_QUERY, list(config.venues), symbol, config.timeframe, start, end
+            )
+            rows_by_symbol[symbol] = [dict(r) for r in fetched]
+    finally:
+        await close_pool()
+
+    report = analyze_dislocation_events(rows_by_symbol, config)
+    print_dislocation_report(report, config)
+    _write_verdict(
+        report.verdict,
+        report.note,
+        report.passing_scenarios,
+        report.per_scenario_stats,
+        config,
+        args.verdict_output,
+    )
+
+
+def main() -> None:
+    asyncio.run(main_async())
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/probe_dislocation_event_strategy.py
+++ b/scripts/probe_dislocation_event_strategy.py
@@ -265,6 +265,49 @@ def _apply_cooldown_thin(heads: list[int], cooldown: int) -> list[int]:
     return selected
 
 
+def _precompute_rolling_thresholds(
+    bars: list[EventBar],
+    rolling_days: int,
+    tail_pcts: tuple[int, ...],
+) -> dict[tuple[str, int], dict[str, list[float]]]:
+    """Cache per-bar rolling thresholds per (metric, tail_pct) once per pair.
+
+    Reuses the same window across positive (high), negative (low), and normalization
+    (high+low+band). Uses two-pointer sliding window per metric for efficiency
+    (avoids O(N^2) repeated full scans from _get_window_values and the prior
+    double-compute of window inside _collect_extreme + _compute_threshold).
+    """
+    if not bars:
+        return {}
+    metrics = ("basis_bps", "premium_index")
+    delta = timedelta(days=rolling_days)
+    times = [b.time for b in bars]
+    cache: dict[tuple[str, int], dict[str, list[float]]] = {}
+    for metric in metrics:
+        vals = [_metric_value(b, metric) for b in bars]
+        n = len(bars)
+        for tp in tail_pcts:
+            highs = [0.0] * n
+            lows = [0.0] * n
+            bands = [0.0] * n
+            left = 0
+            for i in range(n):
+                cutoff = times[i] - delta
+                while left < i and times[left] < cutoff:
+                    left += 1
+                if left >= i:
+                    continue
+                win = vals[left:i]
+                if len(win) < 2:
+                    continue
+                highs[i] = tail_threshold_high(win, tp)
+                lows[i] = tail_threshold_low(win, tp)
+                abs_win = [abs(v) for v in win]
+                bands[i] = _percentile(abs_win, 50.0) if abs_win else 0.0
+            cache[(metric, tp)] = {"high": highs, "low": lows, "band": bands}
+    return cache
+
+
 def _collect_extreme_candidate_indices(
     bars: list[EventBar],
     metric: str,
@@ -272,16 +315,37 @@ def _collect_extreme_candidate_indices(
     threshold_mode: str,
     threshold_spec: float,
     rolling_days: int,
+    rolling_cache: dict[tuple[str, int], dict[str, list[float]]] | None = None,
 ) -> list[int]:
-    """All bars meeting the (possibly per-bar rolling) threshold. Raw before dedup."""
+    """All bars meeting the (possibly per-bar rolling) threshold. Raw before dedup.
+
+    When rolling_cache provided (for mode=rolling), uses precomputed per-bar thresholds
+    (avoids repeated _get_window_values per kind and the double window computation
+    that used to happen inside the len-check + _compute_threshold).
+    """
     cands: list[int] = []
     for i in range(len(bars)):
         val = _metric_value(bars[i], metric)
         if threshold_mode == "rolling":
-            win = _get_window_values(bars, i, metric, rolling_days)
-            if len(win) < 2:
-                continue
-        th = _compute_threshold(bars, i, metric, threshold_mode, threshold_spec, rolling_days, kind)
+            if rolling_cache is not None:
+                key = (metric, int(threshold_spec))
+                entry = rolling_cache.get(key)
+                if entry is None:
+                    continue
+                th = entry["high"][i] if kind == ScenarioKind.EXTREME_POSITIVE else entry["low"][i]
+                if th == 0.0:
+                    continue
+            else:
+                win = _get_window_values(bars, i, metric, rolling_days)
+                if len(win) < 2:
+                    continue
+                th = _compute_threshold(
+                    bars, i, metric, threshold_mode, threshold_spec, rolling_days, kind
+                )
+        else:
+            th = _compute_threshold(
+                bars, i, metric, threshold_mode, threshold_spec, rolling_days, kind
+            )
         if kind == ScenarioKind.EXTREME_POSITIVE:
             if val >= th:
                 cands.append(i)
@@ -297,6 +361,7 @@ def _collect_normalization_candidate_indices(
     threshold_mode: str,
     threshold_spec: float,
     rolling_days: int,
+    rolling_cache: dict[tuple[str, int], dict[str, list[float]]] | None = None,
 ) -> list[int]:
     """State-machine fire points for normalization (pre-cooldown)."""
     if not bars:
@@ -304,16 +369,28 @@ def _collect_normalization_candidate_indices(
     cands: list[int] = []
     state = "idle"
     prior_extreme = 0.0
+    n = len(bars)
     for i, bar in enumerate(bars):
         val = _metric_value(bar, metric)
         if threshold_mode == "rolling":
-            win = _get_window_values(bars, i, metric, rolling_days)
-            if len(win) < 2:
-                continue
-            high_entry = tail_threshold_high(win, int(threshold_spec))
-            low_entry = tail_threshold_low(win, int(threshold_spec))
-            abs_win = [abs(v) for v in win]
-            exit_band = _percentile(abs_win, 50.0) if abs_win else 0.0
+            if rolling_cache is not None:
+                key = (metric, int(threshold_spec))
+                entry = rolling_cache.get(key)
+                if entry is None:
+                    continue
+                high_entry = entry["high"][i] if i < n else 0.0
+                low_entry = entry["low"][i] if i < n else 0.0
+                exit_band = entry["band"][i] if i < n else 0.0
+                if high_entry == 0.0 and low_entry == 0.0:
+                    continue
+            else:
+                win = _get_window_values(bars, i, metric, rolling_days)
+                if len(win) < 2:
+                    continue
+                high_entry = tail_threshold_high(win, int(threshold_spec))
+                low_entry = tail_threshold_low(win, int(threshold_spec))
+                abs_win = [abs(v) for v in win]
+                exit_band = _percentile(abs_win, 50.0) if abs_win else 0.0
         else:
             high_entry = float(threshold_spec)
             low_entry = -float(threshold_spec)
@@ -444,29 +521,53 @@ def _probe_bars(
         else:
             for tp in config.tail_pcts:
                 thresh_items.append((float(tp), f"tail{tp}"))
+        # For rolling, precompute per-bar thresholds once per (metric, tail_pct) and reuse
+        # across all three kinds + avoid re-computes inside collects. Hoisted below.
+        rolling_cache: dict[tuple[str, int], dict[str, list[float]]] | None = None
+        if mode == "rolling":
+            rolling_cache = _precompute_rolling_thresholds(
+                bars, config.rolling_days, config.tail_pcts
+            )
         for metric in ("basis_bps", "premium_index"):
             for kind in (
                 ScenarioKind.EXTREME_POSITIVE,
                 ScenarioKind.EXTREME_NEGATIVE,
                 ScenarioKind.NORMALIZATION,
             ):
+                if mode == "fixed" and kind == ScenarioKind.NORMALIZATION:
+                    # fixed mode has no meaningful exit band; rolling mode covers normalization
+                    continue
                 for spec_val, spec_label in thresh_items:
+                    # Hoist candidate collection (and clustering for extremes) out of the
+                    # horizon loop: these are independent of horizon (only the cooldown
+                    # thinning + forward/MAE window inside directed stats depend on it).
+                    if kind in (ScenarioKind.EXTREME_POSITIVE, ScenarioKind.EXTREME_NEGATIVE):
+                        qual = _collect_extreme_candidate_indices(
+                            bars,
+                            metric,
+                            kind,
+                            mode,
+                            spec_val,
+                            config.rolling_days,
+                            rolling_cache=rolling_cache,
+                        )
+                        raw_c = len(qual)
+                        base_cands = _first_of_clusters(qual)
+                    else:
+                        cands = _collect_normalization_candidate_indices(
+                            bars,
+                            metric,
+                            mode,
+                            spec_val,
+                            config.rolling_days,
+                            rolling_cache=rolling_cache,
+                        )
+                        raw_c = len(cands)
+                        base_cands = cands
                     horizon_details: dict[str, Any] = {}
                     for horizon in config.horizons:
                         cooldown = horizon  # --cooldown-mode horizon
-                        if kind in (ScenarioKind.EXTREME_POSITIVE, ScenarioKind.EXTREME_NEGATIVE):
-                            qual = _collect_extreme_candidate_indices(
-                                bars, metric, kind, mode, spec_val, config.rolling_days
-                            )
-                            raw_c = len(qual)
-                            heads = _first_of_clusters(qual)
-                            dedup_is = _apply_cooldown_thin(heads, cooldown)
-                        else:
-                            cands = _collect_normalization_candidate_indices(
-                                bars, metric, mode, spec_val, config.rolling_days
-                            )
-                            raw_c = len(cands)
-                            dedup_is = _apply_cooldown_thin(cands, cooldown)
+                        dedup_is = _apply_cooldown_thin(base_cands, cooldown)
                         dir_stats: dict[str, Any] = {}
                         for direction in ("long", "short"):
                             dst = _compute_directed_event_stats(

--- a/tests/test_probe_dislocation_event_strategy.py
+++ b/tests/test_probe_dislocation_event_strategy.py
@@ -176,25 +176,6 @@ def test_cooldown_blocks_overlap():
 
 def test_rolling_threshold_at_i_ignores_bars_ge_i():
     """Construct series where full-sample tail th differs from trailing; prove bar i uses only <i."""
-    # 20 bars. Early (0-9) have a huge outlier 100 at bar 2, making full p95 very high.
-    # Late (10-19) are small values 0-1; at bar 15 we plant a 2.0 which crosses a *late* rolling p95
-    # but would be below full-sample p95.
-    bars = [_mk_bar(i, float(i % 3) * 0.3, 100.0, 99.0, 101.0) for i in range(20)]
-    bars[2] = _mk_bar(2, 100.0, 100.2, 99.0, 101.0)  # full-sample poison
-    # late window before 15 (rolling_days=1 ~24 but we use tiny data, adjust: use rolling_days=0.5 days? use 10 bars window by using days=1 with 1h, but make data sparse? use small rolling_days=1 (24h=24>len, so use rolling that takes last 5 manually? For test use explicit small.
-    # To force: set rolling_days so that for i=15, window before 15 covers say bars 10-14 only (values ~0-1), p95 ~0.9 something.
-    # full sample p95 high because of 100.
-    # Plant at 15 a value 1.5 which > rolling p95(~1.0) but << full p95(~90).
-    bars[15] = _mk_bar(15, 1.5, 101.5, 99.0, 101.0)
-    # For rolling_days small enough that window at 15 is only recent: since 1h bars, rolling_days=1 means 24 bars, but our series 0-19, so for i=15 window is 0-14 still includes poison.
-    # Force small effective: use rolling_days=0 (but timedelta(0) -> only before? wait 0 days takes all prior.
-    # Instead, hack test by calling _get_window_values and tail directly, and the collect with rolling.
-    # Simpler: make rolling_days very small by using fractional? timedelta(days=0.2) but int arg. rolling_days int.
-    # Use 1h bars, set rolling_days=1 (24h), but truncate the series length? For i late, window will include early if total <24.
-    # Solution: construct with enough late-only bars. Make first 30 low, spike early? Put poison early, then 100 low bars, then at far i the test bar.
-    #  rolling_days=1 (24 bars) ; put poison at bar 0, then bars 1-40 normal 0.1, bar 30 plant 0.8 .
-    # At bar 30, window=30-24=6 to 29 : all ~0.1, tail5 high ~0.1x ; 0.8 > that.
-    # Full sample tail5 high dominated by 100 at 0 -> very high, 0.8 < full th.
     bars = [_mk_bar(i, 0.1, 100.0 + i * 0.01, 99.9, 100.1) for i in range(50)]
     bars[0] = _mk_bar(0, 100.0, 100.0, 99.0, 101.0)
     bars[1] = _mk_bar(1, 80.0, 100.0, 99.0, 101.0)

--- a/tests/test_probe_dislocation_event_strategy.py
+++ b/tests/test_probe_dislocation_event_strategy.py
@@ -1,0 +1,340 @@
+"""Tests for the dislocation event strategy probe.
+
+Covers smoke path, dedup/cooldown, no-lookahead rolling thresholds (provably
+ignores bars at/after i), net-of-cost arithmetic, short MAE on highs, and
+synthetic end-to-end planted dislocation. All tests are synthetic (no DB).
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+from scripts.probe_dislocation_event_strategy import (
+    DislocationEventProbeConfig,
+    EventBar,
+    ScenarioKind,
+    _cheap_smoke_test,
+    _collect_extreme_candidate_indices,
+    _get_window_values,
+    _probe_bars,
+    analyze_dislocation_events,
+    build_pair_spread_bars,
+    tail_threshold_high,
+)
+
+T0 = datetime(2024, 1, 1, tzinfo=UTC)
+
+
+def _mk_bar(
+    hour: int,
+    basis: float,
+    close: float,
+    low: float,
+    high: float,
+    premium: float = 0.0,
+) -> EventBar:
+    return EventBar(
+        time=T0 + timedelta(hours=hour),
+        basis_bps=basis,
+        premium_index=premium,
+        close_price=close,
+        low_price=low,
+        high_price=high,
+    )
+
+
+def _gate_config(**overrides) -> DislocationEventProbeConfig:
+    defaults = {
+        "venues": ("va", "vb"),
+        "symbols": ("TEST",),
+        "timeframe": "1h",
+        "start": "2024-01-01",
+        "end": "2024-01-10",
+        "fee_pct": 0.08,
+        "slippage_pct": 0.02,
+        "horizons": (6, 12),
+        "cooldown_mode": "horizon",
+        "threshold_mode": "both",
+        "rolling_days": 2,  # small for synthetic
+        "abs_bps_grid": (5.0, 7.0),
+        "tail_pcts": (5,),
+    }
+    defaults.update(overrides)
+    return DislocationEventProbeConfig(**defaults)
+
+
+def _rows_for_bars(bars: list[EventBar], venue_a: str = "va", venue_b: str = "vb") -> list[dict]:
+    rows: list[dict] = []
+    for b in bars:
+        rows.append(
+            {
+                "time": b.time,
+                "exchange": venue_a,
+                "basis_bps": b.basis_bps + 1.0,  # arbitrary split
+                "premium_index": b.premium_index + 0.001,
+                "close_price": b.close_price,
+                "low_price": b.low_price,
+                "high_price": b.high_price,
+            }
+        )
+        rows.append(
+            {
+                "time": b.time,
+                "exchange": venue_b,
+                "basis_bps": 1.0,
+                "premium_index": 0.001,
+                "close_price": b.close_price,
+                "low_price": b.low_price,
+                "high_price": b.high_price,
+            }
+        )
+    return rows
+
+
+def test_cheap_smoke_helper():
+    report = _cheap_smoke_test()
+    assert report.verdict == "NO_PULSE"
+    assert "SMOKE" in report.note
+
+
+def test_smoke_cli_no_data(tmp_path: Path):
+    verdict_path = tmp_path / "verdict.json"
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/probe_dislocation_event_strategy.py",
+            "--smoke",
+            "--verdict-output",
+            str(verdict_path),
+            "--venues",
+            "binance_usdm,bybit",
+            "--symbols",
+            "SOLUSDT",
+        ],
+        capture_output=True,
+        text=True,
+        cwd=Path(__file__).parent.parent,
+    )
+    assert result.returncode == 0
+    assert "NO_PULSE" in result.stdout
+    assert "SMOKE" in result.stdout
+    assert verdict_path.exists()
+    data = json.loads(verdict_path.read_text())
+    assert data["verdict"] == "NO_PULSE"
+    assert "SMOKE" in data["note"]
+    assert "fee_pct" in data["config"]
+    assert data["config"]["fee_pct"] == 0.08
+
+
+def test_dedup_merges_consecutive_tail_bars_into_one_event():
+    """Consecutive qualifying bars produce only one deduped event (the first)."""
+    # 10 bars, spread extreme positive fixed 5.0 at bars 3,4,5 (consecutive cluster), then 8
+    bars = [_mk_bar(i, 0.0, 100.0 + i * 0.1, 99.0, 101.0) for i in range(12)]
+    bars[3] = _mk_bar(3, 10.0, 100.3, 99.0, 101.0)
+    bars[4] = _mk_bar(4, 10.1, 100.4, 99.0, 101.0)
+    bars[5] = _mk_bar(5, 10.2, 100.5, 99.0, 101.0)
+    bars[8] = _mk_bar(8, 10.3, 100.8, 99.0, 101.0)
+    # use fixed mode, grid 5.0, horizon 2 (cooldown 2) so second cluster at 8 survives
+    cfg = _gate_config(threshold_mode="fixed", abs_bps_grid=(5.0,), horizons=(2,), tail_pcts=(5,))
+    rows = _rows_for_bars(bars)
+    pairs = build_pair_spread_bars(rows, cfg.venues)
+    test_bars = pairs["va-vb"]
+    passing, stats = _probe_bars(test_bars, "T|va-vb", cfg)
+    # raw for the extreme_positive basis should be 4 qualifying bars; deduped heads=2 (3 and 8)
+    # with cd=2, both survive (8-3=5>2)
+    base = "T|va-vb:extreme_positive:basis_bps:fixed:abs5.0"
+    h2 = stats[base]["horizons"]["2"]
+    assert h2["raw_count"] == 4
+    # after cluster+cd we have 2 deduped candidates; forward window exists for both
+    assert h2["deduped_count_long"] + h2["deduped_count_short"] >= 2
+
+
+def test_cooldown_blocks_overlap():
+    """Cooldown = horizon prevents a new event starting before previous would have exited."""
+    bars = [_mk_bar(i, 0.0, 100.0, 99.0, 101.0) for i in range(20)]
+    # two spikes exactly horizon apart would be blocked; closer blocked, farther allowed
+    bars[5] = _mk_bar(5, 6.0, 100.5, 99.0, 101.0)
+    bars[5 + 3] = _mk_bar(8, 6.1, 100.8, 99.0, 101.0)  # within cd=6
+    bars[5 + 7] = _mk_bar(12, 6.2, 101.2, 99.0, 101.0)  # after cd
+    cfg = _gate_config(threshold_mode="fixed", abs_bps_grid=(5.5,), horizons=(6,), tail_pcts=(5,))
+    rows = _rows_for_bars(bars)
+    pairs = build_pair_spread_bars(rows, cfg.venues)
+    test_bars = pairs["va-vb"]
+    _, stats = _probe_bars(test_bars, "T|va-vb", cfg)
+    base = "T|va-vb:extreme_positive:basis_bps:fixed:abs5.5"
+    h6 = stats[base]["horizons"]["6"]
+    # heads at 5 and 12; 12-5=7 >=6 so both selected -> deduped candidates 2 (before forward filter)
+    assert h6["raw_count"] >= 3
+    # after thin, since 8 skipped by cd from 5, only 5 and 12 -> 2
+    # (forward filter may drop last if horizon exceeds)
+    assert h6["deduped_count_long"] + h6["deduped_count_short"] >= 1
+
+
+def test_rolling_threshold_at_i_ignores_bars_ge_i():
+    """Construct series where full-sample tail th differs from trailing; prove bar i uses only <i."""
+    # 20 bars. Early (0-9) have a huge outlier 100 at bar 2, making full p95 very high.
+    # Late (10-19) are small values 0-1; at bar 15 we plant a 2.0 which crosses a *late* rolling p95
+    # but would be below full-sample p95.
+    bars = [_mk_bar(i, float(i % 3) * 0.3, 100.0, 99.0, 101.0) for i in range(20)]
+    bars[2] = _mk_bar(2, 100.0, 100.2, 99.0, 101.0)  # full-sample poison
+    # late window before 15 (rolling_days=1 ~24 but we use tiny data, adjust: use rolling_days=0.5 days? use 10 bars window by using days=1 with 1h, but make data sparse? use small rolling_days=1 (24h=24>len, so use rolling that takes last 5 manually? For test use explicit small.
+    # To force: set rolling_days so that for i=15, window before 15 covers say bars 10-14 only (values ~0-1), p95 ~0.9 something.
+    # full sample p95 high because of 100.
+    # Plant at 15 a value 1.5 which > rolling p95(~1.0) but << full p95(~90).
+    bars[15] = _mk_bar(15, 1.5, 101.5, 99.0, 101.0)
+    # For rolling_days small enough that window at 15 is only recent: since 1h bars, rolling_days=1 means 24 bars, but our series 0-19, so for i=15 window is 0-14 still includes poison.
+    # Force small effective: use rolling_days=0 (but timedelta(0) -> only before? wait 0 days takes all prior.
+    # Instead, hack test by calling _get_window_values and tail directly, and the collect with rolling.
+    # Simpler: make rolling_days very small by using fractional? timedelta(days=0.2) but int arg. rolling_days int.
+    # Use 1h bars, set rolling_days=1 (24h), but truncate the series length? For i late, window will include early if total <24.
+    # Solution: construct with enough late-only bars. Make first 30 low, spike early? Put poison early, then 100 low bars, then at far i the test bar.
+    #  rolling_days=1 (24 bars) ; put poison at bar 0, then bars 1-40 normal 0.1, bar 30 plant 0.8 .
+    # At bar 30, window=30-24=6 to 29 : all ~0.1, tail5 high ~0.1x ; 0.8 > that.
+    # Full sample tail5 high dominated by 100 at 0 -> very high, 0.8 < full th.
+    bars = [_mk_bar(i, 0.1, 100.0 + i * 0.01, 99.9, 100.1) for i in range(50)]
+    bars[0] = _mk_bar(0, 100.0, 100.0, 99.0, 101.0)
+    bars[1] = _mk_bar(1, 80.0, 100.0, 99.0, 101.0)
+    bars[2] = _mk_bar(2, 30.0, 100.0, 99.0, 101.0)
+    bars[30] = _mk_bar(30, 0.8, 100.3, 99.9, 100.1)
+    # Direct: at i=30, window should exclude bar 0-2 (t30-1d=t6, early poison t< cutoff excluded).
+    # bars[6] onward in window. Yes bar0-2 excluded from rolling at 30.
+    win_at_30 = _get_window_values(bars, 30, "basis_bps", 1)
+    assert len(win_at_30) >= 20
+    assert max(win_at_30) < 1.0  # poison excluded
+    full_th = tail_threshold_high([b.basis_bps for b in bars], 5)
+    roll_th = tail_threshold_high(win_at_30, 5)
+    assert roll_th < 1.0
+    assert (
+        full_th > roll_th
+    )  # full sample (with 3 poisons) yields higher th than late-only rolling window
+    # Now the collect under rolling must pick bar 30 (qualifies roll th), even though not full.
+    qual = _collect_extreme_candidate_indices(
+        bars, "basis_bps", ScenarioKind.EXTREME_POSITIVE, "rolling", 5.0, 1
+    )
+    assert 30 in qual
+    # And full-sample collect would not (but we don't call full here; the point of rolling path is it used the small th)
+    # Prove by direct: the th used inside collect at i=30 was the rolling one (we already asserted win and ths)
+
+
+def test_net_return_subtraction():
+    """net = signed_gross - (fee+slip) exactly."""
+    bars = [_mk_bar(i, 0.0, 100.0, 99.0, 101.0) for i in range(10)]
+    # plant extreme and a +0.25% move exactly at +6
+    bars[1] = _mk_bar(1, 6.0, 100.0, 99.0, 101.0)
+    bars[1 + 6] = _mk_bar(7, 0.0, 100.25, 99.0, 101.0)
+    cfg = _gate_config(
+        fee_pct=0.08, slippage_pct=0.02, horizons=(6,), threshold_mode="fixed", abs_bps_grid=(5.5,)
+    )
+    rows = _rows_for_bars(bars)
+    pairs = build_pair_spread_bars(rows, cfg.venues)
+    test_bars = pairs["va-vb"]
+    _, stats = _probe_bars(test_bars, "T|va-vb", cfg)
+    base = "T|va-vb:extreme_positive:basis_bps:fixed:abs5.5"
+    long_s = stats[base]["horizons"]["6"]["long"]
+    assert long_s["deduped_count"] == 1
+    # gross +0.25, net +0.25 - 0.10 = +0.15
+    assert abs(long_s["net_mean"] - 0.15) < 1e-9
+    assert abs(long_s["net_median"] - 0.15) < 1e-9
+
+
+def test_short_mae_uses_highs():
+    """For short direction, MAE is computed from highs (adverse upward move)."""
+    bars = [_mk_bar(i, 0.0, 100.0, 99.0, 101.0) for i in range(10)]
+    # short entry at bar1, plant adverse high at bar3 (within h=6)
+    bars[1] = _mk_bar(1, -6.0, 100.0, 99.0, 101.0)  # extreme negative for short
+    bars[3] = _mk_bar(3, 0.0, 100.0, 99.0, 102.5)  # high 102.5
+    bars[7] = _mk_bar(7, 0.0, 99.0, 98.0, 99.5)  # later lower, but mae window to +6 uses up to bar7
+    cfg = _gate_config(
+        fee_pct=0.0, slippage_pct=0.0, horizons=(6,), threshold_mode="fixed", abs_bps_grid=(5.5,)
+    )
+    rows = _rows_for_bars(bars)
+    pairs = build_pair_spread_bars(rows, cfg.venues)
+    test_bars = pairs["va-vb"]
+    _, stats = _probe_bars(test_bars, "T|va-vb", cfg)
+    base = "T|va-vb:extreme_negative:basis_bps:fixed:abs5.5"
+    short_s = stats[base]["horizons"]["6"]["short"]
+    assert short_s["deduped_count"] == 1
+    # entry 100, max high in window=102.5 -> mae = (102.5-100)/100 *100 = 2.5
+    assert abs(short_s["mae_mean"] - 2.5) < 1e-9
+    # long would have used lows (not relevant here)
+
+
+def test_synthetic_end_to_end_planted_dislocation_one_event_expected_net():
+    """Planted known dislocation + known move -> exactly 1 deduped event, exact net."""
+    bars = [_mk_bar(i, 0.0, 100.0 + i * 0.01, 99.9, 100.1) for i in range(20)]
+    # fixed 4.5, plant at bar 2 spread 5.0 (qual), then at +12 exactly +0.30% price move
+    bars[2] = _mk_bar(2, 5.0, 100.02, 99.9, 100.1)
+    bars[2 + 12] = _mk_bar(14, 0.0, 100.02 * 1.003, 99.9, 100.1)
+    cfg = _gate_config(
+        fee_pct=0.08,
+        slippage_pct=0.02,
+        horizons=(12,),
+        threshold_mode="fixed",
+        abs_bps_grid=(4.5,),
+        tail_pcts=(5,),
+    )
+    rows = _rows_for_bars(bars)
+    pairs = build_pair_spread_bars(rows, cfg.venues)
+    test_bars = pairs["va-vb"]
+    passing, stats = _probe_bars(test_bars, "SYN|va-vb", cfg)
+    base = "SYN|va-vb:extreme_positive:basis_bps:fixed:abs4.5"
+    h12 = stats[base]["horizons"]["12"]
+    assert h12["raw_count"] == 1
+    # one trigger index produces stats entries for both directions (long gets the positive edge)
+    assert h12["deduped_count_long"] == 1
+    assert h12["deduped_count_short"] == 1
+    long_s = h12["long"]
+    # gross = +0.30 , net = 0.30 - 0.10 = 0.20
+    assert long_s["deduped_count"] == 1
+    assert abs(long_s["net_mean"] - 0.20) < 1e-12
+    assert abs(long_s["net_median"] - 0.20) < 1e-12
+    # also via full analyze path (end-to-end)
+    rows_by_sym = {"SYN": rows}
+    report = analyze_dislocation_events(rows_by_sym, cfg)
+    assert report.verdict in ("HAS_PULSE", "WEAK_EDGE")  # may or not pass 40 etc, but 1 event
+    # check a stat entry exists with the expected net
+    key = "SYN|va-vb:extreme_positive:basis_bps:fixed:abs4.5"
+    assert key in report.per_scenario_stats
+    assert abs(report.per_scenario_stats[key]["horizons"]["12"]["long"]["net_mean"] - 0.20) < 1e-12
+
+
+def test_analyze_via_rows_smoke_path_equivalent():
+    """analyze on empty rows yields NO_PULSE with empty passing and stats."""
+    cfg = _gate_config()
+    report = analyze_dislocation_events({"EMPTY": []}, cfg)
+    assert report.verdict == "NO_PULSE"
+    assert report.passing_scenarios == ()
+    # per_scenario_stats contains zero-count entries for all combos (shape contract); passing empty + verdict correct is the smoke assertion
+    assert isinstance(report.per_scenario_stats, dict)
+
+
+def test_verdict_json_shape_has_per_scenario_stats(tmp_path: Path):
+    verdict_path = tmp_path / "v.json"
+    subprocess.run(
+        [
+            sys.executable,
+            "scripts/probe_dislocation_event_strategy.py",
+            "--smoke",
+            "--verdict-output",
+            str(verdict_path),
+        ],
+        capture_output=True,
+        cwd=Path(__file__).parent.parent,
+        check=True,
+    )
+    data = json.loads(verdict_path.read_text())
+    assert set(data.keys()) >= {
+        "verdict",
+        "note",
+        "passing_scenarios",
+        "per_scenario_stats",
+        "config",
+        "generated_at",
+    }
+    assert "fee_pct" in data["config"]
+    assert "horizons" in data["config"]
+    assert "threshold_mode" in data["config"]


### PR DESCRIPTION
## Summary

Adds `scripts/probe_dislocation_event_strategy.py` + tests: the sharpened Gate 1 cheap probe for lane **cross-venue-dislocation-event-v0** (brief: `docs/specs/cross-venue-dislocation-event-strategy-v0.md`, manifest merged in #70). Standalone event-strategy probe — the shape the parent cross-venue-basis-v1 probe actually measured before that lane closed 0/30 (#69).

Fixes all four flaws of the v1 probe machinery:
- **No lookahead**: thresholds are trailing rolling-window (strictly prior bars) or fixed abs-bps grid — never full-sample percentiles. Test plants a full-sample poison outlier and proves the event fires only under the trailing threshold.
- **Event dedup**: consecutive tail bars cluster to the first bar; cooldown = horizon between events.
- **Net of costs**: net = gross − (fee 0.08% + slippage 0.02%), exact subtraction tested.
- **Two-sided MAE**: long MAE from lows, short MAE from highs.

HAS_PULSE requires ≥40 deduped events, net mean>0 AND median>0, win ≥45%, monthly concentration ≤50%, in a no-lookahead mode.

## Review (commit 2ff0f97 fix round, independently re-verified)

- Hoisted candidate collection out of the horizon loop + per-(metric,tail) rolling-threshold cache: `_probe_bars` at 21,365 bars, default config = **~21–39s/pair** (was ~12 min/pair → would have risked the manifest's 3600s timeout).
- **Bit-identity verified**: cached vs fallback candidate paths produce identical indices across all 12 scenario comparisons on 21k synthetic bars.
- Fixed-mode normalization (dead: exit band 0.0 never fires on real floats) now skipped — zero dead scenario keys emitted.
- `ruff check` / `format --check` clean; **929 passed, 1 skipped**; smoke CLI returns safe NO_PULSE with no DB access.

No real probe execution in this PR. Real run happens post-merge via `rbi_loop_from_manifest.py --execute` on the v0 manifest, with explicit go-ahead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)