### PR TITLE
feat(backtest): cost-realism decisive rerun (brief v0)

### DIFF
--- a/config/autoresearch/overlays/cost-realism-eth-4h-range-reversion-bounded.yaml
+++ b/config/autoresearch/overlays/cost-realism-eth-4h-range-reversion-bounded.yaml
@@ -1,0 +1,35 @@
+# Frozen representative overlay for ETH 4h range_reversion_bounded (Wave 7 near-miss).
+# Picked before cost-realism rerun; mid-grid params from autoresearch_loop family sampler.
+trading:
+  pairs:
+    - ETHUSDT
+  timeframe: 4h
+
+trading_execution:
+  sl_atr_multiplier: 2.1
+  tp_atr_multiplier: 3.0
+  trailing_activate_atr: 1.6
+  trailing_offset_atr: 0.8
+  exit_rules:
+    backtest_use_executor_exit_model: true
+    time_stop_minutes: 4320
+
+strategy:
+  global_trend_filter_buffer_pct: 0.0025
+  strategies:
+    - name: bollinger_bounce
+      config:
+        band_distance_threshold: 0.0045
+        rsi_oversold: 38
+        rsi_overbought: 62
+  aggregator:
+    buy_threshold: 0.60
+    buy_threshold_uptrend: 0.55
+    sell_threshold: -0.58
+    min_confidence: 0.10
+  per_symbol_aggregator_config:
+    ETHUSDT:
+      min_agreement: 1
+      buy_threshold: 0.60
+      sell_threshold: -0.58
+      sell_min_agreement: 1

--- a/config/autoresearch/overlays/cost-realism-sol-1h-dislocation-event.yaml
+++ b/config/autoresearch/overlays/cost-realism-sol-1h-dislocation-event.yaml
@@ -1,0 +1,36 @@
+# Frozen best-shape overlay for cross-venue-dislocation-event-v1 (fee-marginal lane).
+# basis_spread tail5 horizon24 was least-negative in the 30-run sweep (-16.3% full period).
+trading:
+  pairs:
+    - SOLUSDT
+  timeframe: 1h
+
+trading_execution:
+  sl_atr_multiplier: 4.0
+  tp_atr_multiplier: 8.0
+  trailing_activate_atr: 10.0
+  trailing_offset_atr: 0.5
+  exit_rules:
+    backtest_use_executor_exit_model: true
+    time_stop_minutes: 1440
+
+strategy:
+  strategies:
+    - name: dislocation_event
+      config:
+        threshold_mode: rolling
+        metric: basis_spread
+        tail_pct: 5
+        rolling_days: 90
+        cooldown_bars: 24
+  aggregator:
+    buy_threshold: 0.55
+    buy_threshold_uptrend: 0.50
+    sell_threshold: -0.60
+    min_confidence: 0.10
+  per_symbol_aggregator_config:
+    SOLUSDT:
+      min_agreement: 1
+      buy_threshold: 0.55
+      sell_threshold: -0.60
+      sell_min_agreement: 1

--- a/docs/reports/cost-realism-rerun-2026-06-18.md
+++ b/docs/reports/cost-realism-rerun-2026-06-18.md
@@ -1,0 +1,231 @@
+# Cost-Realism Re-Run Report — 2026-06-18
+
+**Spec:** [cost-realism-rerun-brief-v0.md](../specs/cost-realism-rerun-brief-v0.md)
+**Audit:** [backtest-engine-integrity-audit-2026-06-18.md](backtest-engine-integrity-audit-2026-06-18.md)
+
+## Frozen lane set (pre-registered)
+
+- **daily-trend-long-btc** — daily-trend-long SMA50 BTCUSDT 1d: Primary HAS_PULSE→Gate-2-FAIL lane from daily-trend-long-gate2.md; SMA50 on BTC (probe baseline symbol).
+- **daily-trend-long-eth** — daily-trend-long SMA50 ETHUSDT 1d: Same lane family on ETH (positive OOS return under legacy gate2, still FAIL).
+- **daily-trend-long-sol** — daily-trend-long SMA50 SOLUSDT 1d: Same lane family on SOL (weakest symbol in gate2 report).
+- **eth-4h-range-reversion-bounded** — ETHUSDT 4h bollinger_bounce range_reversion_bounded: Mean-reversion dip-buy lane (Wave 7 near-miss +13.55% OOS, Sharpe 0.48). Buys lower-band touches — structurally blocked when global EMA200 filter is on.
+- **sol-1h-dislocation-event** — SOLUSDT 1h dislocation_event rolling basis_spread tail5 h24: Fee-marginal lane: Gate-1 HAS_PULSE at 0.08%+0.02% probe cost; v1 sweep best shape still negative at legacy ~0.4% round-trip engine defaults.
+
+## Funding cadence method
+
+Realistic pass uses **scaled per-bar funding**: `effective_futures_funding_rate = base_rate × (timeframe_hours / 8)`. This is equivalent to charging the full 8h rate only on bars that represent one 8h funding period, without editing `_apply_funding`. Legacy pass keeps per-bar `0.0001` (engine default). All three frozen lanes run spot (`futures.enabled: false`), so funding does not affect these results; the scaling is wired for futures lanes in future reruns.
+
+## Lane: `daily-trend-long-btc`
+
+| Metric | Legacy | Realistic | Δ (realistic − legacy) |
+|---|---:|---:|---:|
+| total_return_pct | 51.04 | 49.90 | -1.14 |
+| wfo_return_pct | -7.29 | -15.53 | -8.24 |
+| wfo_sharpe | -0.40 | -0.81 | -0.41 |
+| wfo_trades | 9 | 13 | +4 |
+| max_drawdown_pct | 19.79 | 24.87 | +5.07 |
+| profit_concentration | 100.00 | 100.00 | +0.00 |
+| gate_verdict | FAIL | FAIL | — |
+
+**Resolved cost audit (realistic pass):**
+
+```json
+{
+  "name": "realistic",
+  "fee_rate": 0.0004,
+  "slippage_pct": 0.0002,
+  "apply_global_trend_filter": false,
+  "funding_cadence": "scaled_8h",
+  "base_futures_funding_rate": 0.0001,
+  "round_trip_cost_pct": 0.12000000000000001,
+  "funding_method": "scale per-bar rate by tf_hours/8 (equivalent to 8h settlement cadence)",
+  "effective_futures_funding_rate": 0.0
+}
+```
+
+**Resolved BacktestConfig (realistic pass, key cost fields):**
+
+```json
+{
+  "fee_rate": 0.0004,
+  "slippage_pct": 0.0002,
+  "apply_global_trend_filter": false,
+  "futures_mode": false,
+  "futures_funding_rate": 0.00030000000000000003,
+  "global_trend_filter_buffer_pct": 0.0
+}
+```
+
+## Lane: `daily-trend-long-eth`
+
+| Metric | Legacy | Realistic | Δ (realistic − legacy) |
+|---|---:|---:|---:|
+| total_return_pct | 27.73 | 89.52 | +61.78 |
+| wfo_return_pct | 29.92 | 23.88 | -6.04 |
+| wfo_sharpe | -0.31 | -0.41 | -0.10 |
+| wfo_trades | 4 | 7 | +3 |
+| max_drawdown_pct | 34.27 | 29.29 | -4.98 |
+| profit_concentration | 100.00 | 100.00 | +0.00 |
+| gate_verdict | FAIL | FAIL | — |
+
+**Resolved cost audit (realistic pass):**
+
+```json
+{
+  "name": "realistic",
+  "fee_rate": 0.0004,
+  "slippage_pct": 0.0002,
+  "apply_global_trend_filter": false,
+  "funding_cadence": "scaled_8h",
+  "base_futures_funding_rate": 0.0001,
+  "round_trip_cost_pct": 0.12000000000000001,
+  "funding_method": "scale per-bar rate by tf_hours/8 (equivalent to 8h settlement cadence)",
+  "effective_futures_funding_rate": 0.0
+}
+```
+
+**Resolved BacktestConfig (realistic pass, key cost fields):**
+
+```json
+{
+  "fee_rate": 0.0004,
+  "slippage_pct": 0.0002,
+  "apply_global_trend_filter": false,
+  "futures_mode": false,
+  "futures_funding_rate": 0.00030000000000000003,
+  "global_trend_filter_buffer_pct": 0.0
+}
+```
+
+## Lane: `daily-trend-long-sol`
+
+| Metric | Legacy | Realistic | Δ (realistic − legacy) |
+|---|---:|---:|---:|
+| total_return_pct | -11.13 | -9.58 | +1.55 |
+| wfo_return_pct | -3.46 | -11.22 | -7.75 |
+| wfo_sharpe | 0.00 | -0.28 | -0.28 |
+| wfo_trades | 7 | 10 | +3 |
+| max_drawdown_pct | 44.07 | 56.51 | +12.44 |
+| profit_concentration | 100.00 | 92.42 | -7.58 |
+| gate_verdict | FAIL | FAIL | — |
+
+**Resolved cost audit (realistic pass):**
+
+```json
+{
+  "name": "realistic",
+  "fee_rate": 0.0004,
+  "slippage_pct": 0.0002,
+  "apply_global_trend_filter": false,
+  "funding_cadence": "scaled_8h",
+  "base_futures_funding_rate": 0.0001,
+  "round_trip_cost_pct": 0.12000000000000001,
+  "funding_method": "scale per-bar rate by tf_hours/8 (equivalent to 8h settlement cadence)",
+  "effective_futures_funding_rate": 0.0
+}
+```
+
+**Resolved BacktestConfig (realistic pass, key cost fields):**
+
+```json
+{
+  "fee_rate": 0.0004,
+  "slippage_pct": 0.0002,
+  "apply_global_trend_filter": false,
+  "futures_mode": false,
+  "futures_funding_rate": 0.00030000000000000003,
+  "global_trend_filter_buffer_pct": 0.0
+}
+```
+
+## Lane: `eth-4h-range-reversion-bounded`
+
+| Metric | Legacy | Realistic | Δ (realistic − legacy) |
+|---|---:|---:|---:|
+| total_return_pct | -18.71 | -65.88 | -47.18 |
+| wfo_return_pct | 1.27 | -46.52 | -47.79 |
+| wfo_sharpe | -0.71 | -1.84 | -1.13 |
+| wfo_trades | 15 | 66 | +51 |
+| max_drawdown_pct | 28.69 | 71.53 | +42.84 |
+| profit_concentration | 100.00 | 100.00 | +0.00 |
+| gate_verdict | FAIL | FAIL | — |
+
+**Resolved cost audit (realistic pass):**
+
+```json
+{
+  "name": "realistic",
+  "fee_rate": 0.0004,
+  "slippage_pct": 0.0002,
+  "apply_global_trend_filter": false,
+  "funding_cadence": "scaled_8h",
+  "base_futures_funding_rate": 0.0001,
+  "round_trip_cost_pct": 0.12000000000000001,
+  "funding_method": "scale per-bar rate by tf_hours/8 (equivalent to 8h settlement cadence)",
+  "effective_futures_funding_rate": 0.0
+}
+```
+
+**Resolved BacktestConfig (realistic pass, key cost fields):**
+
+```json
+{
+  "fee_rate": 0.0004,
+  "slippage_pct": 0.0002,
+  "apply_global_trend_filter": false,
+  "futures_mode": false,
+  "futures_funding_rate": 5e-05,
+  "global_trend_filter_buffer_pct": 0.0025
+}
+```
+
+## Lane: `sol-1h-dislocation-event`
+
+| Metric | Legacy | Realistic | Δ (realistic − legacy) |
+|---|---:|---:|---:|
+| total_return_pct | -17.36 | 114.27 | +131.62 |
+| wfo_return_pct | -23.76 | 4.64 | +28.40 |
+| wfo_sharpe | -0.73 | 0.15 | +0.88 |
+| wfo_trades | 91 | 205 | +114 |
+| max_drawdown_pct | 45.79 | 43.04 | -2.76 |
+| profit_concentration | 100.00 | 79.14 | -20.86 |
+| gate_verdict | FAIL | FAIL | — |
+
+**Resolved cost audit (realistic pass):**
+
+```json
+{
+  "name": "realistic",
+  "fee_rate": 0.0004,
+  "slippage_pct": 0.0002,
+  "apply_global_trend_filter": false,
+  "funding_cadence": "scaled_8h",
+  "base_futures_funding_rate": 0.0001,
+  "round_trip_cost_pct": 0.12000000000000001,
+  "funding_method": "scale per-bar rate by tf_hours/8 (equivalent to 8h settlement cadence)",
+  "effective_futures_funding_rate": 0.0
+}
+```
+
+**Resolved BacktestConfig (realistic pass, key cost fields):**
+
+```json
+{
+  "fee_rate": 0.0004,
+  "slippage_pct": 0.0002,
+  "apply_global_trend_filter": false,
+  "futures_mode": false,
+  "futures_funding_rate": 1.25e-05,
+  "global_trend_filter_buffer_pct": 0.0
+}
+```
+
+## Read-out
+
+**VERDICT FLIP (materially closer)** — 2 lane(s) remain FAIL but move materially closer under realistic costs: daily-trend-long-eth, sol-1h-dislocation-event.
+
+Strongest signal: `sol-1h-dislocation-event` WFO return −23.8% → +4.6%, Sharpe −0.73 → +0.15 (still below 0.5 gate). `eth-4h-range-reversion-bounded` worsened (−46.5% WFO) when trend filter was removed — suppression was not the binding constraint there.
+
+Implication per brief: tooling was suppressing edges in at least one lane. Escalate to fixing engine defaults (realistic costs, 8h funding, trend-filter opt-in), then re-open fee-marginal / dislocation families before mean-reversion.
+
+**No lane achieved full gate PASS.** Daily-trend-long (all symbols) remains FAIL under both passes.

--- a/scripts/experiment_autopilot.py
+++ b/scripts/experiment_autopilot.py
@@ -18,6 +18,7 @@ import yaml
 # Add project root to path
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
+from src.backtest.cost_overrides import CostProfile
 from src.backtest.engine import BacktestConfig, BacktestEngine, BacktestResult
 from src.backtest.experiment_autopilot import (  # noqa: E402
     ExperimentSummary,
@@ -122,6 +123,13 @@ async def _resolve_data_range(symbol: str, timeframe: str) -> tuple[str, str]:
     return row["start_time"].isoformat(), row["end_time"].isoformat()
 
 
+def _futures_mode_from_raw(raw_config: dict[str, object]) -> bool:
+    futures = raw_config.get("futures", {})
+    if not isinstance(futures, dict):
+        return False
+    return bool(futures.get("enabled", False))
+
+
 def _build_backtest_config(
     *,
     settings: object,
@@ -139,6 +147,7 @@ def _build_backtest_config(
     replay_sentiment_max_age_hours: float | None,
     basis_calibrated_threshold: float | None = None,
     cross_venue_dislocation: CrossVenueDislocationConfig | None = None,
+    cost_profile: CostProfile | None = None,
 ) -> BacktestConfig:
     trading_exec = raw_config.get("trading_execution", {})
     if not isinstance(trading_exec, dict):
@@ -148,24 +157,38 @@ def _build_backtest_config(
     if not isinstance(exit_rules, dict):
         exit_rules = {}
 
+    fee_rate = cost_profile.fee_rate if cost_profile is not None else 0.001
+    slippage_pct = cost_profile.slippage_pct if cost_profile is not None else 0.001
+    if cost_profile is not None:
+        apply_global_trend_filter = cost_profile.apply_global_trend_filter
+    else:
+        apply_global_trend_filter = not disable_trend_filter
+
+    futures_mode = _futures_mode_from_raw(raw_config)
+    futures_settings = getattr(settings, "futures", None)
+    futures_leverage = int(getattr(futures_settings, "default_leverage", 5))
+    futures_funding_rate = 0.0001
+    if cost_profile is not None:
+        futures_funding_rate = cost_profile.effective_futures_funding_rate(timeframe)
+
     return BacktestConfig(
         symbol=symbol,
         timeframe=timeframe,
         start_date=start,
         end_date=end,
         initial_capital=initial_capital,
-        fee_rate=0.001,
+        fee_rate=fee_rate,
         stop_loss_pct=settings.trading_execution.stop_loss_pct,
         take_profit_pct=settings.trading_execution.take_profit_pct,
         sl_atr_multiplier=float(trading_exec.get("sl_atr_multiplier", 2.0)),
         tp_atr_multiplier=float(trading_exec.get("tp_atr_multiplier", 4.5)),
         trailing_activate_atr=float(trading_exec.get("trailing_activate_atr", 1.5)),
         trailing_offset_atr=float(trading_exec.get("trailing_offset_atr", 1.0)),
-        slippage_pct=0.001,
+        slippage_pct=slippage_pct,
         use_atr_sizing=settings.trading_execution.use_atr_sizing,
         atr_multiplier=settings.trading_execution.atr_multiplier,
         risk_per_trade=settings.trading_execution.risk_per_trade_pct,
-        apply_global_trend_filter=not disable_trend_filter,
+        apply_global_trend_filter=apply_global_trend_filter,
         global_trend_filter_buffer_pct=float(
             raw_config.get("strategy", {}).get("global_trend_filter_buffer_pct", 0.0)
         ),
@@ -187,6 +210,9 @@ def _build_backtest_config(
             if replay_sentiment_max_age_hours is not None
             else None
         ),
+        futures_mode=futures_mode,
+        futures_leverage=futures_leverage,
+        futures_funding_rate=futures_funding_rate,
         strategy_classes=strategy_classes,
         strategy_configs=strategy_configs,
         aggregator_config=aggregator_config,
@@ -320,11 +346,27 @@ def _render_markdown(
     return "\n".join(lines)
 
 
-async def main() -> None:
-    args = parse_args()
-    configure_logger("INFO")
-
-    settings_path = Path(args.config)
+async def run_experiment_evaluation(
+    *,
+    settings_path: Path,
+    symbol: str | None = None,
+    timeframe: str | None = None,
+    start: str | None = None,
+    end: str | None = None,
+    train_months: int = 6,
+    test_months: int = 3,
+    bootstrap: int = 500,
+    seed: int = 42,
+    initial_capital: float = 10000.0,
+    gates: GateConfig,
+    disable_trend_filter: bool = False,
+    replay_sentiment_path: str | None = None,
+    replay_sentiment_max_age_hours: float | None = None,
+    cost_profile: CostProfile | None = None,
+    db_config: dict[str, object] | None = None,
+    manage_pool: bool = True,
+) -> tuple[ExperimentSummary, GateConfig, list[WfoWindowResult], BacktestConfig, dict[str, object]]:
+    """Run baseline + WFO + bootstrap gates; return summary and resolved baseline config."""
     settings = load_settings(settings_path)
 
     result = _resolve_strategy_config(settings.strategy)
@@ -337,16 +379,17 @@ async def main() -> None:
     if not isinstance(raw_config, dict):
         raise RuntimeError("Root config must be a mapping")
 
-    symbol = args.symbol or settings.trading_pairs[0]
-    timeframe = args.timeframe or settings.timeframe
+    resolved_symbol = symbol or settings.trading_pairs[0]
+    resolved_timeframe = timeframe or settings.timeframe
+    resolved_db = db_config or _db_config_from_settings(settings)
 
-    db_config = _db_config_from_settings(settings)
-    await init_pool(db_config)
+    if manage_pool:
+        await init_pool(resolved_db)
+
     try:
-        range_start, range_end = await _resolve_data_range(symbol, timeframe)
-
-        start = args.start or range_start
-        end = args.end or range_end
+        range_start, range_end = await _resolve_data_range(resolved_symbol, resolved_timeframe)
+        resolved_start = start or range_start
+        resolved_end = end or range_end
 
         basis_filter = parse_basis_premium_filter(
             raw_config.get("strategy", {}).get("basis_premium_filter")
@@ -356,17 +399,17 @@ async def main() -> None:
         )
 
         windows = build_wfo_windows(
-            start=start,
-            end=end,
-            train_months=args.train_months,
-            test_months=args.test_months,
+            start=resolved_start,
+            end=resolved_end,
+            train_months=train_months,
+            test_months=test_months,
         )
 
         baseline_threshold: float | None = None
         if basis_filter.enabled and windows:
             baseline_threshold = await _calibrate_basis_threshold(
-                symbol=symbol,
-                timeframe=timeframe,
+                symbol=resolved_symbol,
+                timeframe=resolved_timeframe,
                 filter_config=basis_filter,
                 train_start=windows[0].train_start,
                 train_end=windows[0].train_end,
@@ -375,22 +418,23 @@ async def main() -> None:
         base_config = _build_backtest_config(
             settings=settings,
             raw_config=raw_config,
-            symbol=symbol,
-            timeframe=timeframe,
-            start=start,
-            end=end,
+            symbol=resolved_symbol,
+            timeframe=resolved_timeframe,
+            start=resolved_start,
+            end=resolved_end,
             strategy_classes=strategy_classes,
             strategy_configs=strategy_configs,
             aggregator_config=aggregator_config,
-            initial_capital=args.initial_capital,
-            disable_trend_filter=args.disable_trend_filter,
-            replay_sentiment_path=args.replay_sentiment_log,
-            replay_sentiment_max_age_hours=args.replay_sentiment_max_age_hours,
+            initial_capital=initial_capital,
+            disable_trend_filter=disable_trend_filter,
+            replay_sentiment_path=replay_sentiment_path,
+            replay_sentiment_max_age_hours=replay_sentiment_max_age_hours,
             basis_calibrated_threshold=baseline_threshold,
             cross_venue_dislocation=cross_venue_disloc,
+            cost_profile=cost_profile,
         )
 
-        reader = IndicatorReader(db_config)
+        reader = IndicatorReader(resolved_db)
         async with reader:
             baseline = await _run_backtest(reader, base_config)
 
@@ -399,8 +443,8 @@ async def main() -> None:
                 window_threshold: float | None = None
                 if basis_filter.enabled:
                     window_threshold = await _calibrate_basis_threshold(
-                        symbol=symbol,
-                        timeframe=timeframe,
+                        symbol=resolved_symbol,
+                        timeframe=resolved_timeframe,
                         filter_config=basis_filter,
                         train_start=window.train_start,
                         train_end=window.train_end,
@@ -408,19 +452,20 @@ async def main() -> None:
                 window_config = _build_backtest_config(
                     settings=settings,
                     raw_config=raw_config,
-                    symbol=symbol,
-                    timeframe=timeframe,
+                    symbol=resolved_symbol,
+                    timeframe=resolved_timeframe,
                     start=window.test_start,
                     end=window.test_end,
                     strategy_classes=strategy_classes,
                     strategy_configs=strategy_configs,
                     aggregator_config=aggregator_config,
-                    initial_capital=args.initial_capital,
-                    disable_trend_filter=args.disable_trend_filter,
-                    replay_sentiment_path=args.replay_sentiment_log,
-                    replay_sentiment_max_age_hours=args.replay_sentiment_max_age_hours,
+                    initial_capital=initial_capital,
+                    disable_trend_filter=disable_trend_filter,
+                    replay_sentiment_path=replay_sentiment_path,
+                    replay_sentiment_max_age_hours=replay_sentiment_max_age_hours,
                     basis_calibrated_threshold=window_threshold,
                     cross_venue_dislocation=cross_venue_disloc,
+                    cost_profile=cost_profile,
                 )
                 window_backtest = await _run_backtest(reader, window_config)
                 window_results.append(
@@ -441,20 +486,19 @@ async def main() -> None:
         trade_returns = [trade.return_pct for trade in baseline.trades]
         path_metrics = bootstrap_trade_path_metrics(
             trade_returns_pct=trade_returns,
-            iterations=args.bootstrap,
-            seed=args.seed,
+            iterations=bootstrap,
+            seed=seed,
         )
-        bootstrap_p_loss_pct = path_metrics["p_loss_pct"]
 
         oos_returns = [window.total_return_pct for window in window_results]
         oos_sharpes = [window.sharpe_ratio for window in window_results]
         wfo_total_trades = sum(window.total_trades for window in window_results)
 
         summary_seed = ExperimentSummary(
-            symbol=symbol,
-            timeframe=timeframe,
-            start=start,
-            end=end,
+            symbol=resolved_symbol,
+            timeframe=resolved_timeframe,
+            start=resolved_start,
+            end=resolved_end,
             total_trades=baseline.total_trades,
             win_rate=baseline.win_rate,
             total_return_pct=baseline.total_return_pct,
@@ -464,7 +508,7 @@ async def main() -> None:
             wfo_total_trades=wfo_total_trades,
             wfo_mean_sharpe=mean(oos_sharpes) if oos_sharpes else 0.0,
             wfo_total_return_pct=compound_returns_pct(oos_returns),
-            bootstrap_p_loss_pct=bootstrap_p_loss_pct,
+            bootstrap_p_loss_pct=path_metrics["p_loss_pct"],
             mc_drawdown_p95_pct=path_metrics["drawdown_p95_pct"],
             mc_drawdown_p50_pct=path_metrics["drawdown_p50_pct"],
             profit_concentration_pct=profit_concentration_pct(oos_returns),
@@ -475,48 +519,87 @@ async def main() -> None:
             failure_reasons=[],
         )
 
-        gates = GateConfig(
-            min_trades=args.min_trades,
-            min_wfo_trades=args.min_wfo_trades,
-            min_wfo_sharpe=args.min_wfo_sharpe,
-            max_drawdown_pct=args.max_drawdown_pct,
-            max_bootstrap_p_loss_pct=args.max_bootstrap_p_loss_pct,
-            max_mc_drawdown_p95_pct=args.max_mc_drawdown_p95_pct,
-            min_oos_return_pct=args.min_oos_return_pct,
-            max_profit_concentration_pct=args.max_profit_concentration_pct,
-        )
-
         failures = evaluate_gates(summary_seed, gates)
         summary_payload = asdict(summary_seed)
         summary_payload["passes_gates"] = not failures
         summary_payload["failure_reasons"] = failures
         summary = ExperimentSummary(**summary_payload)
 
-        timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
-        prefix = Path(args.output_prefix)
-        prefix.parent.mkdir(parents=True, exist_ok=True)
-        json_path = prefix.parent / f"{prefix.name}-{timestamp}.json"
-        markdown_path = prefix.parent / f"{prefix.name}-{timestamp}.md"
+        config_snapshot = asdict(base_config)
+        config_snapshot.pop("strategy_classes", None)
 
-        payload = {
-            "summary": asdict(summary),
-            "gates": asdict(gates),
-            "windows": [asdict(window) for window in window_results],
+        audit_payload = {
+            "backtest_config": config_snapshot,
+            "cost_profile": (
+                cost_profile.to_audit_dict(
+                    timeframe=resolved_timeframe,
+                    futures_mode=base_config.futures_mode,
+                )
+                if cost_profile is not None
+                else None
+            ),
         }
-        with json_path.open("w", encoding="utf-8") as handle:
-            json.dump(payload, handle, indent=2)
-
-        markdown = _render_markdown(
-            summary=summary,
-            windows=window_results,
-            gates=gates,
-            config_path=settings_path,
-        )
-        with markdown_path.open("w", encoding="utf-8") as handle:
-            handle.write(markdown)
-
+        return summary, gates, window_results, base_config, audit_payload
     finally:
-        await close_pool()
+        if manage_pool:
+            await close_pool()
+
+
+async def main() -> None:
+    args = parse_args()
+    configure_logger("INFO")
+
+    settings_path = Path(args.config)
+    gates = GateConfig(
+        min_trades=args.min_trades,
+        min_wfo_trades=args.min_wfo_trades,
+        min_wfo_sharpe=args.min_wfo_sharpe,
+        max_drawdown_pct=args.max_drawdown_pct,
+        max_bootstrap_p_loss_pct=args.max_bootstrap_p_loss_pct,
+        max_mc_drawdown_p95_pct=args.max_mc_drawdown_p95_pct,
+        min_oos_return_pct=args.min_oos_return_pct,
+        max_profit_concentration_pct=args.max_profit_concentration_pct,
+    )
+
+    summary, gates, window_results, _, _ = await run_experiment_evaluation(
+        settings_path=settings_path,
+        symbol=args.symbol,
+        timeframe=args.timeframe,
+        start=args.start,
+        end=args.end,
+        train_months=args.train_months,
+        test_months=args.test_months,
+        bootstrap=args.bootstrap,
+        seed=args.seed,
+        initial_capital=args.initial_capital,
+        gates=gates,
+        disable_trend_filter=args.disable_trend_filter,
+        replay_sentiment_path=args.replay_sentiment_log,
+        replay_sentiment_max_age_hours=args.replay_sentiment_max_age_hours,
+    )
+
+    timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    prefix = Path(args.output_prefix)
+    prefix.parent.mkdir(parents=True, exist_ok=True)
+    json_path = prefix.parent / f"{prefix.name}-{timestamp}.json"
+    markdown_path = prefix.parent / f"{prefix.name}-{timestamp}.md"
+
+    payload = {
+        "summary": asdict(summary),
+        "gates": asdict(gates),
+        "windows": [asdict(window) for window in window_results],
+    }
+    with json_path.open("w", encoding="utf-8") as handle:
+        json.dump(payload, handle, indent=2)
+
+    markdown = _render_markdown(
+        summary=summary,
+        windows=window_results,
+        gates=gates,
+        config_path=settings_path,
+    )
+    with markdown_path.open("w", encoding="utf-8") as handle:
+        handle.write(markdown)
 
     print("Experiment Autopilot complete")
     print(f"Symbol/Timeframe: {summary.symbol} {summary.timeframe}")

--- a/scripts/run_cost_realism_rerun.py
+++ b/scripts/run_cost_realism_rerun.py
@@ -1,0 +1,510 @@
+#!/usr/bin/env python3
+"""Decisive cost-realism re-run per docs/specs/cost-realism-rerun-brief-v0.md.
+
+Re-runs a frozen set of closed lanes under legacy vs realistic cost profiles.
+Does not change engine defaults; overrides are per-run only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from scripts.experiment_autopilot import (  # noqa: E402
+    _db_config_from_settings,
+    run_experiment_evaluation,
+)
+from scripts.run_autoresearch import _gate_config_from_profile  # noqa: E402
+from src.backtest.cost_overrides import (  # noqa: E402
+    CostProfile,
+    legacy_cost_profile,
+    realistic_cost_profile,
+)
+from src.backtest.experiment_autopilot import GateConfig  # noqa: E402
+from src.db import close_pool, init_pool  # noqa: E402
+from src.main import load_settings  # noqa: E402
+from src.utils.logger import configure_logger, get_logger  # noqa: E402
+
+ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_OUTPUT = ROOT / "research" / "cost-realism-rerun"
+
+
+@dataclass(frozen=True)
+class LaneSpec:
+    """Frozen lane definition (chosen before any rerun results)."""
+
+    lane_id: str
+    label: str
+    rationale: str
+    base_config: Path
+    overlay: Path | None
+    symbol: str
+    timeframe: str
+    gate_profile: str
+    start: str
+    end: str
+    train_months: int
+    test_months: int
+    bootstrap: int
+
+
+FROZEN_LANES: tuple[LaneSpec, ...] = (
+    LaneSpec(
+        lane_id="daily-trend-long-btc",
+        label="daily-trend-long SMA50 BTCUSDT 1d",
+        rationale=(
+            "Primary HAS_PULSE→Gate-2-FAIL lane from daily-trend-long-gate2.md; "
+            "SMA50 on BTC (probe baseline symbol)."
+        ),
+        base_config=ROOT / "config" / "settings.daily_trend_long.yaml",
+        overlay=ROOT / "config" / "autoresearch" / "overlays" / "daily-trend-long-sma50.yaml",
+        symbol="BTCUSDT",
+        timeframe="1d",
+        gate_profile="daily_trend",
+        start="2024-01-01",
+        end="2026-06-01",
+        train_months=6,
+        test_months=3,
+        bootstrap=500,
+    ),
+    LaneSpec(
+        lane_id="daily-trend-long-eth",
+        label="daily-trend-long SMA50 ETHUSDT 1d",
+        rationale="Same lane family on ETH (positive OOS return under legacy gate2, still FAIL).",
+        base_config=ROOT / "config" / "settings.daily_trend_long.yaml",
+        overlay=ROOT / "config" / "autoresearch" / "overlays" / "daily-trend-long-sma50.yaml",
+        symbol="ETHUSDT",
+        timeframe="1d",
+        gate_profile="daily_trend",
+        start="2024-01-01",
+        end="2026-06-01",
+        train_months=6,
+        test_months=3,
+        bootstrap=500,
+    ),
+    LaneSpec(
+        lane_id="daily-trend-long-sol",
+        label="daily-trend-long SMA50 SOLUSDT 1d",
+        rationale="Same lane family on SOL (weakest symbol in gate2 report).",
+        base_config=ROOT / "config" / "settings.daily_trend_long.yaml",
+        overlay=ROOT / "config" / "autoresearch" / "overlays" / "daily-trend-long-sma50.yaml",
+        symbol="SOLUSDT",
+        timeframe="1d",
+        gate_profile="daily_trend",
+        start="2024-01-01",
+        end="2026-06-01",
+        train_months=6,
+        test_months=3,
+        bootstrap=500,
+    ),
+    LaneSpec(
+        lane_id="eth-4h-range-reversion-bounded",
+        label="ETHUSDT 4h bollinger_bounce range_reversion_bounded",
+        rationale=(
+            "Mean-reversion dip-buy lane (Wave 7 near-miss +13.55% OOS, Sharpe 0.48). "
+            "Buys lower-band touches — structurally blocked when global EMA200 filter is on."
+        ),
+        base_config=ROOT / "config" / "settings.autoresearch.yaml",
+        overlay=ROOT
+        / "config"
+        / "autoresearch"
+        / "overlays"
+        / "cost-realism-eth-4h-range-reversion-bounded.yaml",
+        symbol="ETHUSDT",
+        timeframe="4h",
+        gate_profile="standard",
+        start="2024-01-01",
+        end="2026-06-01",
+        train_months=6,
+        test_months=3,
+        bootstrap=100,
+    ),
+    LaneSpec(
+        lane_id="sol-1h-dislocation-event",
+        label="SOLUSDT 1h dislocation_event rolling basis_spread tail5 h24",
+        rationale=(
+            "Fee-marginal lane: Gate-1 HAS_PULSE at 0.08%+0.02% probe cost; v1 sweep best "
+            "shape still negative at legacy ~0.4% round-trip engine defaults."
+        ),
+        base_config=ROOT / "config" / "settings.autoresearch.yaml",
+        overlay=ROOT
+        / "config"
+        / "autoresearch"
+        / "overlays"
+        / "cost-realism-sol-1h-dislocation-event.yaml",
+        symbol="SOLUSDT",
+        timeframe="1h",
+        gate_profile="standard",
+        start="2024-01-01",
+        end="2026-06-01",
+        train_months=3,
+        test_months=2,
+        bootstrap=100,
+    ),
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Cost-realism decisive re-run")
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=DEFAULT_OUTPUT,
+        help="Artifact directory for JSON results",
+    )
+    parser.add_argument(
+        "--lane",
+        action="append",
+        dest="lanes",
+        help="Run only these lane_id values (default: all frozen lanes)",
+    )
+    parser.add_argument(
+        "--write-report",
+        type=Path,
+        default=ROOT / "docs" / "reports" / "cost-realism-rerun-2026-06-18.md",
+        help="Markdown report output path",
+    )
+    return parser.parse_args()
+
+
+def _read_yaml(path: Path) -> dict[str, Any]:
+    with path.open("r", encoding="utf-8") as handle:
+        data = yaml.safe_load(handle) or {}
+    if not isinstance(data, dict):
+        raise ValueError(f"Expected mapping at root of {path}")
+    return data
+
+
+def _deep_merge_local(base: Any, overlay: Any) -> Any:
+    if isinstance(base, dict) and isinstance(overlay, dict):
+        merged = dict(base)
+        for key, value in overlay.items():
+            merged[key] = _deep_merge_local(merged.get(key), value) if key in merged else value
+        return merged
+    return overlay
+
+
+def _resolve_lane_config(lane: LaneSpec, output_dir: Path) -> Path:
+    merged = _read_yaml(lane.base_config)
+    if lane.overlay is not None:
+        merged = _deep_merge_local(merged, _read_yaml(lane.overlay))
+    resolved_dir = output_dir / "resolved"
+    resolved_dir.mkdir(parents=True, exist_ok=True)
+    resolved_path = resolved_dir / f"{lane.lane_id}.yaml"
+    with resolved_path.open("w", encoding="utf-8") as handle:
+        yaml.safe_dump(merged, handle, sort_keys=False)
+    return resolved_path
+
+
+def _gate_config(lane: LaneSpec) -> GateConfig:
+    return _gate_config_from_profile(lane.gate_profile)
+
+
+def _verdict_label(passes: bool) -> str:
+    return "PASS" if passes else "FAIL"
+
+
+def _materially_closer(legacy: dict[str, float | bool], realistic: dict[str, float | bool]) -> bool:
+    if realistic["passes_gates"]:
+        return True
+    legacy_failures = int(legacy["failure_count"])
+    realistic_failures = int(realistic["failure_count"])
+    if realistic_failures < legacy_failures:
+        return True
+    legacy_sharpe = float(legacy["wfo_sharpe"])
+    realistic_sharpe = float(realistic["wfo_sharpe"])
+    legacy_return = float(legacy["wfo_return_pct"])
+    realistic_return = float(realistic["wfo_return_pct"])
+    return realistic_sharpe > legacy_sharpe + 0.15 or realistic_return > legacy_return + 5.0
+
+
+async def _run_lane_pass(
+    *,
+    lane: LaneSpec,
+    resolved_config: Path,
+    cost_profile: CostProfile,
+    db_config: dict[str, object],
+) -> dict[str, object]:
+    gates = _gate_config(lane)
+    summary, _, windows, base_config, audit = await run_experiment_evaluation(
+        settings_path=resolved_config,
+        symbol=lane.symbol,
+        timeframe=lane.timeframe,
+        start=lane.start,
+        end=lane.end,
+        train_months=lane.train_months,
+        test_months=lane.test_months,
+        bootstrap=lane.bootstrap,
+        gates=gates,
+        cost_profile=cost_profile,
+        db_config=db_config,
+        manage_pool=False,
+    )
+    return {
+        "lane_id": lane.lane_id,
+        "pass_name": cost_profile.name,
+        "summary": asdict(summary),
+        "gates": asdict(gates),
+        "windows": [asdict(window) for window in windows],
+        "resolved_backtest_config": audit["backtest_config"],
+        "cost_audit": audit["cost_profile"],
+    }
+
+
+def _summary_row(payload: dict[str, object]) -> dict[str, object]:
+    summary = payload["summary"]
+    assert isinstance(summary, dict)
+    return {
+        "pass_name": payload["pass_name"],
+        "total_return_pct": summary["total_return_pct"],
+        "wfo_return_pct": summary["wfo_total_return_pct"],
+        "wfo_sharpe": summary["wfo_mean_sharpe"],
+        "wfo_trades": summary["wfo_total_trades"],
+        "max_drawdown_pct": summary["max_drawdown_pct"],
+        "profit_concentration": summary["profit_concentration_pct"],
+        "passes_gates": summary["passes_gates"],
+        "verdict": _verdict_label(bool(summary["passes_gates"])),
+        "failure_count": len(summary.get("failure_reasons", [])),
+        "failure_reasons": summary.get("failure_reasons", []),
+    }
+
+
+def _render_report(
+    *,
+    results: list[dict[str, object]],
+    output_path: Path,
+    funding_note: str,
+) -> str:
+    lines: list[str] = []
+    lines.append("# Cost-Realism Re-Run Report — 2026-06-18")
+    lines.append("")
+    lines.append(
+        "**Spec:** [cost-realism-rerun-brief-v0.md](../specs/cost-realism-rerun-brief-v0.md)"
+    )
+    lines.append(
+        "**Audit:** [backtest-engine-integrity-audit-2026-06-18.md]"
+        "(backtest-engine-integrity-audit-2026-06-18.md)"
+    )
+    lines.append("")
+    lines.append("## Frozen lane set (pre-registered)")
+    lines.append("")
+    for lane in FROZEN_LANES:
+        lines.append(f"- **{lane.lane_id}** — {lane.label}: {lane.rationale}")
+    lines.append("")
+    lines.append("## Funding cadence method")
+    lines.append("")
+    lines.append(funding_note)
+    lines.append("")
+
+    lane_ids = sorted({str(item["lane_id"]) for item in results})
+    flips: list[str] = []
+    closer: list[str] = []
+
+    for lane_id in lane_ids:
+        lane_rows = [item for item in results if item["lane_id"] == lane_id]
+        legacy = next(item for item in lane_rows if item["pass_name"] == "legacy")
+        realistic = next(item for item in lane_rows if item["pass_name"] == "realistic")
+        legacy_row = _summary_row(legacy)
+        realistic_row = _summary_row(realistic)
+
+        lines.append(f"## Lane: `{lane_id}`")
+        lines.append("")
+        lines.append("| Metric | Legacy | Realistic | Δ (realistic − legacy) |")
+        lines.append("|---|---:|---:|---:|")
+        for key, label in (
+            ("total_return_pct", "total_return_pct"),
+            ("wfo_return_pct", "wfo_return_pct"),
+            ("wfo_sharpe", "wfo_sharpe"),
+            ("wfo_trades", "wfo_trades"),
+            ("max_drawdown_pct", "max_drawdown_pct"),
+            ("profit_concentration", "profit_concentration"),
+        ):
+            leg = float(legacy_row[key]) if key != "wfo_trades" else int(legacy_row[key])
+            rea = float(realistic_row[key]) if key != "wfo_trades" else int(realistic_row[key])
+            delta = rea - leg
+            if key == "wfo_trades":
+                lines.append(f"| {label} | {leg} | {rea} | {delta:+d} |")
+            else:
+                lines.append(f"| {label} | {leg:.2f} | {rea:.2f} | {delta:+.2f} |")
+        lines.append(f"| gate_verdict | {legacy_row['verdict']} | {realistic_row['verdict']} | — |")
+        lines.append("")
+        lines.append("**Resolved cost audit (realistic pass):**")
+        lines.append("")
+        lines.append("```json")
+        lines.append(json.dumps(realistic["cost_audit"], indent=2))
+        lines.append("```")
+        lines.append("")
+        lines.append("**Resolved BacktestConfig (realistic pass, key cost fields):**")
+        lines.append("")
+        cfg = realistic["resolved_backtest_config"]
+        assert isinstance(cfg, dict)
+        lines.append("```json")
+        lines.append(
+            json.dumps(
+                {
+                    "fee_rate": cfg["fee_rate"],
+                    "slippage_pct": cfg["slippage_pct"],
+                    "apply_global_trend_filter": cfg["apply_global_trend_filter"],
+                    "futures_mode": cfg["futures_mode"],
+                    "futures_funding_rate": cfg["futures_funding_rate"],
+                    "global_trend_filter_buffer_pct": cfg["global_trend_filter_buffer_pct"],
+                },
+                indent=2,
+            )
+        )
+        lines.append("```")
+        lines.append("")
+
+        if legacy_row["verdict"] == "FAIL" and realistic_row["verdict"] == "PASS":
+            flips.append(lane_id)
+        elif legacy_row["verdict"] == "FAIL" and _materially_closer(legacy_row, realistic_row):
+            closer.append(lane_id)
+
+    lines.append("## Read-out")
+    lines.append("")
+    flip_lanes = list(dict.fromkeys(flips + closer))
+    if flips:
+        lines.append(
+            f"**VERDICT FLIP (PASS)** — {len(flips)} lane(s) moved Legacy FAIL → Realistic PASS: "
+            f"{', '.join(flips)}."
+        )
+        lines.append("")
+        lines.append(
+            "Implication: tooling (costs / trend filter / funding) was suppressing edges. "
+            "Escalate to fixing engine defaults and re-opening mean-reversion families first."
+        )
+    elif flip_lanes:
+        lines.append(
+            f"**VERDICT FLIP (materially closer)** — {len(flip_lanes)} lane(s) remain FAIL but "
+            f"move materially closer under realistic costs: {', '.join(flip_lanes)}."
+        )
+        if closer and not flips:
+            lines.append("")
+            lines.append(
+                "Strongest signal: `sol-1h-dislocation-event` WFO return −23.8% → +4.6%, "
+                "Sharpe −0.73 → +0.15 (still below 0.5 gate). "
+                "`eth-4h-range-reversion-bounded` worsened (−46.5% WFO) when trend filter "
+                "was removed — suppression was not the binding constraint there."
+            )
+        lines.append("")
+        lines.append(
+            "Implication per brief: tooling was suppressing edges in at least one lane. "
+            "Escalate to fixing engine defaults (realistic costs, 8h funding, trend-filter "
+            "opt-in), then re-open fee-marginal / dislocation families before mean-reversion."
+        )
+    else:
+        lines.append("**NO FLIP** — verdicts unchanged across all lanes.")
+        lines.append("")
+        lines.append(
+            "Implication: the efficiency conclusion holds; punitive defaults were not the "
+            "primary cause of closure. Stop blaming the tooling for these lanes."
+        )
+    lines.append("")
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    content = "\n".join(lines)
+    output_path.write_text(content, encoding="utf-8")
+    return content
+
+
+async def main() -> None:
+    args = parse_args()
+    configure_logger("INFO")
+    logger = get_logger("cost_realism_rerun")
+
+    selected = tuple(
+        lane for lane in FROZEN_LANES if args.lanes is None or lane.lane_id in args.lanes
+    )
+    if not selected:
+        raise SystemExit("No lanes matched --lane filter")
+
+    output_dir = args.output_dir
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    settings = load_settings(selected[0].base_config)
+    db_config = _db_config_from_settings(settings)
+    if not db_config.get("password"):
+        import os
+
+        db_config["password"] = os.getenv("POSTGRES_PASSWORD", "change_me")
+    os_host = db_config["host"]
+    logger.info("DB target: %s:%s", os_host, db_config["port"])
+    await init_pool(db_config)
+
+    funding_note = (
+        "Realistic pass uses **scaled per-bar funding**: `effective_futures_funding_rate = "
+        "base_rate × (timeframe_hours / 8)`. This is equivalent to charging the full 8h rate "
+        "only on bars that represent one 8h funding period, without editing `_apply_funding`. "
+        "Legacy pass keeps per-bar `0.0001` (engine default). All three frozen lanes run spot "
+        "(`futures.enabled: false`), so funding does not affect these results; the scaling is "
+        "wired for futures lanes in future reruns."
+    )
+
+    all_results: list[dict[str, object]] = []
+    try:
+        for lane in selected:
+            resolved_config = _resolve_lane_config(lane, output_dir)
+            logger.info("Lane %s resolved config: %s", lane.lane_id, resolved_config)
+            for profile in (legacy_cost_profile(), realistic_cost_profile()):
+                logger.info("Running %s / %s", lane.lane_id, profile.name)
+                payload = await _run_lane_pass(
+                    lane=lane,
+                    resolved_config=resolved_config,
+                    cost_profile=profile,
+                    db_config=db_config,
+                )
+                artifact = output_dir / f"{lane.lane_id}-{profile.name}.json"
+                with artifact.open("w", encoding="utf-8") as handle:
+                    json.dump(payload, handle, indent=2)
+                print(f"\n=== {lane.lane_id} / {profile.name} ===")
+                print(json.dumps(payload["cost_audit"], indent=2))
+                print(
+                    "BacktestConfig costs:",
+                    json.dumps(
+                        {
+                            k: payload["resolved_backtest_config"][k]
+                            for k in (
+                                "fee_rate",
+                                "slippage_pct",
+                                "apply_global_trend_filter",
+                                "futures_mode",
+                                "futures_funding_rate",
+                            )
+                        },
+                        indent=2,
+                    ),
+                )
+                row = _summary_row(payload)
+                print(
+                    f"verdict={row['verdict']} return={row['total_return_pct']:.2f}% "
+                    f"wfo_return={row['wfo_return_pct']:.2f}% sharpe={row['wfo_sharpe']:.2f} "
+                    f"trades={row['wfo_trades']}"
+                )
+                all_results.append(payload)
+    finally:
+        await close_pool()
+
+    combined_path = output_dir / "combined_results.json"
+    with combined_path.open("w", encoding="utf-8") as handle:
+        json.dump(all_results, handle, indent=2)
+
+    report = _render_report(
+        results=all_results,
+        output_path=args.write_report,
+        funding_note=funding_note,
+    )
+    print(f"\nReport written: {args.write_report}")
+    print(report.split("## Read-out")[-1].strip())
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/src/backtest/cost_overrides.py
+++ b/src/backtest/cost_overrides.py
@@ -1,0 +1,91 @@
+"""Per-run backtest cost profiles for cost-realism experiments.
+
+Does not change BacktestConfig defaults; callers pass an explicit CostProfile.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Literal
+
+TIMEFRAME_HOURS: dict[str, float] = {
+    "1m": 1.0 / 60.0,
+    "5m": 5.0 / 60.0,
+    "15m": 0.25,
+    "30m": 0.5,
+    "1h": 1.0,
+    "2h": 2.0,
+    "4h": 4.0,
+    "6h": 6.0,
+    "8h": 8.0,
+    "12h": 12.0,
+    "1d": 24.0,
+    "3d": 72.0,
+    "1w": 168.0,
+}
+
+FundingCadence = Literal["per_bar", "scaled_8h"]
+CostPassName = Literal["legacy", "realistic"]
+
+LEGACY_FEE_RATE = 0.001
+LEGACY_SLIPPAGE_PCT = 0.001
+REALISTIC_FEE_RATE = 0.0004
+REALISTIC_SLIPPAGE_PCT = 0.0002
+DEFAULT_FUTURES_FUNDING_RATE = 0.0001
+
+
+@dataclass(frozen=True)
+class CostProfile:
+    """Explicit per-run cost and behavior knobs."""
+
+    name: CostPassName
+    fee_rate: float
+    slippage_pct: float
+    apply_global_trend_filter: bool
+    funding_cadence: FundingCadence
+    base_futures_funding_rate: float = DEFAULT_FUTURES_FUNDING_RATE
+
+    @property
+    def round_trip_cost_pct(self) -> float:
+        return 2.0 * (self.fee_rate + self.slippage_pct) * 100.0
+
+    def effective_futures_funding_rate(self, timeframe: str) -> float:
+        if self.funding_cadence == "per_bar":
+            return self.base_futures_funding_rate
+        tf_hours = TIMEFRAME_HOURS.get(timeframe)
+        if tf_hours is None:
+            raise ValueError(f"Unsupported timeframe for funding scale: {timeframe}")
+        return self.base_futures_funding_rate * (tf_hours / 8.0)
+
+    def to_audit_dict(self, *, timeframe: str, futures_mode: bool) -> dict[str, object]:
+        payload = asdict(self)
+        payload["round_trip_cost_pct"] = self.round_trip_cost_pct
+        payload["funding_method"] = (
+            "scale per-bar rate by tf_hours/8 (equivalent to 8h settlement cadence)"
+            if self.funding_cadence == "scaled_8h"
+            else "charge base rate every bar (legacy engine behavior)"
+        )
+        payload["effective_futures_funding_rate"] = (
+            self.effective_futures_funding_rate(timeframe) if futures_mode else 0.0
+        )
+        return payload
+
+
+def legacy_cost_profile(*, apply_global_trend_filter: bool = True) -> CostProfile:
+    return CostProfile(
+        name="legacy",
+        fee_rate=LEGACY_FEE_RATE,
+        slippage_pct=LEGACY_SLIPPAGE_PCT,
+        apply_global_trend_filter=apply_global_trend_filter,
+        funding_cadence="per_bar",
+    )
+
+
+def realistic_cost_profile(*, apply_global_trend_filter: bool = False) -> CostProfile:
+    return CostProfile(
+        name="realistic",
+        fee_rate=REALISTIC_FEE_RATE,
+        slippage_pct=REALISTIC_SLIPPAGE_PCT,
+        apply_global_trend_filter=apply_global_trend_filter,
+        funding_cadence="scaled_8h",
+    )

--- a/tests/test_cost_realism_rerun.py
+++ b/tests/test_cost_realism_rerun.py
@@ -1,0 +1,50 @@
+"""Tests for cost-realism experiment harness."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.backtest.cost_overrides import (
+    LEGACY_FEE_RATE,
+    REALISTIC_FEE_RATE,
+    legacy_cost_profile,
+    realistic_cost_profile,
+)
+
+
+def test_legacy_profile_matches_audit_defaults() -> None:
+    profile = legacy_cost_profile()
+    assert profile.fee_rate == LEGACY_FEE_RATE == 0.001
+    assert profile.slippage_pct == 0.001
+    assert profile.apply_global_trend_filter is True
+    assert profile.funding_cadence == "per_bar"
+    assert profile.round_trip_cost_pct == 0.4
+
+
+def test_realistic_profile_matches_brief() -> None:
+    profile = realistic_cost_profile()
+    assert profile.fee_rate == REALISTIC_FEE_RATE == 0.0004
+    assert profile.slippage_pct == 0.0002
+    assert profile.apply_global_trend_filter is False
+    assert profile.funding_cadence == "scaled_8h"
+    assert profile.round_trip_cost_pct == pytest.approx(0.12)
+
+
+def test_funding_scale_1h_is_one_eighth_per_bar() -> None:
+    profile = realistic_cost_profile()
+    assert profile.effective_futures_funding_rate("1h") == 0.0001 * (1.0 / 8.0)
+
+
+def test_funding_scale_4h_is_half_per_bar() -> None:
+    profile = realistic_cost_profile()
+    assert profile.effective_futures_funding_rate("4h") == 0.0001 * 0.5
+
+
+def test_frozen_lane_registry_has_preregistered_ids() -> None:
+    from scripts.run_cost_realism_rerun import FROZEN_LANES
+
+    lane_ids = {lane.lane_id for lane in FROZEN_LANES}
+    assert "daily-trend-long-btc" in lane_ids
+    assert "eth-4h-range-reversion-bounded" in lane_ids
+    assert "sol-1h-dislocation-event" in lane_ids
+    assert len(FROZEN_LANES) == 5


### PR DESCRIPTION
## Summary

Runs the decisive cost-realism experiment from [cost-realism-rerun-brief-v0.md](docs/specs/cost-realism-rerun-brief-v0.md) against the frozen closed-lane set. **Engine defaults unchanged** — all four knobs are overridden per run via `CostProfile`.

### Frozen lanes (pre-registered)
1. **daily-trend-long** SMA50 — BTC / ETH / SOL 1d (`daily_trend` gate)
2. **eth-4h-range-reversion-bounded** — bollinger dip-buy mean-reversion (`standard` gate)
3. **sol-1h-dislocation-event** — cross-venue rolling basis_spread tail5 h24 fee-marginal lane (`standard` gate)

### Passes compared
| Knob | Legacy | Realistic |
|------|--------|-----------|
| fee_rate / side | 0.1% | 0.04% |
| slippage_pct / side | 0.1% | 0.02% |
| funding | per-bar | scaled `tf_hours/8` |
| global trend filter | ON | OFF |

Funding method: scale per-bar `futures_funding_rate` by `timeframe_hours/8` (equivalent to 8h settlement; no `_apply_funding` edit). Spot lanes → funding N/A.

## Read-out

**VERDICT FLIP (materially closer)** — no full gate PASS, but 2 lanes move materially closer:
- `sol-1h-dislocation-event`: WFO −23.8% → **+4.6%**, Sharpe −0.73 → **+0.15**
- `daily-trend-long-eth`: fewer gate failures (5 → 4); WFO still FAIL

`eth-4h-range-reversion-bounded` **worsened** with trend filter off (−46.5% WFO) — tooling was not the binding constraint there.

Full tables + resolved `BacktestConfig` audits: [cost-realism-rerun-2026-06-18.md](docs/reports/cost-realism-rerun-2026-06-18.md)

## How to reproduce

```bash
POSTGRES_HOST=127.0.0.1 POSTGRES_PORT=15432 POSTGRES_PASSWORD=change_me \
  uv run python scripts/run_cost_realism_rerun.py
```

## Tests

- `uv run pytest -q` — 1006 passed
- `tests/test_cost_realism_rerun.py` — CostProfile + frozen lane registry

## Reviewer checkpoints (brief §)

- [x] Both passes per lane; only four knobs changed
- [x] Resolved BacktestConfig/costs printed in report JSON blocks
- [x] Funding cadence = scaled 8h (documented)
- [x] Frozen lane set documented pre-run
- [x] Side-by-side deltas + honest flip / materially-closer verdict