### PR TITLE
Gate 0 brief: scheduled macro-event drift probe (opens news/event family)

### DIFF
--- a/docs/reports/daily-trend-breadth-probe-v0.md
+++ b/docs/reports/daily-trend-breadth-probe-v0.md
@@ -1,59 +1,81 @@
 # Daily Trend-Following Breadth Probe — Report
 
 **Verdict:** **NO_PULSE**
-**Status:** **BLOCKED_ON_INGESTION**
-**Date:** 2026-06-16
+**Date:** 2026-06-17
 **Script:** `scripts/probe_daily_trend_breadth.py`
 **Spec:** [daily-trend-breadth-probe-v0.md](../specs/daily-trend-breadth-probe-v0.md)
-**Data:** production TimescaleDB (SSH tunnel localhost:15432), `ohlcv` 1h — read-only.
+**Data:** production TimescaleDB (SSH tunnel `127.0.0.1:15434` → `crypto-agent-timescaledb`), read-only.
 
-## Coverage audit (feasibility gate)
+## Coverage audit (finest intraday TF per symbol)
 
-Prod `ohlcv` at 1h holds **4 USDT pairs** with ≥700d span — far below the
-**15–20 liquid-pair** universe this lane requires. Other symbols (ADA, AVAX, DOGE,
-DOT, LINK, XRP) exist at 1m/4h/5m but **not** at 1h with sufficient depth.
+Universe selection uses **finest available intraday TF** (prefer 1h, else 4h). Minimum
+to run: **8 symbols**; prod holds **10 eligible** USDT pairs — probe ran.
 
-| Symbol | Bars | Span (d) | First | Quote vol (USDT) |
-|--------|------|----------|-------|------------------|
-| BTCUSDT | 21,399 | 891 | 2024-01-01 | 1.85e12 |
-| ETHUSDT | 21,399 | 891 | 2024-01-01 | 1.24e12 |
-| SOLUSDT | 21,399 | 891 | 2024-01-01 | 5.66e11 |
-| BNBUSDT | 18,834 | 784 | 2024-01-01 | 2.03e11 |
+| Symbol | TF | Bars | Span (d) | First | Quote vol (USDT) |
+|--------|----|------|----------|-------|------------------|
+| BTCUSDT | 1h | 20,725 | 882 | 2024-01-01 | 1.80e12 |
+| ETHUSDT | 1h | 20,727 | 882 | 2024-01-01 | 1.21e12 |
+| SOLUSDT | 1h | 21,106 | 898 | 2024-01-01 | 5.60e11 |
+| XRPUSDT | 1h | 20,544 | 855 | 2024-01-01 | 3.49e11 |
+| DOGEUSDT | 1h | 20,544 | 855 | 2024-01-01 | 2.74e11 |
+| BNBUSDT | 1h | 20,544 | 855 | 2024-01-01 | 2.08e11 |
+| ADAUSDT | 1h | 20,544 | 855 | 2024-01-01 | 9.35e10 |
+| AVAXUSDT | 1h | 20,137 | 839 | 2024-01-01 | 6.67e10 |
+| LINKUSDT | 1h | 20,544 | 855 | 2024-01-01 | 6.39e10 |
+| LTCUSDT | 1h | 20,545 | 856 | 2024-01-01 | 5.31e10 |
 
-**Blocked reason:** only 4 USDT pairs have ≥700d of 1h history; need ≥15.
+Universe (fixed, liquidity-ranked): BTC, ETH, SOL, XRP, DOGE, BNB, ADA, AVAX, LINK, LTC.
 
-Per spec guardrail #5: **do not run pulse metrics on a thin universe.** The probe
-stopped after the coverage audit.
+## Config
 
-## Pulse metrics
+- SMA window: **50** (frozen)
+- Window: 2024-01-01 → 2026-06-01
+- One-way fee: 0.04%
+- Portfolio: equal-weight across currently-long symbols
 
-**Not run** — blocked on ingestion.
+## Pulse metrics (equal-weight portfolio)
 
 | Metric | Value | Gate | Pass |
 |--------|-------|------|------|
-| Max single-symbol PnL share | n/a | < 50% | n/a |
-| State changes / OOS window (2mo) | n/a | ≥ 20 | n/a |
-| Portfolio Sharpe vs buy-hold | n/a | Sharpe ≥ BH | n/a |
-| Portfolio max DD vs buy-hold | n/a | DD < BH | n/a |
-| Mean pairwise signal correlation | n/a | diagnostic | n/a |
+| Max single-symbol PnL share | **24.0%** | < 50% | **True** |
+| State changes / OOS window (2mo) | **46.1** | ≥ 20 | **True** |
+| Portfolio Sharpe | **0.07** | ≥ BH 0.30 | False |
+| Portfolio max DD | **63.5%** | < BH 62.4% | False |
+| Mean pairwise signal correlation | **0.593** | diagnostic | n/a |
 
 ## Vol-target variant (secondary)
 
-Not computed — coverage gate failed.
+Return −22.6% | Sharpe 0.05 | Max DD 57.7% — not a gate.
+
+## Per-symbol standalone SMA50 (concentration inputs)
+
+| Symbol | Return % | Role |
+|--------|----------|------|
+| XRPUSDT | +103.4 | largest positive leg (24% share) |
+| ETHUSDT | +92.6 | |
+| BNBUSDT | +84.4 | |
+| BTCUSDT | +72.6 | |
+| DOGEUSDT | +72.0 | |
+| LINKUSDT | +3.0 | |
+| SOLUSDT | +1.9 | |
+| ADAUSDT | −39.1 | |
+| AVAXUSDT | −51.5 | |
+| LTCUSDT | −57.6 | |
 
 ## Interpretation
 
-The breadth hypothesis cannot be tested until prod ingestion backfills **≥15 liquid
-USDT pairs** at 1h (ideally top-20 by quote volume) with ~2y of history. Running
-on BTC/ETH/SOL/BNB alone would repeat the Gate 2 structural failure (7–18 WFO trades,
-92–100% profit concentration) without adding independent trend legs.
+**Breadth fixed the Gate 2 structural failures** — concentration dropped from 92–100%
+(3-symbol book) to **24%**, and implied OOS trade count rose to **46/state-changes per
+2-month window** (vs 7–18 WFO trades). The diversification hypothesis partially holds on
+count and PnL share.
 
-This is a **data-ingestion blocker**, not a directional verdict on SMA50 breadth.
-Once the universe is populated, re-run:
+**Risk-adjusted edge is gone at portfolio level** — equal-weight breadth portfolio
+underperforms buy-and-hold on Sharpe (0.07 vs 0.30) and does not improve max drawdown
+(63.5% vs 62.4%). Mean pairwise signal correlation **0.59** confirms symbols still move
+together (shared beta); breadth added legs but not independent timing.
 
-```bash
-uv run python scripts/probe_daily_trend_breadth.py --json
-```
+**Verdict: NO_PULSE** — close the trend family per spec; pivot to news/event lane. Do
+not reshape into symbol cherry-picking or MA-length search.
 
 ## RBI guard
 
@@ -63,14 +85,6 @@ uv run python scripts/rbi_loop_guard.py \
   --probe-verdict NO_PULSE --pretty
 ```
 
-Expected: `CLOSE_LANE` — cheap probe did not return HAS_PULSE.
-
-## Next action
-
-1. **Ingest** top ~15–20 liquid USDT 1h OHLCV pairs into prod (read-only probe
-   prerequisites only — no strategy code).
-2. Re-run this probe; if concentration stays ≥50% or correlation dominates,
-   **close the trend family** per spec and pivot to news/event lane.
-3. Do **not** reshape into symbol cherry-picking or MA-length search.
+Expected: `CLOSE_LANE`.
 
 See [research-reset-2026-06-06.md](research-reset-2026-06-06.md) for banned surfaces.

--- a/docs/reports/daily-trend-breadth-probe-v0.md
+++ b/docs/reports/daily-trend-breadth-probe-v0.md
@@ -1,0 +1,76 @@
+# Daily Trend-Following Breadth Probe — Report
+
+**Verdict:** **NO_PULSE**
+**Status:** **BLOCKED_ON_INGESTION**
+**Date:** 2026-06-16
+**Script:** `scripts/probe_daily_trend_breadth.py`
+**Spec:** [daily-trend-breadth-probe-v0.md](../specs/daily-trend-breadth-probe-v0.md)
+**Data:** production TimescaleDB (SSH tunnel localhost:15432), `ohlcv` 1h — read-only.
+
+## Coverage audit (feasibility gate)
+
+Prod `ohlcv` at 1h holds **4 USDT pairs** with ≥700d span — far below the
+**15–20 liquid-pair** universe this lane requires. Other symbols (ADA, AVAX, DOGE,
+DOT, LINK, XRP) exist at 1m/4h/5m but **not** at 1h with sufficient depth.
+
+| Symbol | Bars | Span (d) | First | Quote vol (USDT) |
+|--------|------|----------|-------|------------------|
+| BTCUSDT | 21,399 | 891 | 2024-01-01 | 1.85e12 |
+| ETHUSDT | 21,399 | 891 | 2024-01-01 | 1.24e12 |
+| SOLUSDT | 21,399 | 891 | 2024-01-01 | 5.66e11 |
+| BNBUSDT | 18,834 | 784 | 2024-01-01 | 2.03e11 |
+
+**Blocked reason:** only 4 USDT pairs have ≥700d of 1h history; need ≥15.
+
+Per spec guardrail #5: **do not run pulse metrics on a thin universe.** The probe
+stopped after the coverage audit.
+
+## Pulse metrics
+
+**Not run** — blocked on ingestion.
+
+| Metric | Value | Gate | Pass |
+|--------|-------|------|------|
+| Max single-symbol PnL share | n/a | < 50% | n/a |
+| State changes / OOS window (2mo) | n/a | ≥ 20 | n/a |
+| Portfolio Sharpe vs buy-hold | n/a | Sharpe ≥ BH | n/a |
+| Portfolio max DD vs buy-hold | n/a | DD < BH | n/a |
+| Mean pairwise signal correlation | n/a | diagnostic | n/a |
+
+## Vol-target variant (secondary)
+
+Not computed — coverage gate failed.
+
+## Interpretation
+
+The breadth hypothesis cannot be tested until prod ingestion backfills **≥15 liquid
+USDT pairs** at 1h (ideally top-20 by quote volume) with ~2y of history. Running
+on BTC/ETH/SOL/BNB alone would repeat the Gate 2 structural failure (7–18 WFO trades,
+92–100% profit concentration) without adding independent trend legs.
+
+This is a **data-ingestion blocker**, not a directional verdict on SMA50 breadth.
+Once the universe is populated, re-run:
+
+```bash
+uv run python scripts/probe_daily_trend_breadth.py --json
+```
+
+## RBI guard
+
+```bash
+uv run python scripts/rbi_loop_guard.py \
+  --lane-brief docs/specs/daily-trend-breadth-probe-v0.md \
+  --probe-verdict NO_PULSE --pretty
+```
+
+Expected: `CLOSE_LANE` — cheap probe did not return HAS_PULSE.
+
+## Next action
+
+1. **Ingest** top ~15–20 liquid USDT 1h OHLCV pairs into prod (read-only probe
+   prerequisites only — no strategy code).
+2. Re-run this probe; if concentration stays ≥50% or correlation dominates,
+   **close the trend family** per spec and pivot to news/event lane.
+3. Do **not** reshape into symbol cherry-picking or MA-length search.
+
+See [research-reset-2026-06-06.md](research-reset-2026-06-06.md) for banned surfaces.

--- a/docs/specs/daily-trend-breadth-probe-v0.md
+++ b/docs/specs/daily-trend-breadth-probe-v0.md
@@ -62,7 +62,11 @@ from existing long agents, news/event ranks higher. Flagging for the decision-ma
 
 ## Signal definition (frozen from Gate 1 — no new knobs)
 
-- Daily bars (resampled from 1h, UTC buckets), per symbol.
+- Daily bars (UTC buckets), per symbol, **resampled from the finest intraday timeframe available
+  for that symbol in prod `ohlcv` — prefer 1h, else 4h.** This is a *daily* strategy: a daily SMA50
+  only needs daily closes, so 4h→daily is just as valid as 1h→daily. Do **not** gate the universe on
+  1h availability (correction to v0: the 1h-only requirement over-specified the data and wrongly
+  blocked the lane — see PR #84 review).
 - Per-symbol state: `close[t] > SMA50[t]` → long for day *t+1*, else flat. **SMA50 only** (the
   Gate-1 winner). No MA-length search — that fragility is exactly what closed Gate 2's grid.
 - Portfolio: equal weight across all currently-long symbols (report a vol-target variant as a
@@ -71,10 +75,17 @@ from existing long agents, news/event ranks higher. Flagging for the decision-ma
 
 ## Universe & data (builder to confirm against prod DB first)
 
-- Target: top **~15–20** USDT pairs by liquidity that have ≥ ~2y of 1h history in prod `ohlcv`.
-- **Feasibility gate:** if prod only holds BTC/ETH/SOL at daily depth, this lane is **blocked on
-  data ingestion** — record that and stop (do not run on a thin universe). The probe's first step
-  is a coverage audit.
+- Target: top **~15–20** USDT pairs by liquidity with ≥ ~2y of history at **any** intraday
+  timeframe (1h or 4h) — measured in **daily bars after resampling**, not in 1h rows.
+- **Minimum to run: ~8 symbols.** The probe's job is to measure whether breadth cuts concentration;
+  ~10 symbols answers that directionally and is far better than the 3-symbol book that failed Gate 2.
+  Only **< ~8** eligible symbols is a true **blocked-on-ingestion** stop. (Correction to v0: the
+  original 15-symbol floor + 1h gate parked the lane behind an ingestion task that — given BTC/ETH/
+  SOL/BNB @1h plus ADA/AVAX/DOGE/DOT/LINK/XRP @4h — is likely unnecessary.)
+- **Coverage audit is step 1** and must report, per symbol, the finest available TF and the
+  resulting daily-bar depth. Universe is liquidity-defined and **fixed before** the metric run.
+- If ~8 symbols *are* reachable, **run the probe** and report all four pulse metrics. If a real
+  pulse appears, *that* justifies ingesting more pairs to reach 15–20 — not the reverse.
 - Window: 2024-01-01 → 2026-06-01 (same as Gate 1).
 
 ## Pulse criteria (encode in the probe)
@@ -107,7 +118,8 @@ uv run python scripts/rbi_loop_guard.py \
 2. **No symbol cherry-picking** to manufacture a pass — universe is liquidity-defined and fixed before the run.
 3. **Measure correlation/concentration; do not assume diversification.**
 4. **Long-only**, portfolio equal-weight (vol-target is a reported variant, not a tuned knob).
-5. If data coverage is thin, the lane is **blocked on ingestion** — record and stop, don't run thin.
+5. Build daily bars from the **finest available** intraday TF per symbol (1h else 4h) — do not gate
+   on 1h. Only **< ~8** eligible symbols is a true blocked-on-ingestion stop; at ~8+ symbols, run.
 
 ## Reviewer (Claude) checkpoints
 

--- a/docs/specs/daily-trend-breadth-probe-v0.md
+++ b/docs/specs/daily-trend-breadth-probe-v0.md
@@ -62,11 +62,7 @@ from existing long agents, news/event ranks higher. Flagging for the decision-ma
 
 ## Signal definition (frozen from Gate 1 — no new knobs)
 
-- Daily bars (UTC buckets), per symbol, **resampled from the finest intraday timeframe available
-  for that symbol in prod `ohlcv` — prefer 1h, else 4h.** This is a *daily* strategy: a daily SMA50
-  only needs daily closes, so 4h→daily is just as valid as 1h→daily. Do **not** gate the universe on
-  1h availability (correction to v0: the 1h-only requirement over-specified the data and wrongly
-  blocked the lane — see PR #84 review).
+- Daily bars (resampled from 1h, UTC buckets), per symbol.
 - Per-symbol state: `close[t] > SMA50[t]` → long for day *t+1*, else flat. **SMA50 only** (the
   Gate-1 winner). No MA-length search — that fragility is exactly what closed Gate 2's grid.
 - Portfolio: equal weight across all currently-long symbols (report a vol-target variant as a
@@ -75,17 +71,10 @@ from existing long agents, news/event ranks higher. Flagging for the decision-ma
 
 ## Universe & data (builder to confirm against prod DB first)
 
-- Target: top **~15–20** USDT pairs by liquidity with ≥ ~2y of history at **any** intraday
-  timeframe (1h or 4h) — measured in **daily bars after resampling**, not in 1h rows.
-- **Minimum to run: ~8 symbols.** The probe's job is to measure whether breadth cuts concentration;
-  ~10 symbols answers that directionally and is far better than the 3-symbol book that failed Gate 2.
-  Only **< ~8** eligible symbols is a true **blocked-on-ingestion** stop. (Correction to v0: the
-  original 15-symbol floor + 1h gate parked the lane behind an ingestion task that — given BTC/ETH/
-  SOL/BNB @1h plus ADA/AVAX/DOGE/DOT/LINK/XRP @4h — is likely unnecessary.)
-- **Coverage audit is step 1** and must report, per symbol, the finest available TF and the
-  resulting daily-bar depth. Universe is liquidity-defined and **fixed before** the metric run.
-- If ~8 symbols *are* reachable, **run the probe** and report all four pulse metrics. If a real
-  pulse appears, *that* justifies ingesting more pairs to reach 15–20 — not the reverse.
+- Target: top **~15–20** USDT pairs by liquidity that have ≥ ~2y of 1h history in prod `ohlcv`.
+- **Feasibility gate:** if prod only holds BTC/ETH/SOL at daily depth, this lane is **blocked on
+  data ingestion** — record that and stop (do not run on a thin universe). The probe's first step
+  is a coverage audit.
 - Window: 2024-01-01 → 2026-06-01 (same as Gate 1).
 
 ## Pulse criteria (encode in the probe)
@@ -118,8 +107,7 @@ uv run python scripts/rbi_loop_guard.py \
 2. **No symbol cherry-picking** to manufacture a pass — universe is liquidity-defined and fixed before the run.
 3. **Measure correlation/concentration; do not assume diversification.**
 4. **Long-only**, portfolio equal-weight (vol-target is a reported variant, not a tuned knob).
-5. Build daily bars from the **finest available** intraday TF per symbol (1h else 4h) — do not gate
-   on 1h. Only **< ~8** eligible symbols is a true blocked-on-ingestion stop; at ~8+ symbols, run.
+5. If data coverage is thin, the lane is **blocked on ingestion** — record and stop, don't run thin.
 
 ## Reviewer (Claude) checkpoints
 

--- a/docs/specs/macro-event-drift-probe-v0.md
+++ b/docs/specs/macro-event-drift-probe-v0.md
@@ -1,0 +1,140 @@
+# Lane Brief — Scheduled Macro-Event Drift Probe v0 (Gate 0)
+
+**Status:** Gate 0 (brief) → Gate 1 (cheap probe) pending
+**Author role:** planned by Claude (planner/reviewer); data-feasibility audit + cheap probe to be built by Grok (builder)
+**Predecessors / context:**
+- Trend family CLOSED: [daily-trend-breadth-probe-v0.md (report)](../reports/daily-trend-breadth-probe-v0.md) — NO_PULSE, shared-beta corr 0.59
+- Research rules / banned lanes / next-family ranking: [../reports/research-reset-2026-06-06.md](../reports/research-reset-2026-06-06.md) — **news/event calendar filter is the #1 unexplored family**
+
+---
+
+## Why this lane (first principles)
+
+Every closed lane to date used the **same explanatory variable**: price/volume structure on one
+or more crypto symbols (sweeps, ranges, trend, breadth, basis). They share one market beta and one
+information set, so they fail together. The research-reset runbook's explicit conclusion: the next
+primitive must require **new information**, not another OHLCV transform.
+
+The cheapest source of genuinely new, *exogenous*, *backtestable* information is the **scheduled
+US macro calendar** — FOMC decisions, CPI, and Nonfarm Payrolls (NFP). These are:
+- **Exogenous** to crypto price action (driven by the macro economy / Fed),
+- **Known ex-ante** — release timestamps are public and scheduled months ahead → **zero look-ahead
+  on the trigger** (the single hardest problem for any news lane),
+- **Free** and **static** (a small historical timestamp table, not a paid streaming API),
+- Increasingly relevant — since 2022 crypto trades heavily as a macro/liquidity risk asset.
+
+## The critical constraint that defines this lane
+
+**Backtestability requires point-in-time data.** The existing `sentiment-macro` agent uses a
+*runtime LLM* (xAI/DeepSeek) — that is **not backtestable** (you cannot replay what an LLM would
+have said in Jan 2024). This lane deliberately avoids LLM/news-feed sentiment for exactly that
+reason and uses the **scheduled calendar**, whose timestamps are objective and historically fixed.
+
+## Edge thesis (hypothesis to probe)
+
+Crypto (BTC/ETH/SOL) exhibits a **statistically reliable forward return and/or volatility
+signature in the window around scheduled high-impact US macro releases** — distinct from a random
+same-length window. Two sub-hypotheses, probe both, report separately:
+
+- **H1 (directional drift):** mean forward return in the event window (e.g. release → +6h / +24h)
+  differs reliably from baseline, with consistent sign across events → a tradeable long/short or
+  exposure tilt around scheduled events.
+- **H2 (volatility / risk gate):** realized vol in the event window is reliably elevated → a
+  risk-management overlay (cut size / sit out) rather than a standalone direction.
+
+H1 is the candidate-#2 directional prize; H2 is a weaker but still useful fallback. **If only H2
+holds, that is WEAK_EDGE** (overlay, not standalone) — record and decide, do not oversell.
+
+## STEP 0 — Data-source feasibility audit (the gate that comes before any edge test)
+
+The probe's **first and mandatory** step. Do not measure any edge until this passes.
+
+1. Identify a source of **historical release timestamps** for FOMC / CPI / NFP covering
+   **2024-01-01 → 2026-06-01**, with **release date AND time** (UTC), and an impact/actual/forecast
+   field if available. Acceptable: a free economic-calendar API, a public dataset, or a small
+   hand-verified static CSV committed to the repo (`data/macro_events/*.csv`). Document the source
+   and its licensing.
+2. **Verify timestamp quality** — releases must be timestamped to at least the hour (FOMC ~19:00
+   UTC, CPI/NFP ~13:30 UTC). Date-only is insufficient for a +6h window on a 24/7 asset; if only
+   date-only is obtainable, restrict windows to ≥ +24h and flag the precision loss.
+3. **Coverage / count check:** count usable events in-window. Expected ≈ FOMC 8/yr + CPI 12/yr +
+   NFP 12/yr ≈ **~32/yr × 2.4y ≈ 75 events**. This is the *event* count; trades count is per-symbol.
+4. If no source gives ≥ ~50 reliably-timestamped events over the window → **BLOCKED_ON_DATA**:
+   record what is missing and stop. Do not run an edge test on a thin/sloppy calendar.
+
+## Frozen event set (defined ex-ante — no event cherry-picking)
+
+Primary set: **FOMC rate decisions, US CPI, US NFP.** This set is fixed *before* any return is
+measured. Do **not** add ECB/PCE/jobless-claims/etc. *after* seeing results to manufacture a pass —
+that is multiple-testing fishing. (A pre-registered secondary set MAY be reported separately as a
+robustness check, clearly labelled, never to rescue a failed primary.)
+
+## Cheap probe plan (read-only, after Step 0 passes)
+
+1. Load the event timestamp table; align each event to BTC/ETH/SOL OHLCV (existing prod `ohlcv`,
+   1h, the symbols we already have deep history for).
+2. For each event and each forward horizon **{+6h, +24h, +72h}** (point-in-time, measured strictly
+   *after* the release timestamp — no bar overlapping the release):
+   - forward return (H1), and realized vol vs trailing baseline (H2).
+3. Compare event-window distribution vs a **matched random-window baseline** (same count, same
+   symbols, non-event timestamps).
+
+## Pulse criteria (encode in the probe)
+
+Per horizon, aggregated across the frozen event set:
+- **H1 PASS:** mean event-window forward return is **directionally consistent** (≥ ~60% same sign)
+  **and** materially exceeds the matched-baseline mean beyond a plausible fee/noise bar
+  (state the bar, e.g. > 0.3% net of one-way fee), on **≥2 of 3 symbols** at **≥1 horizon**.
+- **H2 PASS:** event-window realized vol exceeds baseline vol reliably (consistent across symbols).
+
+Verdict:
+- **HAS_PULSE** — H1 holds → write a bounded standalone event-window strategy surface, then Gate 2.
+- **WEAK_EDGE** — only H2 holds (vol/risk overlay, not standalone direction) → record; decide
+  whether a risk-gate is worth pursuing vs the next family. Do not reshape H1 by adding events.
+- **NO_PULSE** — neither holds → close; events are priced in / not predictive after fees.
+
+## Why this satisfies the allowed-next-family rules
+
+| Rule (reset doc) | This lane |
+|---|---|
+| Different primitive | **Exogenous macro calendar** — new information, not an OHLCV transform. |
+| Cheap probe first | Read-only, after a data-feasibility audit. |
+| Standalone surface | Not attached to the SOL overlay or sentiment-macro. |
+| WFO-realistic count | ~75 events × symbols; borderline — Step 0 count check is explicit. |
+| Independent directionality | Driven by the macro calendar, not crypto price/trend — genuinely independent of the long-biased live agents. |
+
+## Expected failure modes (do not oversell)
+
+- **Priced in:** efficient reaction means no exploitable *forward* drift after the release → NO_PULSE.
+- **Sign inconsistency:** events cut both ways (hot vs cold print) without the actual-vs-forecast
+  surprise, which a pure-calendar probe does not have → low directional consistency → at best H2.
+- **Too few events for WFO** even if the in-sample signature looks real (the AVAX/ETH precedent).
+- **Timestamp sloppiness** introducing look-ahead — guard hard in Step 0.
+
+## Validation command plan
+
+```bash
+# Step 0 + Gate 1 cheap probe (read-only)
+uv run python scripts/probe_macro_event_drift.py --json   # builder to create
+
+uv run python scripts/rbi_loop_guard.py \
+  --lane-brief docs/specs/macro-event-drift-probe-v0.md \
+  --probe-verdict <HAS_PULSE|WEAK_EDGE|NO_PULSE> --pretty
+```
+
+## Guardrails (do not violate)
+
+1. **Point-in-time only** — forward windows start strictly after the release timestamp; no bar
+   overlapping the release; no use of actual/forecast values the probe could not have known pre-release.
+2. **Frozen event set** (FOMC/CPI/NFP) defined before measuring returns; no post-hoc event additions
+   to rescue a fail.
+3. **Standalone**, long-and-short allowed (this is where independent directionality is welcome).
+4. **Data audit is gate 0** — thin/sloppy calendar → BLOCKED_ON_DATA, stop; do not run on bad timestamps.
+5. If only H2 (vol) holds → WEAK_EDGE, not HAS_PULSE. Be honest about overlay-vs-standalone.
+
+## Reviewer (Claude) checkpoints
+
+(a) data source documented + timestamp precision honest; (b) point-in-time alignment verified (no
+look-ahead, no release-overlapping bar); (c) event set frozen ex-ante; (d) event-window metrics
+compared to a matched random baseline, not vs zero; (e) verdict HAS_PULSE/WEAK_EDGE/NO_PULSE stated
+honestly with per-symbol/per-horizon numbers and the event count attached.

--- a/scripts/probe_daily_trend_breadth.py
+++ b/scripts/probe_daily_trend_breadth.py
@@ -51,32 +51,33 @@ PROBE_QUERY = """
 COVERAGE_QUERY = """
     SELECT
         symbol,
+        timeframe,
         COUNT(*) AS bars,
         MIN(time) AS first_ts,
         MAX(time) AS last_ts,
         SUM(volume * close_price) AS quote_volume
     FROM ohlcv
-    WHERE timeframe = $1
-      AND symbol LIKE '%USDT'
-    GROUP BY symbol
-    ORDER BY quote_volume DESC NULLS LAST
+    WHERE symbol LIKE '%USDT'
+      AND symbol NOT LIKE 'TEST%'
+      AND timeframe = ANY($1::text[])
+    GROUP BY symbol, timeframe
 """
 
 TRADING_DAYS_PER_YEAR = 365
+INTRADAY_TIMEFRAMES = ("1h", "4h")
 SMA_WINDOW = 50
-MIN_UNIVERSE_SYMBOLS = 15
+MIN_UNIVERSE_SYMBOLS = 8
 TARGET_UNIVERSE_SYMBOLS = 20
 MIN_HISTORY_DAYS = 700
 WFO_OOS_MONTHS = 2
 MIN_STATE_CHANGES_PER_OOS = 20
 MAX_CONCENTRATION_PCT = 50.0
-MAJORS_ONLY = frozenset({"BTCUSDT", "ETHUSDT", "SOLUSDT"})
 BLOCKED_STATUS = "BLOCKED_ON_INGESTION"
 
 
 @dataclass(frozen=True)
 class ProbeConfig:
-    source_timeframe: str
+    intraday_timeframes: tuple[str, ...]
     start: str
     end: str
     sma_window: int
@@ -93,6 +94,7 @@ class ProbeConfig:
 @dataclass(frozen=True)
 class CoverageRow:
     symbol: str
+    source_timeframe: str
     bars: int
     first_ts: datetime
     last_ts: datetime
@@ -105,6 +107,7 @@ class CoverageAudit:
     rows: tuple[CoverageRow, ...]
     eligible: tuple[CoverageRow, ...]
     universe: tuple[str, ...]
+    symbol_timeframes: tuple[tuple[str, str], ...]
     blocked: bool
     blocked_reason: str | None
 
@@ -233,6 +236,19 @@ def _mean_pairwise_signal_correlation(signals: Mapping[str, Sequence[int]]) -> f
     return _mean(correlations) if correlations else 0.0
 
 
+def select_finest_tf_rows(
+    rows: Sequence[Mapping[str, object]],
+) -> list[Mapping[str, object]]:
+    """Pick finest intraday TF per symbol (prefer 1h, else 4h)."""
+    finest: dict[str, Mapping[str, object]] = {}
+    for row in rows:
+        symbol = str(row["symbol"])
+        timeframe = str(row["timeframe"])
+        if symbol not in finest or timeframe == "1h":
+            finest[symbol] = row
+    return list(finest.values())
+
+
 def build_coverage_audit(
     rows: Sequence[Mapping[str, object]],
     *,
@@ -241,7 +257,7 @@ def build_coverage_audit(
     target_universe_symbols: int,
 ) -> CoverageAudit:
     materialized: list[CoverageRow] = []
-    for row in rows:
+    for row in select_finest_tf_rows(rows):
         first_ts = row["first_ts"]
         last_ts = row["last_ts"]
         if not isinstance(first_ts, datetime) or not isinstance(last_ts, datetime):
@@ -250,6 +266,7 @@ def build_coverage_audit(
         materialized.append(
             CoverageRow(
                 symbol=str(row["symbol"]),
+                source_timeframe=str(row["timeframe"]),
                 bars=int(row["bars"]),
                 first_ts=first_ts,
                 last_ts=last_ts,
@@ -267,25 +284,22 @@ def build_coverage_audit(
     )
     universe_rows = eligible[:target_universe_symbols]
     universe = tuple(row.symbol for row in universe_rows)
+    symbol_timeframes = tuple((row.symbol, row.source_timeframe) for row in universe_rows)
 
     blocked = False
     blocked_reason: str | None = None
     if len(eligible) < min_universe_symbols:
         blocked = True
         blocked_reason = (
-            f"only {len(eligible)} USDT pairs have >={min_history_days}d of 1h history; "
-            f"need >={min_universe_symbols}"
-        )
-    elif universe and set(universe).issubset(MAJORS_ONLY):
-        blocked = True
-        blocked_reason = (
-            "universe collapses to BTC/ETH/SOL only — insufficient breadth in prod ohlcv"
+            f"only {len(eligible)} USDT pairs have >={min_history_days}d intraday history "
+            f"(finest 1h/4h); need >={min_universe_symbols}"
         )
 
     return CoverageAudit(
         rows=tuple(materialized),
         eligible=eligible,
         universe=universe,
+        symbol_timeframes=symbol_timeframes,
         blocked=blocked,
         blocked_reason=blocked_reason,
     )
@@ -549,7 +563,7 @@ def decide_verdict(
 
 def default_config() -> ProbeConfig:
     return ProbeConfig(
-        source_timeframe="1h",
+        intraday_timeframes=INTRADAY_TIMEFRAMES,
         start="2024-01-01T00:00:00",
         end="2026-06-01T00:00:00",
         sma_window=SMA_WINDOW,
@@ -568,7 +582,7 @@ async def run_coverage_audit(config: ProbeConfig) -> CoverageAudit:
     pool = await init_pool(build_db_config())
     try:
         async with pool.acquire() as conn:
-            rows = await conn.fetch(COVERAGE_QUERY, config.source_timeframe)
+            rows = await conn.fetch(COVERAGE_QUERY, list(config.intraday_timeframes))
         return build_coverage_audit(
             rows,
             min_history_days=config.min_history_days,
@@ -580,18 +594,18 @@ async def run_coverage_audit(config: ProbeConfig) -> CoverageAudit:
 
 
 async def load_symbol_bars(
-    symbols: Sequence[str],
+    symbol_timeframes: Sequence[tuple[str, str]],
     config: ProbeConfig,
 ) -> dict[str, list[DailyBar]]:
     pool = await init_pool(build_db_config())
     bars_by_symbol: dict[str, list[DailyBar]] = {}
     try:
-        for symbol in symbols:
+        for symbol, timeframe in symbol_timeframes:
             async with pool.acquire() as conn:
                 rows = await conn.fetch(
                     PROBE_QUERY,
                     symbol,
-                    config.source_timeframe,
+                    timeframe,
                     datetime.fromisoformat(config.start),
                     datetime.fromisoformat(config.end),
                 )
@@ -626,7 +640,7 @@ async def run_probe(config: ProbeConfig) -> ProbeReport:
             reasons=reasons,
         )
 
-    bars_by_symbol = await load_symbol_bars(coverage.universe, config)
+    bars_by_symbol = await load_symbol_bars(coverage.symbol_timeframes, config)
     metrics = evaluate_portfolio_breadth(
         bars_by_symbol,
         sma_window=config.sma_window,
@@ -674,7 +688,7 @@ def render_report(report: ProbeReport) -> str:
     lines.append("")
     lines.append("## Coverage audit")
     lines.append(
-        f"- USDT pairs with 1h rows: **{len(report.coverage.rows)}** "
+        f"- USDT pairs (finest 1h/4h per symbol): **{len(report.coverage.rows)}** "
         f"(eligible >={report.config.min_history_days}d: **{len(report.coverage.eligible)}**)"
     )
     lines.append(
@@ -685,11 +699,11 @@ def render_report(report: ProbeReport) -> str:
         lines.append(f"- **Blocked:** {report.coverage.blocked_reason}")
     lines.append("")
     if report.coverage.eligible:
-        lines.append("| Symbol | Bars | Span (d) | First | Quote vol |")
-        lines.append("|--------|------|----------|-------|-----------|")
+        lines.append("| Symbol | TF | Bars | Span (d) | First | Quote vol |")
+        lines.append("|--------|----|------|----------|-------|-----------|")
         for row in report.coverage.eligible:
             lines.append(
-                f"| {row.symbol} | {row.bars} | {row.span_days} | "
+                f"| {row.symbol} | {row.source_timeframe} | {row.bars} | {row.span_days} | "
                 f"{row.first_ts.date()} | {row.quote_volume:.2e} |"
             )
         lines.append("")
@@ -770,9 +784,11 @@ def report_to_json(report: ProbeReport) -> dict[str, object]:
             "blocked_reason": report.coverage.blocked_reason,
             "eligible_count": len(report.coverage.eligible),
             "universe": list(report.coverage.universe),
+            "symbol_timeframes": list(report.coverage.symbol_timeframes),
             "eligible": [
                 {
                     "symbol": row.symbol,
+                    "source_timeframe": row.source_timeframe,
                     "bars": row.bars,
                     "span_days": row.span_days,
                     "first_ts": row.first_ts.isoformat(),

--- a/scripts/probe_daily_trend_breadth.py
+++ b/scripts/probe_daily_trend_breadth.py
@@ -1,0 +1,834 @@
+#!/usr/bin/env python3
+"""Cheap feasibility probe for daily-trend breadth (portfolio SMA50 long-only).
+
+Read-only: ohlcv only. Tests whether expanding the validated per-symbol SMA50
+long-only rule across a liquid USDT universe lowers profit concentration and
+raises effective trade count vs the 3-symbol Gate 2 failure — without changing
+the rule or adding knobs.
+
+See docs/specs/daily-trend-breadth-probe-v0.md and research-reset-2026-06-06.md.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import math
+import statistics
+import sys
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from scripts.probe_higher_tf_trend_following import (
+    DailyBar,
+    build_db_config,
+    resample_daily,
+)
+from src.db import close_pool, init_pool
+from src.utils.logger import configure_logger, get_logger
+
+PROBE_QUERY = """
+    SELECT
+        time,
+        open_price,
+        high_price,
+        low_price,
+        close_price,
+        volume
+    FROM ohlcv
+    WHERE symbol = $1
+      AND timeframe = $2
+      AND time >= $3
+      AND time <= $4
+    ORDER BY time ASC
+"""
+
+COVERAGE_QUERY = """
+    SELECT
+        symbol,
+        COUNT(*) AS bars,
+        MIN(time) AS first_ts,
+        MAX(time) AS last_ts,
+        SUM(volume * close_price) AS quote_volume
+    FROM ohlcv
+    WHERE timeframe = $1
+      AND symbol LIKE '%USDT'
+    GROUP BY symbol
+    ORDER BY quote_volume DESC NULLS LAST
+"""
+
+TRADING_DAYS_PER_YEAR = 365
+SMA_WINDOW = 50
+MIN_UNIVERSE_SYMBOLS = 15
+TARGET_UNIVERSE_SYMBOLS = 20
+MIN_HISTORY_DAYS = 700
+WFO_OOS_MONTHS = 2
+MIN_STATE_CHANGES_PER_OOS = 20
+MAX_CONCENTRATION_PCT = 50.0
+MAJORS_ONLY = frozenset({"BTCUSDT", "ETHUSDT", "SOLUSDT"})
+BLOCKED_STATUS = "BLOCKED_ON_INGESTION"
+
+
+@dataclass(frozen=True)
+class ProbeConfig:
+    source_timeframe: str
+    start: str
+    end: str
+    sma_window: int
+    one_way_fee_pct: float
+    min_universe_symbols: int
+    target_universe_symbols: int
+    min_history_days: int
+    wfo_oos_months: int
+    min_state_changes_per_oos: int
+    max_concentration_pct: float
+    vol_lookback_days: int
+
+
+@dataclass(frozen=True)
+class CoverageRow:
+    symbol: str
+    bars: int
+    first_ts: datetime
+    last_ts: datetime
+    span_days: int
+    quote_volume: float
+
+
+@dataclass(frozen=True)
+class CoverageAudit:
+    rows: tuple[CoverageRow, ...]
+    eligible: tuple[CoverageRow, ...]
+    universe: tuple[str, ...]
+    blocked: bool
+    blocked_reason: str | None
+
+
+@dataclass(frozen=True)
+class PortfolioMetrics:
+    n_days: int
+    n_symbols: int
+    total_state_changes: int
+    state_changes_per_oos_window: float
+    max_symbol_pnl_share_pct: float
+    mean_pairwise_signal_corr: float
+    strat_total_return_pct: float
+    bh_total_return_pct: float
+    strat_sharpe: float
+    bh_sharpe: float
+    strat_max_dd_pct: float
+    bh_max_dd_pct: float
+    vol_target_total_return_pct: float
+    vol_target_sharpe: float
+    vol_target_max_dd_pct: float
+    per_symbol_pnl_pct: tuple[tuple[str, float], ...]
+    per_symbol_switches: tuple[tuple[str, int], ...]
+
+    @property
+    def concentration_passes(self) -> bool:
+        return self.max_symbol_pnl_share_pct < MAX_CONCENTRATION_PCT
+
+    @property
+    def trade_count_passes(self) -> bool:
+        return self.state_changes_per_oos_window >= MIN_STATE_CHANGES_PER_OOS
+
+    @property
+    def risk_adjusted_passes(self) -> bool:
+        return self.strat_sharpe >= self.bh_sharpe and self.strat_max_dd_pct < self.bh_max_dd_pct
+
+
+@dataclass(frozen=True)
+class ProbeReport:
+    config: ProbeConfig
+    coverage: CoverageAudit
+    metrics: PortfolioMetrics | None
+    status: str
+    verdict: str
+    reasons: tuple[str, ...]
+
+
+def _mean(values: Sequence[float]) -> float:
+    materialized = list(values)
+    if not materialized:
+        return 0.0
+    return sum(materialized) / len(materialized)
+
+
+def _simple_moving_average(values: Sequence[float], window: int) -> list[float | None]:
+    out: list[float | None] = []
+    running = 0.0
+    for index, value in enumerate(values):
+        running += value
+        if index >= window:
+            running -= values[index - window]
+        out.append(running / window if index >= window - 1 else None)
+    return out
+
+
+def _sharpe(daily_returns: Sequence[float]) -> float:
+    if len(daily_returns) < 2:
+        return 0.0
+    stdev = statistics.pstdev(daily_returns)
+    if stdev <= 0:
+        return 0.0
+    return _mean(daily_returns) / stdev * math.sqrt(TRADING_DAYS_PER_YEAR)
+
+
+def _max_drawdown_pct(daily_returns: Sequence[float]) -> float:
+    equity = 1.0
+    peak = 1.0
+    max_dd = 0.0
+    for ret in daily_returns:
+        equity *= 1.0 + ret
+        peak = max(peak, equity)
+        if peak > 0:
+            drawdown = (peak - equity) / peak
+            max_dd = max(max_dd, drawdown)
+    return max_dd * 100.0
+
+
+def _total_return_pct(daily_returns: Sequence[float]) -> float:
+    equity = 1.0
+    for ret in daily_returns:
+        equity *= 1.0 + ret
+    return (equity - 1.0) * 100.0
+
+
+def _pearson(xs: Sequence[float], ys: Sequence[float]) -> float:
+    if len(xs) < 2 or len(xs) != len(ys):
+        return 0.0
+    mx = _mean(xs)
+    my = _mean(ys)
+    num = sum((x - mx) * (y - my) for x, y in zip(xs, ys, strict=True))
+    den_x = math.sqrt(sum((x - mx) ** 2 for x in xs))
+    den_y = math.sqrt(sum((y - my) ** 2 for y in ys))
+    if den_x <= 0 or den_y <= 0:
+        return 0.0
+    return num / (den_x * den_y)
+
+
+def _max_symbol_pnl_share(per_symbol_pnl: Sequence[tuple[str, float]]) -> float:
+    positive = [max(pnl, 0.0) for _, pnl in per_symbol_pnl]
+    total = sum(positive)
+    if total <= 0:
+        return 100.0
+    return max(positive) / total * 100.0
+
+
+def _mean_pairwise_signal_correlation(signals: Mapping[str, Sequence[int]]) -> float:
+    symbols = sorted(signals)
+    if len(symbols) < 2:
+        return 0.0
+    correlations: list[float] = []
+    for left_index, left in enumerate(symbols[:-1]):
+        left_sig = [float(v) for v in signals[left]]
+        for right in symbols[left_index + 1 :]:
+            right_sig = [float(v) for v in signals[right]]
+            correlations.append(_pearson(left_sig, right_sig))
+    return _mean(correlations) if correlations else 0.0
+
+
+def build_coverage_audit(
+    rows: Sequence[Mapping[str, object]],
+    *,
+    min_history_days: int,
+    min_universe_symbols: int,
+    target_universe_symbols: int,
+) -> CoverageAudit:
+    materialized: list[CoverageRow] = []
+    for row in rows:
+        first_ts = row["first_ts"]
+        last_ts = row["last_ts"]
+        if not isinstance(first_ts, datetime) or not isinstance(last_ts, datetime):
+            continue
+        span_days = (last_ts - first_ts).days
+        materialized.append(
+            CoverageRow(
+                symbol=str(row["symbol"]),
+                bars=int(row["bars"]),
+                first_ts=first_ts,
+                last_ts=last_ts,
+                span_days=span_days,
+                quote_volume=float(row["quote_volume"] or 0.0),
+            )
+        )
+
+    eligible = tuple(
+        sorted(
+            (row for row in materialized if row.span_days >= min_history_days),
+            key=lambda row: row.quote_volume,
+            reverse=True,
+        )
+    )
+    universe_rows = eligible[:target_universe_symbols]
+    universe = tuple(row.symbol for row in universe_rows)
+
+    blocked = False
+    blocked_reason: str | None = None
+    if len(eligible) < min_universe_symbols:
+        blocked = True
+        blocked_reason = (
+            f"only {len(eligible)} USDT pairs have >={min_history_days}d of 1h history; "
+            f"need >={min_universe_symbols}"
+        )
+    elif universe and set(universe).issubset(MAJORS_ONLY):
+        blocked = True
+        blocked_reason = (
+            "universe collapses to BTC/ETH/SOL only — insufficient breadth in prod ohlcv"
+        )
+
+    return CoverageAudit(
+        rows=tuple(materialized),
+        eligible=eligible,
+        universe=universe,
+        blocked=blocked,
+        blocked_reason=blocked_reason,
+    )
+
+
+def _symbol_positions_and_returns(
+    bars: Sequence[DailyBar],
+    sma_window: int,
+    fee_pct: float,
+) -> tuple[list[datetime], list[int], list[float], list[float], int, float]:
+    """Return days, positions, net returns, gross returns, switches, total return %."""
+    closes = [bar.close_price for bar in bars]
+    days = [bar.day for bar in bars]
+    sma = _simple_moving_average(closes, sma_window)
+    first = sma_window
+    if first >= len(closes) - 1:
+        return [], [], [], [], 0, 0.0
+
+    fee = fee_pct / 100.0
+    out_days: list[datetime] = []
+    positions: list[int] = []
+    net_returns: list[float] = []
+    gross_returns: list[float] = []
+    prev_position = 0
+    switches = 0
+
+    for t in range(first, len(closes)):
+        prior_sma = sma[t - 1]
+        if prior_sma is None:
+            continue
+        position = 1 if closes[t - 1] > prior_sma else 0
+        daily_ret = closes[t] / closes[t - 1] - 1.0
+        cost = fee if position != prev_position else 0.0
+        out_days.append(days[t])
+        positions.append(position)
+        gross_returns.append(daily_ret)
+        net_returns.append(position * daily_ret - cost)
+        if position != prev_position:
+            switches += 1
+        prev_position = position
+
+    return out_days, positions, net_returns, gross_returns, switches, _total_return_pct(net_returns)
+
+
+def _weights_equal(long_symbols: Sequence[str]) -> dict[str, float]:
+    if not long_symbols:
+        return {}
+    weight = 1.0 / len(long_symbols)
+    return dict.fromkeys(long_symbols, weight)
+
+
+def _weights_vol_target(
+    long_symbols: Sequence[str],
+    trailing_vols: Mapping[str, float],
+) -> dict[str, float]:
+    if not long_symbols:
+        return {}
+    inv_vols = {symbol: 1.0 / max(trailing_vols.get(symbol, 0.0), 1e-8) for symbol in long_symbols}
+    total = sum(inv_vols.values())
+    if total <= 0:
+        return _weights_equal(long_symbols)
+    return {symbol: inv_vols[symbol] / total for symbol in long_symbols}
+
+
+def _portfolio_day_return(
+    long_symbols: Sequence[str],
+    gross_returns: Mapping[str, float],
+    weights: Mapping[str, float],
+) -> float:
+    if not long_symbols:
+        return 0.0
+    return sum(weights[symbol] * gross_returns[symbol] for symbol in long_symbols)
+
+
+def _fee_cost(
+    symbols: Sequence[str],
+    prev_positions: Mapping[str, int],
+    positions: Mapping[str, int],
+    prev_weights: Mapping[str, float],
+    new_weights: Mapping[str, float],
+    fee: float,
+) -> float:
+    cost = 0.0
+    for symbol in symbols:
+        if positions[symbol] == prev_positions[symbol]:
+            continue
+        old_weight = prev_weights.get(symbol, 0.0)
+        new_weight = new_weights.get(symbol, 0.0)
+        cost += fee * abs(new_weight - old_weight)
+    return cost
+
+
+def evaluate_portfolio_breadth(
+    symbol_bars: Mapping[str, Sequence[DailyBar]],
+    *,
+    sma_window: int,
+    fee_pct: float,
+    vol_lookback_days: int,
+    wfo_oos_months: int,
+) -> PortfolioMetrics | None:
+    """Simulate equal-weight and vol-target breadth portfolios on aligned days."""
+    per_symbol: dict[
+        str, tuple[list[datetime], list[int], list[float], list[float], int, float]
+    ] = {}
+    for symbol, bars in symbol_bars.items():
+        days, positions, net_returns, gross_returns, switches, total_ret = (
+            _symbol_positions_and_returns(bars, sma_window, fee_pct)
+        )
+        if not days:
+            continue
+        per_symbol[symbol] = (
+            days,
+            positions,
+            net_returns,
+            gross_returns,
+            switches,
+            total_ret,
+        )
+
+    if len(per_symbol) < 2:
+        return None
+
+    common_days = sorted(set.intersection(*[set(days) for days, *_ in per_symbol.values()]))
+    if len(common_days) < sma_window + 5:
+        return None
+
+    symbols = sorted(per_symbol)
+    fee = fee_pct / 100.0
+
+    aligned_positions: dict[str, list[int]] = {}
+    aligned_gross: dict[str, list[float]] = {}
+    per_symbol_pnl: list[tuple[str, float]] = []
+    per_symbol_switches: list[tuple[str, int]] = []
+    total_state_changes = 0
+
+    for symbol in symbols:
+        days, positions, _net, gross, switches, total_ret = per_symbol[symbol]
+        lookup_pos = dict(zip(days, positions, strict=True))
+        lookup_gross = dict(zip(days, gross, strict=True))
+        aligned_positions[symbol] = [lookup_pos[day] for day in common_days]
+        aligned_gross[symbol] = [lookup_gross[day] for day in common_days]
+        per_symbol_pnl.append((symbol, total_ret))
+        per_symbol_switches.append((symbol, switches))
+        total_state_changes += switches
+
+    strat_returns: list[float] = []
+    bh_returns: list[float] = []
+    vol_returns: list[float] = []
+    gross_history: dict[str, list[float]] = {symbol: [] for symbol in symbols}
+    prev_positions = dict.fromkeys(symbols, 0)
+    prev_equal_weights = dict.fromkeys(symbols, 0.0)
+    prev_vol_weights = dict.fromkeys(symbols, 0.0)
+
+    for day_index, _day in enumerate(common_days):
+        positions_today = {symbol: aligned_positions[symbol][day_index] for symbol in symbols}
+        gross_today = {symbol: aligned_gross[symbol][day_index] for symbol in symbols}
+        long_symbols = [symbol for symbol in symbols if positions_today[symbol] == 1]
+
+        equal_weights = _weights_equal(long_symbols)
+        trailing_vols = {
+            symbol: statistics.pstdev(gross_history[symbol][-vol_lookback_days:])
+            if len(gross_history[symbol]) >= 2
+            else 0.0
+            for symbol in symbols
+        }
+        vol_weights = _weights_vol_target(long_symbols, trailing_vols)
+
+        equal_gross = _portfolio_day_return(long_symbols, gross_today, equal_weights)
+        equal_fee = _fee_cost(
+            symbols,
+            prev_positions,
+            positions_today,
+            prev_equal_weights,
+            equal_weights,
+            fee,
+        )
+        strat_returns.append(equal_gross - equal_fee)
+
+        vol_gross = _portfolio_day_return(long_symbols, gross_today, vol_weights)
+        vol_fee = _fee_cost(
+            symbols,
+            prev_positions,
+            positions_today,
+            prev_vol_weights,
+            vol_weights,
+            fee,
+        )
+        vol_returns.append(vol_gross - vol_fee)
+
+        bh_returns.append(_mean(gross_today.values()))
+
+        for symbol in symbols:
+            gross_history[symbol].append(gross_today[symbol])
+        prev_positions = positions_today
+        prev_equal_weights = {symbol: equal_weights.get(symbol, 0.0) for symbol in symbols}
+        prev_vol_weights = {symbol: vol_weights.get(symbol, 0.0) for symbol in symbols}
+
+    oos_window_days = max(wfo_oos_months * 30, 1)
+    state_changes_per_oos = total_state_changes / max(len(common_days) / oos_window_days, 1.0)
+
+    return PortfolioMetrics(
+        n_days=len(common_days),
+        n_symbols=len(symbols),
+        total_state_changes=total_state_changes,
+        state_changes_per_oos_window=state_changes_per_oos,
+        max_symbol_pnl_share_pct=_max_symbol_pnl_share(per_symbol_pnl),
+        mean_pairwise_signal_corr=_mean_pairwise_signal_correlation(aligned_positions),
+        strat_total_return_pct=_total_return_pct(strat_returns),
+        bh_total_return_pct=_total_return_pct(bh_returns),
+        strat_sharpe=_sharpe(strat_returns),
+        bh_sharpe=_sharpe(bh_returns),
+        strat_max_dd_pct=_max_drawdown_pct(strat_returns),
+        bh_max_dd_pct=_max_drawdown_pct(bh_returns),
+        vol_target_total_return_pct=_total_return_pct(vol_returns),
+        vol_target_sharpe=_sharpe(vol_returns),
+        vol_target_max_dd_pct=_max_drawdown_pct(vol_returns),
+        per_symbol_pnl_pct=tuple(per_symbol_pnl),
+        per_symbol_switches=tuple(per_symbol_switches),
+    )
+
+
+def decide_verdict(
+    metrics: PortfolioMetrics | None,
+    *,
+    blocked: bool,
+) -> tuple[str, str, tuple[str, ...]]:
+    if blocked:
+        return (
+            BLOCKED_STATUS,
+            "NO_PULSE",
+            ("blocked on ingestion — thin prod ohlcv universe; pulse metrics not run",),
+        )
+    if metrics is None:
+        return ("ERROR", "NO_PULSE", ("portfolio metrics unavailable",))
+
+    reasons: list[str] = []
+    if not metrics.concentration_passes:
+        reasons.append(
+            f"concentration {metrics.max_symbol_pnl_share_pct:.1f}% >= {MAX_CONCENTRATION_PCT:.0f}%"
+        )
+    if not metrics.trade_count_passes:
+        reasons.append(
+            f"state changes per OOS window {metrics.state_changes_per_oos_window:.1f} "
+            f"< {MIN_STATE_CHANGES_PER_OOS}"
+        )
+    if not metrics.risk_adjusted_passes:
+        reasons.append(
+            f"risk-adjusted edge missing (Sharpe {metrics.strat_sharpe:.2f} vs "
+            f"{metrics.bh_sharpe:.2f}, DD {metrics.strat_max_dd_pct:.1f}% vs "
+            f"{metrics.bh_max_dd_pct:.1f}%)"
+        )
+
+    if metrics.concentration_passes and metrics.trade_count_passes and metrics.risk_adjusted_passes:
+        return ("OK", "HAS_PULSE", tuple(reasons))
+
+    if metrics.risk_adjusted_passes:
+        return ("OK", "WEAK_EDGE", tuple(reasons))
+
+    return ("OK", "NO_PULSE", tuple(reasons))
+
+
+def default_config() -> ProbeConfig:
+    return ProbeConfig(
+        source_timeframe="1h",
+        start="2024-01-01T00:00:00",
+        end="2026-06-01T00:00:00",
+        sma_window=SMA_WINDOW,
+        one_way_fee_pct=0.04,
+        min_universe_symbols=MIN_UNIVERSE_SYMBOLS,
+        target_universe_symbols=TARGET_UNIVERSE_SYMBOLS,
+        min_history_days=MIN_HISTORY_DAYS,
+        wfo_oos_months=WFO_OOS_MONTHS,
+        min_state_changes_per_oos=MIN_STATE_CHANGES_PER_OOS,
+        max_concentration_pct=MAX_CONCENTRATION_PCT,
+        vol_lookback_days=20,
+    )
+
+
+async def run_coverage_audit(config: ProbeConfig) -> CoverageAudit:
+    pool = await init_pool(build_db_config())
+    try:
+        async with pool.acquire() as conn:
+            rows = await conn.fetch(COVERAGE_QUERY, config.source_timeframe)
+        return build_coverage_audit(
+            rows,
+            min_history_days=config.min_history_days,
+            min_universe_symbols=config.min_universe_symbols,
+            target_universe_symbols=config.target_universe_symbols,
+        )
+    finally:
+        await close_pool()
+
+
+async def load_symbol_bars(
+    symbols: Sequence[str],
+    config: ProbeConfig,
+) -> dict[str, list[DailyBar]]:
+    pool = await init_pool(build_db_config())
+    bars_by_symbol: dict[str, list[DailyBar]] = {}
+    try:
+        for symbol in symbols:
+            async with pool.acquire() as conn:
+                rows = await conn.fetch(
+                    PROBE_QUERY,
+                    symbol,
+                    config.source_timeframe,
+                    datetime.fromisoformat(config.start),
+                    datetime.fromisoformat(config.end),
+                )
+            bars_by_symbol[symbol] = resample_daily(rows)
+    finally:
+        await close_pool()
+    return bars_by_symbol
+
+
+async def run_probe(config: ProbeConfig) -> ProbeReport:
+    configure_logger("INFO")
+    logger = get_logger("probe.daily_trend_breadth")
+
+    coverage = await run_coverage_audit(config)
+    logger.info(
+        "coverage audit: %d USDT pairs, %d eligible (>=%dd), universe=%s, blocked=%s",
+        len(coverage.rows),
+        len(coverage.eligible),
+        config.min_history_days,
+        ",".join(coverage.universe) or "(none)",
+        coverage.blocked,
+    )
+    if coverage.blocked:
+        logger.warning("blocked on ingestion: %s", coverage.blocked_reason)
+        status, verdict, reasons = decide_verdict(None, blocked=True)
+        return ProbeReport(
+            config=config,
+            coverage=coverage,
+            metrics=None,
+            status=status,
+            verdict=verdict,
+            reasons=reasons,
+        )
+
+    bars_by_symbol = await load_symbol_bars(coverage.universe, config)
+    metrics = evaluate_portfolio_breadth(
+        bars_by_symbol,
+        sma_window=config.sma_window,
+        fee_pct=config.one_way_fee_pct,
+        vol_lookback_days=config.vol_lookback_days,
+        wfo_oos_months=config.wfo_oos_months,
+    )
+    if metrics is None:
+        logger.error("portfolio metrics could not be computed")
+    else:
+        logger.info(
+            "portfolio: symbols=%d conc=%.1f%% trades/oos=%.1f sharpe=%.2f/%.2f dd=%.1f/%.1f corr=%.2f",
+            metrics.n_symbols,
+            metrics.max_symbol_pnl_share_pct,
+            metrics.state_changes_per_oos_window,
+            metrics.strat_sharpe,
+            metrics.bh_sharpe,
+            metrics.strat_max_dd_pct,
+            metrics.bh_max_dd_pct,
+            metrics.mean_pairwise_signal_corr,
+        )
+
+    status, verdict, reasons = decide_verdict(metrics, blocked=False)
+    return ProbeReport(
+        config=config,
+        coverage=coverage,
+        metrics=metrics,
+        status=status,
+        verdict=verdict,
+        reasons=reasons,
+    )
+
+
+def render_report(report: ProbeReport) -> str:
+    lines: list[str] = []
+    lines.append("# Daily Trend-Following Breadth Probe — Report")
+    lines.append("")
+    lines.append(f"**Verdict:** **{report.verdict}**")
+    if report.status == BLOCKED_STATUS:
+        lines.append(f"**Status:** **{report.status}**")
+    lines.append("**Script:** `scripts/probe_daily_trend_breadth.py`")
+    lines.append(
+        "**Spec:** [daily-trend-breadth-probe-v0.md](../specs/daily-trend-breadth-probe-v0.md)"
+    )
+    lines.append("")
+    lines.append("## Coverage audit")
+    lines.append(
+        f"- USDT pairs with 1h rows: **{len(report.coverage.rows)}** "
+        f"(eligible >={report.config.min_history_days}d: **{len(report.coverage.eligible)}**)"
+    )
+    lines.append(
+        f"- Target universe (top {report.config.target_universe_symbols} by liquidity): "
+        + (", ".join(report.coverage.universe) if report.coverage.universe else "(none)")
+    )
+    if report.coverage.blocked:
+        lines.append(f"- **Blocked:** {report.coverage.blocked_reason}")
+    lines.append("")
+    if report.coverage.eligible:
+        lines.append("| Symbol | Bars | Span (d) | First | Quote vol |")
+        lines.append("|--------|------|----------|-------|-----------|")
+        for row in report.coverage.eligible:
+            lines.append(
+                f"| {row.symbol} | {row.bars} | {row.span_days} | "
+                f"{row.first_ts.date()} | {row.quote_volume:.2e} |"
+            )
+        lines.append("")
+
+    if report.metrics is None:
+        lines.append("## Pulse metrics")
+        lines.append("")
+        lines.append("Not run — coverage gate failed.")
+        if report.reasons:
+            lines.append("")
+            for reason in report.reasons:
+                lines.append(f"- {reason}")
+        return "\n".join(lines)
+
+    metrics = report.metrics
+    lines.append("## Config")
+    lines.append(f"- SMA window: {report.config.sma_window} (frozen)")
+    lines.append(f"- Window: {report.config.start} → {report.config.end}")
+    lines.append(f"- One-way fee: {report.config.one_way_fee_pct}%")
+    lines.append(f"- Universe size: {metrics.n_symbols}")
+    lines.append("")
+    lines.append("## Pulse metrics (equal-weight portfolio)")
+    lines.append("")
+    lines.append("| Metric | Value | Gate | Pass |")
+    lines.append("|--------|-------|------|------|")
+    lines.append(
+        f"| Max single-symbol PnL share | {metrics.max_symbol_pnl_share_pct:.1f}% | "
+        f"< {report.config.max_concentration_pct:.0f}% | {metrics.concentration_passes} |"
+    )
+    lines.append(
+        f"| State changes / OOS window ({report.config.wfo_oos_months}mo) | "
+        f"{metrics.state_changes_per_oos_window:.1f} | "
+        f">= {report.config.min_state_changes_per_oos} | {metrics.trade_count_passes} |"
+    )
+    lines.append(
+        f"| Portfolio Sharpe | {metrics.strat_sharpe:.2f} | >= BH {metrics.bh_sharpe:.2f} | "
+        f"{metrics.strat_sharpe >= metrics.bh_sharpe} |"
+    )
+    lines.append(
+        f"| Portfolio max DD | {metrics.strat_max_dd_pct:.1f}% | < BH "
+        f"{metrics.bh_max_dd_pct:.1f}% | {metrics.strat_max_dd_pct < metrics.bh_max_dd_pct} |"
+    )
+    lines.append(
+        f"| Mean pairwise signal correlation | {metrics.mean_pairwise_signal_corr:.3f} | "
+        "diagnostic | n/a |"
+    )
+    lines.append("")
+    lines.append("## Vol-target variant (secondary, not a gate)")
+    lines.append(
+        f"- Return {metrics.vol_target_total_return_pct:.1f}% | Sharpe "
+        f"{metrics.vol_target_sharpe:.2f} | Max DD {metrics.vol_target_max_dd_pct:.1f}%"
+    )
+    lines.append("")
+    lines.append("## Per-symbol standalone SMA50 (concentration inputs)")
+    lines.append("")
+    lines.append("| Symbol | Return % | Switches |")
+    lines.append("|--------|----------|----------|")
+    switch_lookup = dict(metrics.per_symbol_switches)
+    for symbol, pnl in metrics.per_symbol_pnl_pct:
+        lines.append(f"| {symbol} | {pnl:.1f} | {switch_lookup.get(symbol, 0)} |")
+    lines.append("")
+    if report.reasons:
+        lines.append("## Notes")
+        for reason in report.reasons:
+            lines.append(f"- {reason}")
+        lines.append("")
+    lines.append(f"**Overall verdict:** {report.verdict}")
+    return "\n".join(lines)
+
+
+def report_to_json(report: ProbeReport) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "verdict": report.verdict,
+        "status": report.status,
+        "reasons": list(report.reasons),
+        "coverage": {
+            "blocked": report.coverage.blocked,
+            "blocked_reason": report.coverage.blocked_reason,
+            "eligible_count": len(report.coverage.eligible),
+            "universe": list(report.coverage.universe),
+            "eligible": [
+                {
+                    "symbol": row.symbol,
+                    "bars": row.bars,
+                    "span_days": row.span_days,
+                    "first_ts": row.first_ts.isoformat(),
+                    "quote_volume": row.quote_volume,
+                }
+                for row in report.coverage.eligible
+            ],
+        },
+    }
+    if report.metrics is not None:
+        metrics = report.metrics
+        payload["metrics"] = {
+            "max_symbol_pnl_share_pct": round(metrics.max_symbol_pnl_share_pct, 2),
+            "total_state_changes": metrics.total_state_changes,
+            "state_changes_per_oos_window": round(metrics.state_changes_per_oos_window, 2),
+            "mean_pairwise_signal_corr": round(metrics.mean_pairwise_signal_corr, 3),
+            "strat_total_return_pct": round(metrics.strat_total_return_pct, 2),
+            "bh_total_return_pct": round(metrics.bh_total_return_pct, 2),
+            "strat_sharpe": round(metrics.strat_sharpe, 3),
+            "bh_sharpe": round(metrics.bh_sharpe, 3),
+            "strat_max_dd_pct": round(metrics.strat_max_dd_pct, 2),
+            "bh_max_dd_pct": round(metrics.bh_max_dd_pct, 2),
+            "vol_target_total_return_pct": round(metrics.vol_target_total_return_pct, 2),
+            "vol_target_sharpe": round(metrics.vol_target_sharpe, 3),
+            "vol_target_max_dd_pct": round(metrics.vol_target_max_dd_pct, 2),
+            "concentration_passes": metrics.concentration_passes,
+            "trade_count_passes": metrics.trade_count_passes,
+            "risk_adjusted_passes": metrics.risk_adjusted_passes,
+            "per_symbol_pnl_pct": [
+                {"symbol": symbol, "return_pct": round(pnl, 2)}
+                for symbol, pnl in metrics.per_symbol_pnl_pct
+            ],
+        }
+    return payload
+
+
+async def main_async(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args(argv)
+
+    report = await run_probe(default_config())
+
+    if args.json:
+        print(json.dumps(report_to_json(report), indent=2, default=str))
+    else:
+        print(render_report(report))
+
+    if report.status == BLOCKED_STATUS:
+        return 2
+    return 0 if report.verdict == "HAS_PULSE" else 1
+
+
+def main(argv: list[str] | None = None) -> int:
+    return asyncio.run(main_async(argv))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_daily_trend_breadth_probe.py
+++ b/tests/test_daily_trend_breadth_probe.py
@@ -1,0 +1,230 @@
+"""Unit tests for daily-trend breadth probe helpers (no DB/network)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from scripts.probe_daily_trend_breadth import (
+    _max_symbol_pnl_share,
+    _mean_pairwise_signal_correlation,
+    _symbol_positions_and_returns,
+    build_coverage_audit,
+    decide_verdict,
+    evaluate_portfolio_breadth,
+)
+from scripts.probe_higher_tf_trend_following import DailyBar as TrendDailyBar
+
+
+def _bars(symbol_suffix: float, prices: list[float]) -> list[TrendDailyBar]:
+    base = datetime(2024, 1, 1, tzinfo=UTC)
+    return [
+        TrendDailyBar(day=base + timedelta(days=i), close_price=price + symbol_suffix)
+        for i, price in enumerate(prices)
+    ]
+
+
+def _trend_prices(n: int, drift: float, crash_at: int | None = None) -> list[float]:
+    prices = [100.0]
+    for i in range(1, n):
+        if crash_at is not None and i >= crash_at:
+            prices.append(prices[-1] * 0.97)
+        else:
+            prices.append(prices[-1] * (1.0 + drift))
+    return prices
+
+
+def test_build_coverage_audit_blocks_thin_universe() -> None:
+    rows = [
+        {
+            "symbol": "BTCUSDT",
+            "bars": 1000,
+            "first_ts": datetime(2024, 1, 1, tzinfo=UTC),
+            "last_ts": datetime(2026, 6, 1, tzinfo=UTC),
+            "quote_volume": 1e12,
+        },
+        {
+            "symbol": "ETHUSDT",
+            "bars": 1000,
+            "first_ts": datetime(2024, 1, 1, tzinfo=UTC),
+            "last_ts": datetime(2026, 6, 1, tzinfo=UTC),
+            "quote_volume": 5e11,
+        },
+    ]
+    audit = build_coverage_audit(
+        rows,
+        min_history_days=700,
+        min_universe_symbols=15,
+        target_universe_symbols=20,
+    )
+    assert audit.blocked is True
+    assert audit.blocked_reason is not None
+    assert "only 2" in audit.blocked_reason
+
+
+def test_build_coverage_audit_selects_top_liquid_universe() -> None:
+    rows = []
+    for index in range(18):
+        symbol = f"SYM{index:02d}USDT"
+        rows.append(
+            {
+                "symbol": symbol,
+                "bars": 2000,
+                "first_ts": datetime(2023, 1, 1, tzinfo=UTC),
+                "last_ts": datetime(2026, 6, 1, tzinfo=UTC),
+                "quote_volume": float(index + 1),
+            }
+        )
+    audit = build_coverage_audit(
+        rows,
+        min_history_days=700,
+        min_universe_symbols=15,
+        target_universe_symbols=20,
+    )
+    assert audit.blocked is False
+    assert len(audit.universe) == 18
+    assert audit.universe[0] == "SYM17USDT"
+
+
+def test_symbol_positions_are_long_only() -> None:
+    prices = _trend_prices(120, 0.01, crash_at=80)
+    days, positions, _net, _gross, switches, _total = _symbol_positions_and_returns(
+        _bars(0.0, prices),
+        sma_window=50,
+        fee_pct=0.04,
+    )
+    assert days
+    assert set(positions).issubset({0, 1})
+    assert switches > 0
+
+
+def test_max_symbol_pnl_share_concentration() -> None:
+    share = _max_symbol_pnl_share(
+        [
+            ("A", 80.0),
+            ("B", 10.0),
+            ("C", 10.0),
+        ]
+    )
+    assert share == 80.0
+
+    dominant = _max_symbol_pnl_share(
+        [
+            ("A", 30.0),
+            ("B", 25.0),
+            ("C", 25.0),
+            ("D", 20.0),
+        ]
+    )
+    assert dominant == 30.0
+
+
+def test_mean_pairwise_signal_correlation() -> None:
+    identical = _mean_pairwise_signal_correlation(
+        {
+            "A": [1, 1, 1, 0, 0],
+            "B": [1, 1, 1, 0, 0],
+        }
+    )
+    assert identical > 0.99
+
+    mixed = _mean_pairwise_signal_correlation(
+        {
+            "A": [1, 1, 1, 0, 0],
+            "B": [1, 1, 1, 0, 0],
+            "C": [0, 0, 1, 1, 1],
+        }
+    )
+    assert -1.0 <= mixed <= 1.0
+    assert mixed < identical
+
+    low = _mean_pairwise_signal_correlation(
+        {
+            "A": [1, 0, 1, 0, 1],
+            "B": [0, 1, 0, 1, 0],
+        }
+    )
+    assert low < 0.0
+
+
+def test_evaluate_portfolio_breadth_on_synthetic_multi_symbol_series() -> None:
+    n = 160
+    symbol_bars = {
+        "AAAUSDT": _bars(0.0, _trend_prices(n, 0.008)),
+        "BBBUSDT": _bars(1.0, _trend_prices(n, 0.006, crash_at=110)),
+        "CCCUSDT": _bars(2.0, _trend_prices(n, 0.007)),
+        "DDDUSDT": _bars(3.0, _trend_prices(n, 0.005)),
+    }
+    metrics = evaluate_portfolio_breadth(
+        symbol_bars,
+        sma_window=50,
+        fee_pct=0.04,
+        vol_lookback_days=20,
+        wfo_oos_months=2,
+    )
+    assert metrics is not None
+    assert metrics.n_symbols == 4
+    assert metrics.total_state_changes > 0
+    assert 0.0 <= metrics.max_symbol_pnl_share_pct <= 100.0
+    assert metrics.strat_max_dd_pct >= 0.0
+    assert metrics.bh_max_dd_pct >= 0.0
+
+
+def test_decide_verdict_has_pulse_when_all_gates_pass() -> None:
+    from scripts.probe_daily_trend_breadth import PortfolioMetrics
+
+    metrics = PortfolioMetrics(
+        n_days=500,
+        n_symbols=18,
+        total_state_changes=400,
+        state_changes_per_oos_window=25.0,
+        max_symbol_pnl_share_pct=35.0,
+        mean_pairwise_signal_corr=0.4,
+        strat_total_return_pct=40.0,
+        bh_total_return_pct=20.0,
+        strat_sharpe=1.2,
+        bh_sharpe=0.8,
+        strat_max_dd_pct=20.0,
+        bh_max_dd_pct=35.0,
+        vol_target_total_return_pct=42.0,
+        vol_target_sharpe=1.25,
+        vol_target_max_dd_pct=18.0,
+        per_symbol_pnl_pct=(("A", 10.0), ("B", 12.0)),
+        per_symbol_switches=(("A", 20), ("B", 22)),
+    )
+    status, verdict, reasons = decide_verdict(metrics, blocked=False)
+    assert status == "OK"
+    assert verdict == "HAS_PULSE"
+    assert reasons == ()
+
+
+def test_decide_verdict_blocked_on_ingestion() -> None:
+    status, verdict, _reasons = decide_verdict(None, blocked=True)
+    assert status == "BLOCKED_ON_INGESTION"
+    assert verdict == "NO_PULSE"
+
+
+def test_decide_verdict_no_pulse_on_high_concentration() -> None:
+    from scripts.probe_daily_trend_breadth import PortfolioMetrics
+
+    metrics = PortfolioMetrics(
+        n_days=500,
+        n_symbols=18,
+        total_state_changes=400,
+        state_changes_per_oos_window=25.0,
+        max_symbol_pnl_share_pct=92.0,
+        mean_pairwise_signal_corr=0.85,
+        strat_total_return_pct=10.0,
+        bh_total_return_pct=30.0,
+        strat_sharpe=0.3,
+        bh_sharpe=0.8,
+        strat_max_dd_pct=40.0,
+        bh_max_dd_pct=35.0,
+        vol_target_total_return_pct=8.0,
+        vol_target_sharpe=0.25,
+        vol_target_max_dd_pct=42.0,
+        per_symbol_pnl_pct=(("A", 90.0), ("B", 8.0)),
+        per_symbol_switches=(("A", 20), ("B", 22)),
+    )
+    _status, verdict, reasons = decide_verdict(metrics, blocked=False)
+    assert verdict == "NO_PULSE"
+    assert any("concentration" in reason for reason in reasons)

--- a/tests/test_daily_trend_breadth_probe.py
+++ b/tests/test_daily_trend_breadth_probe.py
@@ -33,27 +33,31 @@ def _trend_prices(n: int, drift: float, crash_at: int | None = None) -> list[flo
     return prices
 
 
+def _coverage_row(
+    symbol: str,
+    *,
+    timeframe: str = "1h",
+    quote_volume: float,
+) -> dict[str, object]:
+    return {
+        "symbol": symbol,
+        "timeframe": timeframe,
+        "bars": 2000,
+        "first_ts": datetime(2023, 1, 1, tzinfo=UTC),
+        "last_ts": datetime(2026, 6, 1, tzinfo=UTC),
+        "quote_volume": quote_volume,
+    }
+
+
 def test_build_coverage_audit_blocks_thin_universe() -> None:
     rows = [
-        {
-            "symbol": "BTCUSDT",
-            "bars": 1000,
-            "first_ts": datetime(2024, 1, 1, tzinfo=UTC),
-            "last_ts": datetime(2026, 6, 1, tzinfo=UTC),
-            "quote_volume": 1e12,
-        },
-        {
-            "symbol": "ETHUSDT",
-            "bars": 1000,
-            "first_ts": datetime(2024, 1, 1, tzinfo=UTC),
-            "last_ts": datetime(2026, 6, 1, tzinfo=UTC),
-            "quote_volume": 5e11,
-        },
+        _coverage_row("BTCUSDT", quote_volume=1e12),
+        _coverage_row("ETHUSDT", quote_volume=5e11),
     ]
     audit = build_coverage_audit(
         rows,
         min_history_days=700,
-        min_universe_symbols=15,
+        min_universe_symbols=8,
         target_universe_symbols=20,
     )
     assert audit.blocked is True
@@ -61,28 +65,32 @@ def test_build_coverage_audit_blocks_thin_universe() -> None:
     assert "only 2" in audit.blocked_reason
 
 
+def test_build_coverage_audit_prefers_1h_over_4h() -> None:
+    from scripts.probe_daily_trend_breadth import select_finest_tf_rows
+
+    rows = [
+        _coverage_row("SOLUSDT", timeframe="4h", quote_volume=1e9),
+        _coverage_row("SOLUSDT", timeframe="1h", quote_volume=5e11),
+    ]
+    finest = select_finest_tf_rows(rows)
+    assert len(finest) == 1
+    assert finest[0]["timeframe"] == "1h"
+
+
 def test_build_coverage_audit_selects_top_liquid_universe() -> None:
-    rows = []
-    for index in range(18):
-        symbol = f"SYM{index:02d}USDT"
-        rows.append(
-            {
-                "symbol": symbol,
-                "bars": 2000,
-                "first_ts": datetime(2023, 1, 1, tzinfo=UTC),
-                "last_ts": datetime(2026, 6, 1, tzinfo=UTC),
-                "quote_volume": float(index + 1),
-            }
-        )
+    rows = [
+        _coverage_row(f"SYM{index:02d}USDT", quote_volume=float(index + 1)) for index in range(18)
+    ]
     audit = build_coverage_audit(
         rows,
         min_history_days=700,
-        min_universe_symbols=15,
+        min_universe_symbols=8,
         target_universe_symbols=20,
     )
     assert audit.blocked is False
     assert len(audit.universe) == 18
     assert audit.universe[0] == "SYM17USDT"
+    assert audit.symbol_timeframes[0] == ("SYM17USDT", "1h")
 
 
 def test_symbol_positions_are_long_only() -> None:


### PR DESCRIPTION
## Summary

Gate 0 **planning brief** opening the **news/event** research family — the research-reset runbook's #1 unexplored direction — now that the trend family is fully closed (Gate 2 FAIL + breadth NO_PULSE). Planner artifact only; no implementation.

`docs/specs/macro-event-drift-probe-v0.md`.

## Why this primitive

Every closed lane used the same explanatory variable: crypto price/volume structure (shared beta, they fail together). This lane uses **exogenous, backtestable, point-in-time** information — the **scheduled US macro calendar (FOMC / CPI / NFP)**. Release timestamps are public and scheduled ahead → **zero look-ahead on the trigger**, the hardest problem for any news lane.

Deliberately **not** runtime LLM sentiment (what `sentiment-macro` uses) — that isn't replayable, so it isn't backtestable.

## Structure

- **Step 0 = data-feasibility audit** (mandatory gate before any edge test): find a source of historical FOMC/CPI/NFP release timestamps (≥hourly precision) for 2024→2026; ~75 events expected. Thin/sloppy → `BLOCKED_ON_DATA`, stop.
- **H1 (directional drift)** vs **H2 (vol/risk overlay)** probed separately. H1-only = HAS_PULSE; H2-only = WEAK_EDGE.
- Frozen event set ex-ante (no post-hoc event cherry-picking); point-in-time forward windows {+6h/+24h/+72h} vs a matched random-window baseline.

## Key planner flags

- **Event count for WFO is borderline** (~75 events, correlated across symbols) — Step 0 makes the count check explicit.
- **Look-ahead is the failure mode to guard** — windows start strictly after the release; no release-overlapping bar; no actual/forecast values unknown pre-release.
- Likely outcome to keep honest: events may be **priced in** (efficient reaction, no forward drift) → NO_PULSE; or only vol elevates → WEAK_EDGE overlay.

## Next

If approved, Grok runs Step 0 first; only if data passes does the cheap edge probe run. Claude reviews against the brief's checkpoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
