### PR TITLE
Backtest engine integrity audit + cost-realism re-run brief

### DIFF
--- a/docs/reports/backtest-engine-integrity-audit-2026-06-18.md
+++ b/docs/reports/backtest-engine-integrity-audit-2026-06-18.md
@@ -1,0 +1,114 @@
+# Backtest Engine Integrity Audit — 2026-06-18
+
+**Author:** Claude (planner/reviewer)
+**Trigger:** "It's extremely unusual that so many strategies fail — is something missing/broken in the
+tooling?" After ~1,500 autoresearch runs and ~12 probe lanes all closed, while the live
+`sentiment-macro-bot` is profitable and the separate cTrader FX agent is profitable.
+**Scope:** read-only audit of `src/backtest/engine.py` (789 lines) + the cost settings actually
+applied by the gate/WFO path. **No code changed.**
+
+---
+
+## TL;DR
+
+The backtest is **systematically pessimistic about costs** and **silently mutates strategy
+signals**. Three of the findings overcharge or distort in ways that would turn marginal-but-real
+edges into backtest losers — exactly the symptom observed. None of this was wrong on purpose; they
+are stale defaults and a hidden filter. **The verdicts of many closed lanes are suspect until
+re-run at realistic settings.**
+
+| # | Finding | Severity | Effect |
+|---|---------|----------|--------|
+| A | Round-trip cost ~0.4% (0.1% fee + 0.1% slippage, per side) vs ~0.1–0.15% real | **High** | ~3× overcharge; kills high-frequency / small-edge lanes |
+| B | Futures funding applied **every bar** instead of every 8h | **High (futures, sub-8h)** | ~8× funding overcharge on 1h futures backtests |
+| C | `apply_global_trend_filter` defaults **true** (base.yaml) → silently blocks every BUY below EMA200 | **High** | Neuters mean-reversion/dip-buy lanes that never asked for it |
+| D | Sharpe computed on **per-bar** equity incl. flat out-of-market bars | **Medium** | Penalizes intermittent strategies against the `min_wfo_sharpe` gate |
+| E | `return_pct` denominator differs spot vs futures (notional vs margin) | Low | Metric inconsistency, not a P&L bug |
+
+---
+
+## A. Cost model is ~3× too high (confirmed)
+
+`BacktestConfig` defaults (`engine.py:38,45`): `fee_rate = 0.001` (0.1%) **and**
+`slippage_pct = 0.001` (0.1%), each applied **per side**:
+- Entry: `entry_price = price*(1+slippage)` + `fee = notional*fee_rate` (`_open_long` :490-493).
+- Exit: `exit_price = price*(1−slippage)` + `exit_fee` (`_close_position` :563-572).
+- **Round trip = 0.2% slippage + 0.2% fee = ~0.4%.**
+
+Real Binance USDT-perp on majors: taker **0.04%/side** (0.05% spot), slippage on BTC/ETH/SOL a few
+bps → **~0.1–0.15% round trip all-in.** The backtest charges **~3×** reality.
+
+`config/base.yaml` sets **no** fee/slippage override, so every standard lane and the WFO/Gate-2 path
+ran on these defaults. (Only the two `rbi_loop.cross-venue-*` configs override slippage to 0.02%;
+none override `fee_rate`.) The Gate-1 probe scripts, by contrast, used a realistic **0.04% one-way**
+fee — so a lane could pass Gate 1 (realistic cost) and then fail Gate 2 (~0.4% cost). **That is
+exactly the daily-trend pattern: HAS_PULSE → Gate-2 FAIL.**
+
+## B. Futures funding overcharged ~8× on sub-8h timeframes (confirmed)
+
+`_apply_funding` (`engine.py:629-642`) is called **once per bar** while a futures position is open
+(`run` :227), charging `qty*price*futures_funding_rate` (default 0.0001) each bar. Real perp funding
+settles **every 8 hours** (3×/day). On a **1h** futures backtest this charges **24×/day → ~8×** the
+real funding drag. This directly penalizes the one approach with live PnL (`sentiment-macro`, 1h
+futures) in any replay/backtest, and any 1h futures lane.
+
+## C. A hidden global trend filter mutates signals by default (confirmed)
+
+`apply_global_trend_filter` defaults **true** (`engine.py:49`) and `config/base.yaml:69` sets
+`global_trend_filter_enabled: true` (buffer 0.05). In `run` (:251-265) **any BUY** is converted to
+HOLD when `price < EMA200*(1−buffer)`. Consequences:
+- Every strategy is **silently forced long-only-above-EMA200**, regardless of its own logic.
+- **Mean-reversion / dip-buying lanes are structurally blocked** from their core trade — and several
+  such lanes were "closed for no edge." Some of those closures may be the *filter's* doing, not the
+  signal's. Only `settings.daily_trend_long.yaml` explicitly set it `false`.
+
+## D. Sharpe includes flat bars → intermittent strategies under-score (consideration)
+
+`_calculate_metrics` (:707-744) builds returns from the **per-bar** equity curve, which is appended
+**every bar** (:312) including out-of-market bars (return 0). Annualization then uses
+`periods_per_year` for the full bar count. A strategy in-market only part of the time has its return
+stream diluted by zeros, distorting the per-bar Sharpe that feeds `min_wfo_sharpe ≥ 0.5`. This is
+defensible as a *portfolio* (capital-efficiency) Sharpe, but it penalizes signal quality for
+intermittent strategies — relevant to the daily-trend / event lanes that sit flat much of the time.
+A trade-based or active-period Sharpe would be more informative for the gate.
+
+## E. `return_pct` denominator inconsistency (low)
+
+Spot uses `entry_notional + entry_fee`; futures uses `margin_used + entry_fee` (`_close_position`
+:575-582). Leverage makes these non-comparable across modes — a reporting wrinkle, not a P&L error.
+
+---
+
+## What is *not* broken (checked)
+
+- **No same-bar SL/TP cheat.** Exit checks run at the start of each bar (`run` :226-237) *before*
+  entry (`_process_signal` :310); a position opened on bar N cannot be stopped out on bar N. First
+  exit opportunity is bar N+1. ✓
+- **SL-before-TP ordering is conservative** (`_check_fixed_exit` :347-371): if a bar spans both, it
+  takes the stop. ✓
+- **Signal-at-close / fill-at-close** is the standard mild-optimistic convention; slippage partly
+  offsets it. Acceptable. ✓
+
+These rule out the most common look-ahead bugs — so the issue is **cost/behavior calibration**, not
+future leakage. That is good news: it is fixable and testable.
+
+---
+
+## Implication for the closed lanes
+
+The "markets are efficient" conclusion was drawn through a lens that (A) overcharges costs ~3×,
+(B) overcharges 1h-futures funding ~8×, and (C) silently blocks below-trend buys. The cross-asset
+lane had **zero** forward signal (cost-independent) so it stays closed. But **fee-marginal** lanes —
+anything that died "just inside the fee bar," and the mean-reversion family especially — may have
+been suppressed by the tooling, not the market.
+
+## Recommended next steps
+
+1. **Cost-realism re-run** (decisive, builder task — see
+   [cost-realism-rerun-brief-v0.md](../specs/cost-realism-rerun-brief-v0.md)): re-run daily-trend +
+   1–2 fee-marginal closed lanes at realistic fee (0.04%/side), slippage (~0.02%/side), 8h funding,
+   and trend filter off; see if verdicts flip.
+2. **If verdicts flip** → fix the defaults (realistic fee/slippage, 8h-aligned funding, trend filter
+   opt-in not opt-out), then re-open the most affected closed lanes (mean-reversion first).
+3. **Adopt the cTrader agent's cost discipline** — empirical per-symbol costs rather than one flat guess.
+4. **Gate metric review** — consider a trade-based/active-period Sharpe alongside per-bar.

--- a/docs/specs/cost-realism-rerun-brief-v0.md
+++ b/docs/specs/cost-realism-rerun-brief-v0.md
@@ -1,0 +1,81 @@
+# Brief — Cost-Realism Re-Run (decisive tooling test)
+
+**Status:** experiment spec — to be run by Grok (builder); Claude reviews
+**Trigger / context:** [backtest-engine-integrity-audit-2026-06-18.md](../reports/backtest-engine-integrity-audit-2026-06-18.md)
+— the backtest overcharges costs ~3× (fee+slippage), overcharges 1h-futures funding ~8×, and a
+default-on global trend filter silently blocks below-EMA200 buys. This experiment tests whether
+those artifacts — not the market — closed the marginal lanes.
+
+---
+
+## Hypothesis
+
+Lanes that passed Gate 1 (realistic 0.04% probe cost) but failed Gate 2 (the engine's ~0.4%
+round-trip default) failed because of **cost/behavior calibration**, not absence of edge. At
+realistic settings, ≥1 closed lane's verdict flips.
+
+## The experiment (do NOT change engine defaults yet — override per run, measure, report)
+
+Re-run a small, pre-chosen set of **already-closed** lanes under **realistic** vs the **legacy**
+cost settings, side by side, and compare verdicts.
+
+### Settings to compare (two passes per lane)
+
+| Knob | Legacy (as-run) | Realistic |
+|------|-----------------|-----------|
+| `fee_rate` (per side) | 0.001 (0.1%) | **0.0004** (0.04%) |
+| `slippage_pct` (per side) | 0.001 (0.1%) | **0.0002** (0.02%) |
+| futures funding cadence | every bar | **every 8h** (apply only on bars crossing 00/08/16 UTC, or scale per-bar by `tf_hours/8`) |
+| `apply_global_trend_filter` | true (base.yaml) | **false** (let the strategy's own logic stand) |
+
+Realistic fee/slippage are Binance USDT-perp majors taker + a few bps; confirm against the cTrader
+agent's empirical-cost approach (`derive_sm_pair_costs.py`) as a sanity reference for methodology.
+
+### Lanes to re-run (frozen set — no cherry-picking)
+
+1. **daily-trend-long** (SMA50, BTC/ETH/SOL) — the clean HAS_PULSE→Gate-2-FAIL case. Primary.
+2. **One mean-reversion lane** most likely suppressed by the global trend filter (pick from the
+   closed ledger — e.g. an RSI/Bollinger dip-buy; document which and why).
+3. **One fee-marginal lane** that died "just inside the fee bar" (document the pick).
+
+### Method (point-in-time, no other changes)
+
+- Use the existing WFO/autoresearch path; only override the four knobs above. **Print the resolved
+  `BacktestConfig`** in the output so the applied costs are auditable.
+- Run **both** passes (legacy + realistic) for each lane so the delta is attributable to costs alone.
+- Keep the **same gate profile** otherwise (`standard` / `daily_trend` as originally used). Do **not**
+  also loosen gate thresholds — this isolates the cost effect.
+
+## Funding-cadence fix detail (Finding B)
+
+`_apply_funding` currently charges every bar. For the realistic pass, apply funding only when the bar
+timestamp crosses an 8h boundary (00:00/08:00/16:00 UTC), **or** equivalently scale the per-bar
+charge by `timeframe_hours / 8`. Use whichever is cleaner; document the choice. (For the experiment
+this can be a local override in the run harness — engine default fix comes later if verdicts flip.)
+
+## Pass / read-out
+
+For each lane, report a side-by-side table: `total_return_pct`, `wfo_sharpe`, `wfo_trades`,
+`max_drawdown_pct`, `profit_concentration`, and **gate verdict** under Legacy vs Realistic.
+
+- **VERDICT FLIPS (≥1 lane Legacy=FAIL → Realistic=PASS or materially closer):** the tooling was
+  suppressing edges. → escalate: fix engine defaults (realistic costs, 8h funding, trend-filter
+  opt-in), then re-open the most affected closed families (mean-reversion first).
+- **NO FLIP (verdicts unchanged):** costs/filter were not the cause; the efficiency conclusion holds
+  and we stop blaming the tooling. Either outcome is high-information.
+
+## Guardrails
+
+1. **Override per-run; do not silently edit engine defaults** during the experiment (a default change
+   only happens *after* a flip is demonstrated and reviewed).
+2. **Frozen lane set** — no swapping lanes after seeing results to manufacture a flip.
+3. **Run both passes** — a realistic-only run proves nothing without the legacy baseline.
+4. **Print resolved config + costs** for auditability.
+5. Realistic numbers are defensible (Binance majors taker 0.04%/side); do not over-optimistically set
+   fee/slippage to ~0.
+
+## Reviewer (Claude) checkpoints
+
+(a) both passes run with only the four knobs changed; (b) resolved `BacktestConfig`/costs printed and
+realistic; (c) funding-cadence fix correct (8h, not per-bar); (d) frozen lane set; (e) side-by-side
+deltas reported with honest flip / no-flip verdict and the implication stated.


### PR DESCRIPTION
## Summary

Read-only integrity audit of `src/backtest/engine.py`, triggered by "it's extremely unusual that so many strategies fail — is the tooling broken?" Plus a decisive cost-realism re-run brief for the builder.

**Two docs:**
- `docs/reports/backtest-engine-integrity-audit-2026-06-18.md` — findings
- `docs/specs/cost-realism-rerun-brief-v0.md` — the experiment for Grok

## Findings (no code changed)

| # | Finding | Severity |
|---|---------|----------|
| A | Round-trip cost ~0.4% (0.1% fee + 0.1% slippage per side) vs ~0.1–0.15% real | **High** — ~3× overcharge |
| B | Futures funding applied **every bar** not every 8h | **High** — ~8× overcharge on 1h futures |
| C | `apply_global_trend_filter` defaults **true** (base.yaml) → silently blocks every sub-EMA200 BUY | **High** — neuters mean-reversion lanes |
| D | Sharpe on per-bar equity incl. flat bars → penalizes intermittent strategies vs `min_wfo_sharpe` | Medium |
| E | `return_pct` denominator differs spot vs futures | Low |

**No look-ahead bug found** (exit checks precede entry; SL-before-TP is conservative; signal-at-close is standard). So the issue is **cost/behavior calibration — fixable and testable**, not future leakage.

**Why it matters:** Gate-1 probes used realistic 0.04% cost; Gate-2 WFO used the ~0.4% default. A lane could pass Gate 1 then fail Gate 2 on cost alone — exactly the daily-trend pattern. The cross-asset lane had zero forward signal (cost-independent) so it stays closed, but fee-marginal and mean-reversion lanes are suspect.

## Next

`cost-realism-rerun-brief-v0.md` specs a side-by-side legacy-vs-realistic re-run of daily-trend + 1 mean-reversion + 1 fee-marginal lane. If a verdict flips → fix engine defaults and re-open affected families. If not → efficiency conclusion holds. Builder (Grok) runs; Claude reviews.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
