### PR TITLE
docs(backtest): open cross-venue-dislocation-event-v1 lane (rolling variant)

### DIFF
--- a/config/autoresearch/rbi_loop.cross-venue-dislocation-event-v1.yaml
+++ b/config/autoresearch/rbi_loop.cross-venue-dislocation-event-v1.yaml
@@ -1,0 +1,72 @@
+# RBI lane manifest: cross-venue dislocation event strategy v1 (rolling variant)
+#
+# Successor to cross-venue-dislocation-event-v0 (closed 2026-06-12: fixed-threshold
+# shape failed 0/30 on structural WFO sparsity, see
+# docs/reports/cross-venue-dislocation-event-v0-sweep-2026-06-12.md). This lane tests
+# the five rolling-threshold probe scenarios v0 never implemented (28-57 events per
+# 2-month WFO window; the sparsity jaw does not bind). Terminal lane: 0/30 closes the
+# cross-venue dislocation primitive entirely.
+#
+# probe_verdict: HAS_PULSE carried from the v0 Gate 1 probe run (real DB, 2026-06-12,
+# rc=0) whose verdict JSON contains the rolling passing scenarios verbatim. No new
+# probe run is required or permitted (re-probing the same data = selection bias).
+# Evidence: research/rbi_loop/cross-venue-dislocation-event-v0/probe-verdict.json and
+# docs/reports/cross-venue-dislocation-event-v0-probe-2026-06-12.md
+#
+# Drive with:
+#   uv run python scripts/rbi_loop_from_manifest.py --manifest config/autoresearch/rbi_loop.cross-venue-dislocation-event-v1.yaml
+# (dry by default; --execute only after human review of the guard decision)
+
+lane_name: cross-venue-dislocation-event-v1
+lane_brief: docs/specs/cross-venue-dislocation-event-strategy-v1.md
+probe_verdict: HAS_PULSE
+
+last_result:
+overlap_report:
+
+decision_output: research/rbi_loop/cross-venue-dislocation-event-v1/decision.json
+report_output: docs/reports/rbi-loop-cross-venue-dislocation-event-v1.md
+timeout_seconds: 3600
+
+commands:
+  # Gate 1 already satisfied by the v0 probe run; this command exists only for
+  # manifest completeness and must not be re-executed for this lane.
+  RUN_CHEAP_PROBE: >-
+    uv run python scripts/probe_dislocation_event_strategy.py
+    --venues binance_usdm,bybit
+    --symbols SOLUSDT
+    --timeframe 1h
+    --start 2024-01-01
+    --fee-pct 0.08
+    --slippage-pct 0.02
+    --verdict-output research/rbi_loop/cross-venue-dislocation-event-v1/probe-verdict.json
+
+  # Bounded sweep of the rolling-threshold family. The dislocation_event_rolling_entry
+  # family requires the rolling-mode strategy extension (own reviewed plan) before this
+  # can execute.
+  RUN_AUTORESEARCH: >-
+    uv run python scripts/autoresearch_loop.py
+    --config config/settings.autoresearch.yaml
+    --symbol SOLUSDT
+    --timeframe 1h
+    --train-months 3
+    --test-months 2
+    --gate-profile standard
+    --families dislocation_event_rolling_entry
+    --max-runs 30
+
+  RUN_BOOTSTRAP_1000: >-
+    uv run python scripts/run_autoresearch.py
+    --config config/settings.autoresearch.yaml
+    --symbol SOLUSDT
+    --timeframe 1h
+    --train-months 3
+    --test-months 2
+    --bootstrap 1000
+    --gate-profile standard
+    --description cross-venue-dislocation-event-v1-b1000
+
+  CHECK_OVERLAP: >-
+    uv run python scripts/analyze_entry_overlap.py
+    --output docs/reports/rbi-loop-cross-venue-dislocation-event-v1-overlap.json
+    --against sol-1h-trend-pullback-overlay-live,sentiment-macro

--- a/docs/reports/rbi-loop-cross-venue-dislocation-event-v1.md
+++ b/docs/reports/rbi-loop-cross-venue-dislocation-event-v1.md
@@ -1,0 +1,28 @@
+# RBI Loop Decision — cross-venue-dislocation-event-v1
+
+| Field | Value |
+|---|---|
+| Generated at | 2026-06-12T20:41:44.054907+00:00 |
+| Action | `RUN_AUTORESEARCH` |
+| Allowed | True |
+| Execute requested | False |
+| Selected command | `uv run python scripts/autoresearch_loop.py --config config/settings.autoresearch.yaml --symbol SOLUSDT --timeframe 1h --train-months 3 --test-months 2 --gate-profile standard --families dislocation_event_rolling_entry --max-runs 30` |
+
+## Reasons
+
+- cheap probe passed; autoresearch result missing
+
+## Evidence
+
+| Field | Value |
+|---|---|
+| lane_brief | docs/specs/cross-venue-dislocation-event-strategy-v1.md |
+| probe_verdict | HAS_PULSE |
+
+## Execution
+
+No command execution was recorded.
+
+## Next Action
+
+RUN_AUTORESEARCH

--- a/docs/specs/cross-venue-dislocation-event-strategy-v1.md
+++ b/docs/specs/cross-venue-dislocation-event-strategy-v1.md
@@ -1,0 +1,85 @@
+# Lane brief: cross-venue-dislocation-event-v1 (high-frequency rolling variant)
+
+**Hypothesis HYP-CVE-002**: SOL 1h long entries on *rolling-percentile* positive
+extremes of the cross-venue spread (binance_usdm − bybit, premium-index or
+basis), exited at a fixed 12/24-bar horizon, carry a thin but harvestable net
+edge at a trade frequency that satisfies house WFO standards.
+
+## Lineage and why this lane exists
+
+- Parent lane **cross-venue-dislocation-event-v0** closed 2026-06-12 after its
+  30-run sweep failed 0/30 (#74). The failure was structural for the *fixed
+  absolute-threshold* shape only: fat per-event edges (+0.35–1.79% net) at
+  ~1 event/month could not satisfy `min_wfo_trades ≥ 20` inside 2-month test
+  windows, while sub-threshold events carried no edge. Full-period in-engine
+  performance was positive in 26/30 runs (best +43.7% / Sharpe 0.96), so the
+  conditional signal exists; harvestability under OOS cadence was the failure.
+- The v0 Gate 1 probe **also validated five rolling-threshold scenarios that
+  the v0 family never implemented** — this lane tests exactly those, nothing
+  new. Evidence (verbatim from
+  `research/rbi_loop/cross-venue-dislocation-event-v0/probe-verdict.json`,
+  all SOL long, no-lookahead trailing 90d thresholds, net of 0.10% costs):
+
+| scenario | n (deduped) | net mean % | net median % | win % | conc % | events / 2-mo window |
+|---|---|---|---|---|---|---|
+| basis_bps rolling tail5 h12 | 528 | +0.163 | +0.118 | 51.1 | 48.6 | ~36 |
+| premium rolling tail10 h12 | 838 | +0.127 | +0.040 | 50.8 | 39.9 | ~57 |
+| premium rolling tail10 h24 | 549 | +0.205 | +0.114 | 51.5 | 38.0 | ~37 |
+| premium rolling tail5 h24 | 408 | +0.348 | +0.123 | 52.9 | 28.6 | ~28 |
+| premium rolling tail5 h6 | 705 | +0.155 | +0.034 | 50.8 | 43.4 | ~48 |
+
+- The sparsity jaw that killed v0 does not bind here: every scenario yields
+  ≥28 events per 2-month WFO test window vs the ≥20-trade gate. The open
+  question shifts to whether a 51–53% win / ~+0.1% median edge survives
+  Sharpe, drawdown, and bootstrap-P(loss) gates. Odds are honestly
+  low-to-moderate; cost is one bounded sweep.
+
+## Gate 1 (probe) — already satisfied
+
+`probe_verdict: HAS_PULSE` is carried from the v0 probe run (real DB,
+2026-06-12, rc=0; independently re-derived in
+`docs/reports/cross-venue-dislocation-event-v0-probe-2026-06-12.md`). No new
+probe run is required or permitted — re-probing the same data to refresh
+evidence would be selection bias.
+
+## Gate 2: family `dislocation_event_rolling_entry`
+
+Extends `DislocationEventStrategy` with a rolling-threshold mode:
+
+- **Online trailing percentile**: at each bar, threshold = the (100 − tail)th
+  percentile of the spread over the trailing 90 days, computed from strictly
+  prior bars only (the probe's `_precompute_rolling_thresholds` two-pointer
+  window is the reference for the no-lookahead discipline; the live strategy
+  maintains the window incrementally).
+- Long-only, positive extremes only (unchanged from v0; shorts never passed
+  any probe).
+- Sampled free parameters (≤5 rule; 4 used):
+  `metric` ∈ {premium_spread, basis_spread}, `tail_pct` ∈ {5, 10},
+  `horizon` ∈ {12, 24} bars; `rolling_days = 90` fixed (probe-validated, not
+  sampled); `cooldown = horizon` tied. h6 excluded (+0.034 median too thin).
+- Exit: time stop = horizon × 60 min; SL/TP fixed wide (4.0 / 8.0 ATR,
+  trailing neutralized) as in v0.
+
+## Kill criteria (pre-registered; this lane is terminal)
+
+- Sweep fails 0/30 under standard gates → **close the cross-venue dislocation
+  primitive entirely** (both event shapes, fixed and rolling, will then have
+  failed bounded OOS evaluation). No v2, no reshape, no gate relaxation.
+- Family implementation needs lookahead to compute rolling thresholds, or
+  >5 free parameters → close at design stage without sweeping.
+- Insufficient warm-up handling: strategy must HOLD (not crash, not guess)
+  during the first 90 days of window fill.
+
+## Gates 3–6 (unchanged house rules)
+
+- Gate 3/4: promotion pre-filter, then bootstrap=1000.
+- Gate 5: `analyze_entry_overlap.py` vs `sol-1h-trend-pullback-overlay-live`
+  and `sentiment-macro` (<35% Jaccard). Note: at 28–57 events/2 months this
+  strategy trades far more often than v0 would have; overlap risk with
+  sentiment-macro SOL entries is correspondingly higher and Gate 5 is a real
+  gate here, not a formality.
+- Gate 6: ≥20 closed paper trades under a distinct AGENT_ID before any live
+  notional.
+
+Human approval required at every stage transition; the lane manifest guard
+(`rbi_loop_from_manifest.py`, dry by default) records each decision.

--- a/research/rbi_loop/cross-venue-dislocation-event-v1/decision.json
+++ b/research/rbi_loop/cross-venue-dislocation-event-v1/decision.json
@@ -1,0 +1,18 @@
+{
+  "generated_at": "2026-06-12T20:41:44.054907+00:00",
+  "lane_name": "cross-venue-dislocation-event-v1",
+  "execute": false,
+  "decision": {
+    "action": "RUN_AUTORESEARCH",
+    "allowed": true,
+    "reasons": [
+      "cheap probe passed; autoresearch result missing"
+    ],
+    "evidence": {
+      "lane_brief": "docs/specs/cross-venue-dislocation-event-strategy-v1.md",
+      "probe_verdict": "HAS_PULSE"
+    }
+  },
+  "selected_command": "uv run python scripts/autoresearch_loop.py --config config/settings.autoresearch.yaml --symbol SOLUSDT --timeframe 1h --train-months 3 --test-months 2 --gate-profile standard --families dislocation_event_rolling_entry --max-runs 30",
+  "execution": null
+}


### PR DESCRIPTION
## Summary

Opens lane **cross-venue-dislocation-event-v1** per the approved next-path decision: test the five rolling-threshold probe scenarios that the v0 family never implemented.

- **Evidence already banked**: the v0 Gate 1 probe (real run, #72) validated SOL long positive-extreme scenarios under trailing 90d percentile thresholds with **28–57 events per 2-month WFO window** — the `min_wfo_trades` sparsity jaw that structurally killed v0 (#74) does not bind. `probe_verdict: HAS_PULSE` is carried from that run; the brief explicitly forbids re-probing (selection bias).
- **The open question shifts**: from trade counts to whether a thin 51–53% win / ~+0.1% net median edge survives Sharpe/drawdown/bootstrap gates. Odds honestly low-to-moderate; cost is one bounded sweep.
- **Terminal lane, pre-registered**: 0/30 closes the cross-venue dislocation primitive entirely — no v2, no reshape, no gate relaxation. Design-stage kills: lookahead needed for rolling thresholds, >5 free params, or broken 90-day warm-up handling.
- Guard dry tick verified: **RUN_AUTORESEARCH allowed**, gated on the `dislocation_event_rolling_entry` family (builder plan delivered separately; sweep itself stays gated on explicit go-ahead).

## Files

- `docs/specs/cross-venue-dislocation-event-strategy-v1.md` — brief (HYP-CVE-002, lineage, scenario table, kill criteria)
- `config/autoresearch/rbi_loop.cross-venue-dislocation-event-v1.yaml` — manifest
- `research/rbi_loop/cross-venue-dislocation-event-v1/decision.json` + report MD — genuine dry-tick artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)