### PR TITLE
feat(strategy): add dislocation_event standalone strategy + dislocation_event_entry autoresearch family

### DIFF
--- a/scripts/autoresearch_loop.py
+++ b/scripts/autoresearch_loop.py
@@ -44,6 +44,7 @@ DEFAULT_FAMILIES = (
 CV_FAMILIES = (
     "cross_venue_dislocation",
     "venue_basis_filter",
+    "dislocation_event_entry",
 )
 ALL_FAMILIES = DEFAULT_FAMILIES + CV_FAMILIES
 
@@ -1172,6 +1173,42 @@ def generate_candidate(
             f"funding-norm entry={entry_thresh:.5f} exit={exit_thresh:.5f} "
             f"time_stop={time_stop_min:.0f}m"
         )
+    elif family == "dislocation_event_entry":
+        # Gate 2: standalone dislocation event entry family (long-only positive spread).
+        # Per probe evidence (SOL positive fixed-abs, shorts never passed, ETH opposite).
+        # <=5 free params (we use 3): min_spread (sampled), horizon (sampled), cooldown==horizon (tied).
+        # Fixed wide SL/TP + time stop exit (probe MAE 3.2-5%, tight stops kill edge).
+        # Mirror funding_*_standalone pattern for aggregator/per-symbol so single BUY passes.
+        horizon_bars = int(rng.choice([12, 24]))
+        min_bps = _round(rng.uniform(4.5, 7.0), 2)
+        cooldown_bars = horizon_bars  # tied, not a free parameter
+        overlay, _ = _standalone_strategy_overlay(
+            trading_symbol=trading_symbol,
+            rng=rng,
+            strategy_entry={
+                "name": "dislocation_event",
+                "config": {
+                    "min_spread_bps": min_bps,
+                    "cooldown_bars": cooldown_bars,
+                },
+            },
+            buy_low=0.42,
+            buy_high=0.68,
+            sl_atr=4.0,
+            tp_atr=8.0,
+        )
+        # Force the design's fixed wide values (helper would have sampled trail; we neutralize trailing)
+        overlay["trading_execution"]["sl_atr_multiplier"] = 4.0
+        overlay["trading_execution"]["tp_atr_multiplier"] = 8.0
+        overlay["trading_execution"]["trailing_activate_atr"] = _round(rng.uniform(8.0, 12.0), 1)
+        overlay["trading_execution"]["trailing_offset_atr"] = 0.5
+        # Time stop exactly at horizon (bars), mirror exact pattern from volatility/funding time-stop families
+        time_stop_min = float(horizon_bars * 60)
+        overlay["trading_execution"]["exit_rules"] = {
+            "backtest_use_executor_exit_model": True,
+            "time_stop_minutes": time_stop_min,
+        }
+        desc = f"dislocation-event-entry min_bps={min_bps:.2f} horizon={horizon_bars}"
     elif family == "volatility_squeeze_bounded":
         max_hold_bars = int(rng.choice([10, 12, 14]))
         time_stop_min = float(max_hold_bars * 60)

--- a/src/main.py
+++ b/src/main.py
@@ -50,6 +50,7 @@ from src.strategy import (
     BaseStrategy,
     BollingerBounceStrategy,
     CCIBreakoutStrategy,
+    DislocationEventStrategy,
     EngineConfig,
     FundingNormalizationStrategy,
     FundingRateStrategy,
@@ -784,6 +785,7 @@ def _build_strategy_registry() -> dict[str, type[BaseStrategy]]:
         "macro_volatility": MacroVolatilityStrategy,
         "funding_rate": FundingRateStrategy,
         "funding_normalization": FundingNormalizationStrategy,
+        "dislocation_event": DislocationEventStrategy,
     }
 
     optional_strategies = {

--- a/src/strategy/__init__.py
+++ b/src/strategy/__init__.py
@@ -4,6 +4,7 @@ from src.strategy.base import BaseStrategy
 from src.strategy.bollinger_strategy import BollingerBounceStrategy
 from src.strategy.breakout_retest import BreakoutRetestStrategy
 from src.strategy.cci_strategy import CCIBreakoutStrategy
+from src.strategy.dislocation_event import DislocationEventStrategy
 from src.strategy.engine import EngineConfig, StrategyEngine
 from src.strategy.funding_normalization import FundingNormalizationStrategy
 from src.strategy.funding_rate import FundingRateStrategy
@@ -46,4 +47,5 @@ __all__ = [
     "MacroVolatilityStrategy",
     "RegimeRouterStrategy",
     "MultiTimeframeRegimeRouter",
+    "DislocationEventStrategy",
 ]

--- a/src/strategy/dislocation_event.py
+++ b/src/strategy/dislocation_event.py
@@ -1,0 +1,112 @@
+"""Dislocation event entry strategy (standalone, long-only).
+
+Emits BUY on cross-venue basis spread (binance_usdm - bybit) >= min_spread_bps (positive only).
+Uses internal bar-count cooldown (tied to horizon in the autoresearch family) to deduplicate
+consecutive extreme bars into a single event entry. Exit is by time_stop (configured via
+trading_execution.exit_rules in the family sampler), never emits SELL.
+
+Indicators row must include "cross_venue_basis_spread_bps" (already joined by features/reader.py).
+Returns HOLD (no signal) if the value is missing/None for either venue.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from src.strategy.base import BaseStrategy
+from src.strategy.signals import Signal, SignalType
+
+
+class DislocationEventStrategy(BaseStrategy):
+    """Standalone long-only strategy for cross-venue dislocation events.
+
+    BUY when cross_venue_basis_spread_bps >= min_spread_bps (positive tail extreme).
+    Cooldown after fire prevents re-entry on consecutive extreme bars.
+    Never emits SELL; the family configures a time stop exit at the horizon.
+
+    Config:
+        min_spread_bps: minimum |positive| spread in bps to trigger (4.5-7.0 validated range)
+        cooldown_bars: bars to wait after a BUY before allowing another (family ties to horizon)
+    """
+
+    def __init__(self, config: Mapping[str, object] | None = None) -> None:
+        super().__init__(config)
+        self._min_spread_bps: float = float(self._config.get("min_spread_bps", 5.0))
+        self._cooldown_bars: int = int(self._config.get("cooldown_bars", 12))
+
+        if self._min_spread_bps < 0.0:
+            self._min_spread_bps = 0.0
+        if self._cooldown_bars < 1:
+            self._cooldown_bars = 1
+
+        # Per-symbol bar counter and last BUY fire bar (for cooldown dedup)
+        self._bar_count: dict[str, int] = {}
+        self._last_fire_bar: dict[str, int] = {}
+
+    async def evaluate(self, symbol: str, indicators: dict[str, float]) -> Signal:
+        """Evaluate cross-venue basis spread and emit deduplicated long entry or HOLD.
+
+        Returns BUY only on qualifying positive spread after cooldown.
+        Returns HOLD (no trade signal) for sub-threshold, negative, or missing spread.
+        Never returns SELL.
+        """
+        spread = indicators.get("cross_venue_basis_spread_bps")
+        close_price = float(indicators.get("close_price", 0.0))
+
+        # Always advance bar count (evaluate is invoked once per bar in sequence)
+        bar = self._bar_count.get(symbol, 0) + 1
+        self._bar_count[symbol] = bar
+
+        if spread is None:
+            return Signal(
+                type=SignalType.HOLD,
+                symbol=symbol,
+                price=close_price,
+                confidence=0.0,
+                reason="missing_cross_venue_basis_spread",
+                indicators=indicators,
+            )
+
+        spread = float(spread)
+
+        # Positive-only (v0 per probe evidence and caveats)
+        if spread < self._min_spread_bps:
+            return Signal(
+                type=SignalType.HOLD,
+                symbol=symbol,
+                price=close_price,
+                confidence=0.0,
+                reason=f"spread_below_threshold ({spread:.2f} < {self._min_spread_bps:.2f})",
+                indicators=indicators,
+            )
+
+        # Cooldown check (dedup consecutive extremes; cooldown_bars tied to horizon in family)
+        last = self._last_fire_bar.get(symbol, -(10**9))
+        bars_since = bar - last
+        if bars_since < self._cooldown_bars:
+            return Signal(
+                type=SignalType.HOLD,
+                symbol=symbol,
+                price=close_price,
+                confidence=0.0,
+                reason=f"cooldown_active (bars_since={bars_since} < {self._cooldown_bars})",
+                indicators=indicators,
+            )
+
+        # Emit BUY and record fire bar
+        self._last_fire_bar[symbol] = bar
+        # Confidence scales modestly with extremity (capped); threshold at 0.6
+        excess = spread - self._min_spread_bps
+        confidence = min(0.6 + (excess / 5.0), 1.0)
+
+        return Signal(
+            type=SignalType.BUY,
+            symbol=symbol,
+            price=close_price,
+            confidence=confidence,
+            reason=f"cross_venue_dislocation_positive min_bps={self._min_spread_bps:.2f} spread={spread:.2f}",
+            indicators=indicators,
+        )
+
+    def get_name(self) -> str:
+        return "dislocation_event"

--- a/tests/test_dislocation_event_strategy.py
+++ b/tests/test_dislocation_event_strategy.py
@@ -1,0 +1,160 @@
+"""Tests for dislocation_event standalone strategy + its autoresearch family sampler.
+
+Covers the 6 required behaviors + N=50 sampler validation per Gate 2 spec.
+"""
+
+import pytest
+
+from scripts.autoresearch_loop import generate_candidate
+from src.strategy.dislocation_event import DislocationEventStrategy
+from src.strategy.signals import SignalType
+
+
+class TestDislocationEventStrategy:
+    @pytest.fixture
+    def strategy(self) -> DislocationEventStrategy:
+        return DislocationEventStrategy({"min_spread_bps": 5.0, "cooldown_bars": 12})
+
+    def _mk_indicators(self, spread: float | None, close: float = 150.0) -> dict[str, float]:
+        ind: dict[str, float] = {"close_price": close}
+        if spread is not None:
+            ind["cross_venue_basis_spread_bps"] = spread  # type: ignore[assignment]
+        return ind
+
+    @pytest.mark.asyncio
+    async def test_buy_emitted_at_or_above_threshold(
+        self, strategy: DislocationEventStrategy
+    ) -> None:
+        """1. BUY emitted when spread >= threshold (exact boundary included)."""
+        # exact boundary
+        sig = await strategy.evaluate("SOLUSDT", self._mk_indicators(5.0))
+        assert sig.type == SignalType.BUY
+        assert sig.symbol == "SOLUSDT"
+        assert "cross_venue_dislocation_positive" in sig.reason
+        assert sig.confidence > 0.5
+
+        # strictly above (use different symbol to avoid shared cooldown state on same symbol)
+        sig2 = await strategy.evaluate("ETHUSDT", self._mk_indicators(6.2))
+        assert sig2.type == SignalType.BUY
+
+    @pytest.mark.asyncio
+    async def test_no_signal_below_threshold_or_negative(
+        self, strategy: DislocationEventStrategy
+    ) -> None:
+        """2. No signal below threshold; no signal on negative spread of equal magnitude (positive-only)."""
+        # below
+        sig = await strategy.evaluate("SOLUSDT", self._mk_indicators(4.9))
+        assert sig.type == SignalType.HOLD
+        assert "below_threshold" in sig.reason
+
+        # negative equal mag
+        sig_neg = await strategy.evaluate("SOLUSDT", self._mk_indicators(-5.0))
+        assert sig_neg.type == SignalType.HOLD
+        assert "below_threshold" in sig_neg.reason
+
+        # larger negative
+        sig_neg2 = await strategy.evaluate("SOLUSDT", self._mk_indicators(-7.0))
+        assert sig_neg2.type == SignalType.HOLD
+
+    @pytest.mark.asyncio
+    async def test_no_signal_when_spread_missing_or_none(
+        self, strategy: DislocationEventStrategy
+    ) -> None:
+        """3. No signal when cross_venue_basis_spread_bps is None/missing."""
+        sig = await strategy.evaluate("SOLUSDT", self._mk_indicators(None))
+        assert sig.type == SignalType.HOLD
+        assert "missing_cross_venue_basis_spread" in sig.reason
+
+        sig2 = await strategy.evaluate("SOLUSDT", {"close_price": 150.0})
+        assert sig2.type == SignalType.HOLD
+        assert "missing_cross_venue_basis_spread" in sig2.reason
+
+    @pytest.mark.asyncio
+    async def test_cooldown_prevents_refire_within_window(
+        self, strategy: DislocationEventStrategy
+    ) -> None:
+        """4. Cooldown: second qualifying bar within cooldown_bars emits nothing;
+        first bar after cooldown expiry emits again.
+        """
+        cooldown = 12
+        # fire first
+        sig1 = await strategy.evaluate("SOLUSDT", self._mk_indicators(5.5))
+        assert sig1.type == SignalType.BUY
+
+        # within cooldown: no fire even on qualifying
+        for _ in range(cooldown - 1):
+            sig = await strategy.evaluate("SOLUSDT", self._mk_indicators(6.0))
+            assert sig.type == SignalType.HOLD
+            assert "cooldown_active" in sig.reason
+
+        # exactly at cooldown boundary: still within? next after the loop is bar offset=11
+        # after 11 more calls (bars 2..12), current offset from fire =11, 11 <12 -> hold
+        # now one more call reaches bars_since=12
+        sig_at_boundary = await strategy.evaluate("SOLUSDT", self._mk_indicators(5.5))
+        # with >= logic: after cooldown-1 holds, the next call has bars_since = cooldown , should fire
+        assert sig_at_boundary.type == SignalType.BUY
+
+    @pytest.mark.asyncio
+    async def test_never_emits_sell(self, strategy: DislocationEventStrategy) -> None:
+        """5. Never emits SELL."""
+        # qualifying
+        sig = await strategy.evaluate("SOLUSDT", self._mk_indicators(7.0))
+        assert sig.type != SignalType.SELL
+        # sub
+        sig2 = await strategy.evaluate("SOLUSDT", self._mk_indicators(3.0))
+        assert sig2.type != SignalType.SELL
+        # missing
+        sig3 = await strategy.evaluate("SOLUSDT", self._mk_indicators(None))
+        assert sig3.type != SignalType.SELL
+        # negative
+        sig4 = await strategy.evaluate("SOLUSDT", self._mk_indicators(-6.0))
+        assert sig4.type != SignalType.SELL
+
+    @pytest.mark.asyncio
+    async def test_get_name(self, strategy: DislocationEventStrategy) -> None:
+        assert strategy.get_name() == "dislocation_event"
+
+
+def test_dislocation_event_entry_family_sampler_produces_valid_configs() -> None:
+    """6. Sampler test: N=50 dislocation_event_entry configs with seeded rng;
+    assert ranges, horizon, time_stop==horizon*60, strategies==["dislocation_event"] only.
+    Mirrors pattern from test_autoresearch (e.g. volatility_squeeze_bounded loop) and
+    test_cross_venue_dislocation sampler tests.
+    """
+    n = 50
+    seen_horizons: set[int] = set()
+    for i in range(n):
+        cand = generate_candidate(
+            i,
+            seed=42,
+            symbol="SOLUSDT",
+            families=("dislocation_event_entry",),
+        )
+        assert cand.family == "dislocation_event_entry"
+        ov = cand.overlay
+
+        # strategies list exactly the one
+        strategies = ov["strategy"]["strategies"]
+        assert len(strategies) == 1
+        assert strategies[0]["name"] == "dislocation_event"
+        strat_cfg = strategies[0]["config"]
+        min_bps = float(strat_cfg["min_spread_bps"])
+        cooldown = int(strat_cfg["cooldown_bars"])
+
+        assert 4.5 <= min_bps <= 7.0
+        assert cooldown in (12, 24)
+
+        # time stop
+        exit_rules = ov["trading_execution"]["exit_rules"]
+        time_stop = float(exit_rules["time_stop_minutes"])
+        assert exit_rules["backtest_use_executor_exit_model"] is True
+        assert time_stop == cooldown * 60.0
+
+        # also assert fixed wide sl/tp no effective trailing (per design)
+        assert ov["trading_execution"]["sl_atr_multiplier"] == 4.0
+        assert ov["trading_execution"]["tp_atr_multiplier"] == 8.0
+
+        seen_horizons.add(cooldown)
+
+    # both horizons should be hit over 50 draws
+    assert seen_horizons == {12, 24}


### PR DESCRIPTION
## Summary

Gate 2 implementation for lane **cross-venue-dislocation-event-v0** (HAS_PULSE recorded in #72): a standalone `dislocation_event` strategy plus the `dislocation_event_entry` autoresearch family the manifest's RUN_AUTORESEARCH command already references.

Design is fixed by the probe evidence (`docs/reports/cross-venue-dislocation-event-v0-probe-2026-06-12.md`):
- **Long-only, positive spread extremes only** — shorts never passed the probe; ETH conditions on the opposite extreme (both deliberately excluded from v0).
- Entry: `cross_venue_basis_spread_bps >= min_spread_bps` (same binance_usdm − bybit orientation the probe validated; already joined by `features/reader.py`, `None` → HOLD).
- **Cooldown = horizon** (per-symbol bar counter) — the dedup the probe required; re-entry aligns exactly with the time-stop exit.
- Exit: `time_stop_minutes = horizon × 60`; SL/TP fixed wide (4.0/8.0 ATR, trailing neutralized) because probe MAE means run 3.2–5.0% and tight stops would destroy the measured edge.
- Sampled free parameters: `min_spread_bps` ∈ [4.5, 7.0] (validated passing range), `horizon` ∈ {12, 24} (h6 didn't pass for SOL fixed mode), plus the standalone helper's aggregator buy threshold — within the brief's ≤5 rule.

## Review (independently reproduced)

- Diff scope exactly the 5 allowed files (+313). Strategy avoids the v1 require-mode starvation failure: the event IS the entry, no host-stack gating.
- `ruff check` / `format --check` clean; **936 passed, 1 skipped** (7 new tests: boundary entry, positive-only, missing-data HOLD, cooldown refire boundary, never-SELL, name, N=50 seeded sampler property test).
- Reviewer spot-check across 200 seeded draws: all params in range, `min_confidence` inert, trailing effectively off; worst-case aggregator-threshold coupling shifts the effective spread threshold by **+0.40 bps** (vs 2.5 bps grid width) — mild, matches precedent standalone families.

## Next (gated)

After merge: 30-run bounded sweep via the lane manifest (`RUN_AUTORESEARCH`, dry-verified guard) — only with explicit go-ahead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)