### PR TITLE
Three backtest fix/experiment briefs (cost+funding, dislocation isolation, trend-filter opt-in)

### DIFF
--- a/docs/specs/backtest-cost-funding-fix-brief-v0.md
+++ b/docs/specs/backtest-cost-funding-fix-brief-v0.md
@@ -1,0 +1,49 @@
+# Brief — Backtest Cost & Funding Correctness Fix (Task 1)
+
+**Status:** implementation spec — to be built by Grok; Claude reviews
+**Trigger:** [backtest-engine-integrity-audit-2026-06-18.md](../reports/backtest-engine-integrity-audit-2026-06-18.md)
+Findings A (cost ~3× too high) and B (funding charged per-bar, not 8h). These are **correctness**
+fixes justified independent of any strategy result.
+
+---
+
+## Scope (surgical — defaults + one bug, nothing else)
+
+### Fix 1 — realistic default costs (`src/backtest/engine.py:38,45`)
+- `fee_rate`: `0.001` → **`0.0004`** (Binance USDT-perp / spot taker on majors).
+- `slippage_pct`: `0.001` → **`0.0002`** (a few bps on BTC/ETH/SOL).
+- These are *defaults*; every config/CLI override still wins. Round-trip drops ~0.4% → ~0.12%.
+
+### Fix 2 — funding cadence bug (`_apply_funding`, `engine.py:629-642`)
+Funding is charged **every bar**; real perp funding settles **every 8h**. Fix so the effective
+funding over time equals the 8h rate regardless of timeframe. Two acceptable implementations
+(pick one, document it):
+- charge only on bars crossing 00:00/08:00/16:00 UTC; or
+- scale the per-bar charge by `timeframe_hours / 8` (reuse the approach already in
+  `src/backtest/cost_overrides.py` from PR #92 — prefer reusing it, don't duplicate).
+
+### Out of scope (note as follow-ups, do NOT build now)
+- Per-symbol **empirical** costs (the cTrader `derive_sm_pair_costs.py` discipline) — larger
+  enhancement, separate task.
+- The trend filter (Task 3) and the Sharpe-on-flat-bars consideration (audit Finding D).
+
+## Guardrails / risks to handle
+1. **Blast radius:** changing defaults changes *all* future backtest numbers. Prior reports used
+   old costs — **do not retro-edit them**; add a one-line note in the audit report that defaults
+   were corrected on this date so old vs new numbers are comparable knowingly.
+2. **Don't break live-agent replay:** `sentiment-macro` replay/backtest must still run. Verify the
+   sentiment replay path and any test that asserts on fee/slippage/funding values still pass (update
+   expected values where a test hard-codes the old defaults — and call those out in the PR).
+3. **Futures funding:** verify the fix only changes cadence/scaling, not the rate, and that spot
+   lanes (funding N/A) are unaffected.
+
+## Validation
+- `uv run pytest` + `uv run ruff check .` green (update + annotate any tests that pin old defaults).
+- Add/extend a unit test asserting: (a) round-trip cost at new defaults ≈ 0.12%; (b) funding over a
+  known multi-day 1h window equals the 8h-equivalent (≈ 1/8 of the old per-bar total).
+- Print/log the resolved cost config at backtest start so runs stay auditable.
+
+## Reviewer (Claude) checkpoints
+(a) only fee/slippage defaults + funding cadence changed (no other behavior); (b) overrides still
+win; (c) funding fix correct and reuses `cost_overrides` not a duplicate; (d) live-agent replay +
+tests pass with old-default tests knowingly updated; (e) audit report annotated with the change date.

--- a/docs/specs/dislocation-cost-isolation-brief-v0.md
+++ b/docs/specs/dislocation-cost-isolation-brief-v0.md
@@ -1,0 +1,50 @@
+# Brief — Dislocation Cost-Only Isolation (Task 2)
+
+**Status:** experiment spec — to be run by Grok; Claude reviews
+**Trigger:** [cost-realism-rerun-2026-06-18.md](../reports/cost-realism-rerun-2026-06-18.md) — the SOL
+dislocation lane flipped −23.8%/Sharpe −0.73 → **+4.6%/+0.15**, but the "realistic" pass changed
+**cost AND the global trend filter together**, so the flip can't be attributed. This isolates it.
+
+---
+
+## Question
+
+Was the dislocation flip driven by **cheaper costs**, the **trend filter coming off**, or both?
+Answer it with a 2×2 factorial on the **one** lane (SOL 1h dislocation_event, basis_spread tail5 h24).
+
+## Design — 4 cells, change one variable at a time
+
+| Cell | Cost | Trend filter | Purpose |
+|------|------|--------------|---------|
+| 1 | legacy (0.4% RT) | ON | original "legacy" baseline (reproduce PR #92) |
+| 2 | **realistic (0.12% RT)** | **ON** | **cost-only effect** (the missing cell) |
+| 3 | legacy | OFF | filter-only effect |
+| 4 | realistic | OFF | the PR #92 "realistic" cell (reproduce) |
+
+Reuse `scripts/run_cost_realism_rerun.py` + `src/backtest/cost_overrides.py`; just allow the two
+knobs to vary independently (cost profile × filter flag) instead of the bundled legacy/realistic
+pair. Same frozen lane, same gate profile, point-in-time unchanged. Print resolved config per cell.
+
+## Read-out
+
+Report the 4-cell table (`total_return_pct`, `wfo_sharpe`, `wfo_trades`, `max_drawdown_pct`,
+`profit_concentration`, verdict). Then attribute:
+- **Cell 2 ≈ Cell 1** and **Cell 4 ≈ Cell 3** → the flip is the **filter**, not cost.
+- **Cell 2 ≈ Cell 4** (both good) and **Cell 1 ≈ Cell 3** (both bad) → the flip is **cost**.
+- Mixed → both contribute; quantify each (Δ from cost = Cell2−Cell1; Δ from filter = Cell3−Cell1).
+
+## Why it matters
+
+Decides whether re-opening the **fee-marginal / dislocation family** at corrected costs is justified
+(if cost-driven) or whether the result was just the filter (if so, the family stays closed and we
+learned the filter helps this lane too). Do **not** re-open the family until this attribution is clear.
+
+## Guardrails
+1. One variable per cell; run all 4 (no skipping the baselines).
+2. Same lane/gate/period as PR #92 — this is attribution, not a new search. No parameter changes.
+3. Overrides per-run only; print resolved config.
+
+## Reviewer (Claude) checkpoints
+(a) all 4 cells run, one variable each; (b) Cells 1 & 4 reproduce PR #92 within noise (sanity);
+(c) attribution stated explicitly with the cost-Δ and filter-Δ quantified; (d) honest recommendation
+on whether the dislocation family reopens.

--- a/docs/specs/trend-filter-opt-in-brief-v0.md
+++ b/docs/specs/trend-filter-opt-in-brief-v0.md
@@ -1,0 +1,51 @@
+# Brief — Global Trend Filter: make it an explicit per-lane choice (Task 3)
+
+**Status:** implementation spec — to be built by Grok; Claude reviews
+**Trigger:** [backtest-engine-integrity-audit-2026-06-18.md](../reports/backtest-engine-integrity-audit-2026-06-18.md)
+Finding C + the cost-realism result. The `apply_global_trend_filter` defaults **true**
+(`engine.py:49`, `base.yaml:69`) and **silently converts every sub-EMA200 BUY to HOLD for all
+strategies**. The experiment showed it **cuts both ways**: daily-trend wants it off; range-reversion
+got far worse without it (+1.3% → −46.5%). So it is **not** a bug to remove — it is a hidden default
+that must become an **explicit, conscious per-lane decision.**
+
+---
+
+## Goal
+
+Stop the filter from silently mutating signals by inheritance. Keep the mechanism; make every lane
+**declare** its choice, and make the behavior **visible** in logs/output. Do **not** blanket-flip the
+default to off (that would hurt lanes the filter protects).
+
+## Scope
+
+1. **Keep** `apply_global_trend_filter` + `global_trend_filter_buffer_pct` working exactly as-is.
+2. **Make the choice explicit & logged:** at backtest start, log whether the filter is active, its
+   buffer, and source (config vs default), so no run is silently filtered. Include it in the resolved
+   config audit dump.
+3. **Research-workflow rule (doc, not code):** every research lane config under `config/` and every
+   autoresearch overlay MUST set `global_trend_filter_enabled` explicitly (true/false) rather than
+   inheriting. Add this to the RBI runbook / brief template and note it in the audit report.
+4. **Decide the engine/base default** deliberately: recommend leaving `base.yaml` default **true**
+   (it protects naive long strategies) BUT requiring lane briefs to state the choice. If you change
+   any default, document the blast radius. (Planner recommendation: keep default true, enforce
+   explicitness — minimal change, no silent surprise.)
+
+## Out of scope
+- Per-strategy automatic logic (e.g. mean-reversion auto-disables) — too clever; explicit config is better.
+- Cost/funding (Task 1) and the isolation experiment (Task 2).
+
+## Guardrails
+1. **Behavior-preserving by default** — existing configs that rely on the current setting must run
+   identically unless they opt to change. This is about *visibility + explicitness*, not flipping outcomes.
+2. No silent default flips; if you propose changing `base.yaml`, call it out loudly with the affected lanes.
+
+## Validation
+- `uv run pytest` + `uv run ruff check .` green.
+- A test asserting the filter state is logged/auditable and that an explicit `false` disables it while
+  an explicit `true` enables it (buffer respected).
+
+## Reviewer (Claude) checkpoints
+(a) mechanism unchanged, behavior preserved for existing configs; (b) filter state now logged +
+in the audit dump (no silent filtering); (c) research-workflow explicitness rule documented in the
+runbook/brief template; (d) any default change (if proposed) flagged with blast radius — default kept
+true unless there's a strong, stated reason.


### PR DESCRIPTION
## Summary

Planning bundle (docs only) following the cost-realism finding — three briefs for the builder, one per follow-up action.

| Brief | Task | Type |
|-------|------|------|
| `backtest-cost-funding-fix-brief-v0.md` | 1 — realistic default fee/slippage (0.04%/0.02%) + 8h funding cadence | correctness fix |
| `dislocation-cost-isolation-brief-v0.md` | 2 — 2×2 factorial (cost × filter) to attribute the dislocation +EV flip | experiment |
| `trend-filter-opt-in-brief-v0.md` | 3 — make the global trend filter an explicit, logged per-lane choice | hygiene |

## Key constraints baked in

- **Task 1** is behavior-changing (affects all future backtests) → overrides still win, don't retro-edit old reports, don't break `sentiment-macro` replay, update+annotate tests that pin old defaults.
- **Task 2** must run all 4 cells (one variable each) — the missing cell is *realistic-cost + filter-ON* — before re-opening the dislocation family.
- **Task 3** is **behavior-preserving**: the filter cuts both ways (daily-trend wants off, range-reversion needs on), so make it explicit + logged, **don't blanket-flip** the default.

## Ordering

Task 1 and Task 3 are independent engine/config changes; Task 2 depends on the cost-override machinery from #92. Suggest: 1 first (unblocks corrected-cost re-opens), 2 and 3 in parallel after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
