### PR TITLE
fix(backtest): correct default costs and 8h futures funding cadence

### DIFF
--- a/docs/reports/backtest-engine-integrity-audit-2026-06-18.md
+++ b/docs/reports/backtest-engine-integrity-audit-2026-06-18.md
@@ -7,6 +7,9 @@ tooling?" After ~1,500 autoresearch runs and ~12 probe lanes all closed, while t
 **Scope:** read-only audit of `src/backtest/engine.py` (789 lines) + the cost settings actually
 applied by the gate/WFO path. **No code changed.**
 
+**Update (2026-06-18):** Engine defaults corrected in `feat/backtest-cost-funding-fix` — fee
+0.04%/side, slippage 0.02%/side, 8h-scaled futures funding (`scaled_8h` cadence).
+
 ---
 
 ## TL;DR

--- a/scripts/experiment_autopilot.py
+++ b/scripts/experiment_autopilot.py
@@ -18,7 +18,13 @@ import yaml
 # Add project root to path
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
-from src.backtest.cost_overrides import CostProfile
+from src.backtest.cost_overrides import (
+    DEFAULT_FUTURES_FUNDING_RATE,
+    REALISTIC_FEE_RATE,
+    REALISTIC_SLIPPAGE_PCT,
+    CostProfile,
+    FundingCadence,
+)
 from src.backtest.engine import BacktestConfig, BacktestEngine, BacktestResult
 from src.backtest.experiment_autopilot import (  # noqa: E402
     ExperimentSummary,
@@ -157,8 +163,8 @@ def _build_backtest_config(
     if not isinstance(exit_rules, dict):
         exit_rules = {}
 
-    fee_rate = cost_profile.fee_rate if cost_profile is not None else 0.001
-    slippage_pct = cost_profile.slippage_pct if cost_profile is not None else 0.001
+    fee_rate = cost_profile.fee_rate if cost_profile is not None else REALISTIC_FEE_RATE
+    slippage_pct = cost_profile.slippage_pct if cost_profile is not None else REALISTIC_SLIPPAGE_PCT
     if cost_profile is not None:
         apply_global_trend_filter = cost_profile.apply_global_trend_filter
     else:
@@ -167,9 +173,11 @@ def _build_backtest_config(
     futures_mode = _futures_mode_from_raw(raw_config)
     futures_settings = getattr(settings, "futures", None)
     futures_leverage = int(getattr(futures_settings, "default_leverage", 5))
-    futures_funding_rate = 0.0001
+    futures_funding_rate = DEFAULT_FUTURES_FUNDING_RATE
+    funding_cadence: FundingCadence = "scaled_8h"
     if cost_profile is not None:
-        futures_funding_rate = cost_profile.effective_futures_funding_rate(timeframe)
+        futures_funding_rate = cost_profile.base_futures_funding_rate
+        funding_cadence = cost_profile.funding_cadence
 
     return BacktestConfig(
         symbol=symbol,
@@ -213,6 +221,7 @@ def _build_backtest_config(
         futures_mode=futures_mode,
         futures_leverage=futures_leverage,
         futures_funding_rate=futures_funding_rate,
+        funding_cadence=funding_cadence,
         strategy_classes=strategy_classes,
         strategy_configs=strategy_configs,
         aggregator_config=aggregator_config,

--- a/src/backtest/cost_overrides.py
+++ b/src/backtest/cost_overrides.py
@@ -50,12 +50,30 @@ class CostProfile:
         return 2.0 * (self.fee_rate + self.slippage_pct) * 100.0
 
     def effective_futures_funding_rate(self, timeframe: str) -> float:
-        if self.funding_cadence == "per_bar":
-            return self.base_futures_funding_rate
-        tf_hours = TIMEFRAME_HOURS.get(timeframe)
-        if tf_hours is None:
-            raise ValueError(f"Unsupported timeframe for funding scale: {timeframe}")
-        return self.base_futures_funding_rate * (tf_hours / 8.0)
+        return effective_futures_funding_rate_per_bar(
+            self.base_futures_funding_rate,
+            timeframe,
+            cadence=self.funding_cadence,
+        )
+
+
+def effective_futures_funding_rate_per_bar(
+    base_rate: float,
+    timeframe: str,
+    *,
+    cadence: FundingCadence = "scaled_8h",
+) -> float:
+    """Per-bar futures funding charge for the given cadence.
+
+    ``scaled_8h`` scales the 8h settlement rate by ``timeframe_hours / 8`` so sub-8h
+    backtests do not overcharge funding every bar.
+    """
+    if cadence == "per_bar":
+        return base_rate
+    tf_hours = TIMEFRAME_HOURS.get(timeframe)
+    if tf_hours is None:
+        raise ValueError(f"Unsupported timeframe for funding scale: {timeframe}")
+    return base_rate * (tf_hours / 8.0)
 
     def to_audit_dict(self, *, timeframe: str, futures_mode: bool) -> dict[str, object]:
         payload = asdict(self)

--- a/src/backtest/engine.py
+++ b/src/backtest/engine.py
@@ -5,6 +5,13 @@ from collections.abc import Mapping
 from dataclasses import dataclass, field
 from datetime import datetime
 
+from src.backtest.cost_overrides import (
+    DEFAULT_FUTURES_FUNDING_RATE,
+    REALISTIC_FEE_RATE,
+    REALISTIC_SLIPPAGE_PCT,
+    FundingCadence,
+    effective_futures_funding_rate_per_bar,
+)
 from src.backtest.sentiment_replay import ReplaySentimentScorer
 from src.features.reader import IndicatorReader
 from src.strategy.aggregator import SignalAggregator
@@ -35,14 +42,14 @@ class BacktestConfig:
     start_date: str  # ISO 8601
     end_date: str  # ISO 8601
     initial_capital: float = 10000.0
-    fee_rate: float = 0.001  # 0.1%
+    fee_rate: float = REALISTIC_FEE_RATE  # 0.04% per side (Binance USDT-perp taker)
     stop_loss_pct: float = 0.0  # 0.0 = disabled
     take_profit_pct: float = 0.0  # 0.0 = disabled
     sl_atr_multiplier: float = 2.0
     tp_atr_multiplier: float = 4.5
     trailing_activate_atr: float = 1.5
     trailing_offset_atr: float = 1.0
-    slippage_pct: float = 0.001  # 0.1% slippage per trade
+    slippage_pct: float = REALISTIC_SLIPPAGE_PCT  # 0.02% per side
     risk_per_trade: float = 0.02  # 2% risk of equity per trade (used if use_atr_sizing=True)
     use_atr_sizing: bool = False
     atr_multiplier: float = 1.5  # Stop distance = 1.5 * ATR
@@ -66,7 +73,8 @@ class BacktestConfig:
     replay_sentiment_max_age_seconds: float | None = None
     futures_mode: bool = False
     futures_leverage: int = 5
-    futures_funding_rate: float = 0.0001
+    futures_funding_rate: float = DEFAULT_FUTURES_FUNDING_RATE
+    funding_cadence: FundingCadence = "scaled_8h"
     fixed_notional_usdt: float = 0.0  # 0 = size from available capital
     quantity_step_size: float = 0.0  # 0 = ideal fractional quantity
     min_notional_usdt: float = 0.0  # 0 = disabled
@@ -165,9 +173,31 @@ class BacktestEngine:
 
         return first
 
+    def _resolved_cost_audit(self) -> dict[str, object]:
+        round_trip_cost_pct = 2.0 * (self._config.fee_rate + self._config.slippage_pct) * 100.0
+        effective_funding = (
+            effective_futures_funding_rate_per_bar(
+                self._config.futures_funding_rate,
+                self._config.timeframe,
+                cadence=self._config.funding_cadence,
+            )
+            if self._config.futures_mode
+            else 0.0
+        )
+        return {
+            "fee_rate": self._config.fee_rate,
+            "slippage_pct": self._config.slippage_pct,
+            "round_trip_cost_pct": round_trip_cost_pct,
+            "funding_cadence": self._config.funding_cadence,
+            "futures_funding_rate_base": self._config.futures_funding_rate,
+            "effective_futures_funding_rate_per_bar": effective_funding,
+            "futures_mode": self._config.futures_mode,
+        }
+
     async def run(self) -> BacktestResult:
         """Execute the backtest."""
         self._logger.info(f"Starting backtest for {self._config.symbol}...")
+        self._logger.info("Resolved backtest cost config: %s", self._resolved_cost_audit())
 
         # Instantiate strategies first to check if any require MTF
         strategies = []
@@ -630,7 +660,12 @@ class BacktestEngine:
         if not self._config.futures_mode or self._position_qty == 0:
             return
 
-        funding_cost = abs(self._position_qty) * current_price * self._config.futures_funding_rate
+        per_bar_rate = effective_futures_funding_rate_per_bar(
+            self._config.futures_funding_rate,
+            self._config.timeframe,
+            cadence=self._config.funding_cadence,
+        )
+        funding_cost = abs(self._position_qty) * current_price * per_bar_rate
         self._cash -= funding_cost
         self._position_funding_paid += funding_cost
         self._logger.debug(

--- a/tests/test_backtest_cost_defaults.py
+++ b/tests/test_backtest_cost_defaults.py
@@ -1,0 +1,216 @@
+"""Backtest engine default cost and funding-cadence correctness."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from src.backtest.cost_overrides import (
+    LEGACY_FEE_RATE,
+    LEGACY_SLIPPAGE_PCT,
+    REALISTIC_FEE_RATE,
+    REALISTIC_SLIPPAGE_PCT,
+    effective_futures_funding_rate_per_bar,
+)
+from src.backtest.engine import BacktestConfig, BacktestEngine
+from src.features.reader import IndicatorReader
+from src.strategy.base import BaseStrategy
+from src.strategy.sentiment_mean_reversion import SentimentMeanReversionStrategy
+from src.strategy.signals import Signal, SignalType
+
+
+class BuyOnceStrategy(BaseStrategy):
+    """Minimal strategy used only to hold a futures position open."""
+
+    def get_name(self) -> str:
+        return "BuyOnce"
+
+    async def evaluate(self, symbol: str, indicators: dict[str, object]) -> Signal:
+        price = float(indicators["close_price"])
+        if price == 100.0:
+            return Signal(SignalType.BUY, symbol, price, 1.0, "Buy", indicators)
+        return Signal(SignalType.HOLD, symbol, price, 0.0, "Hold", indicators)
+
+
+def _build_reader(data: list[dict[str, object]]) -> IndicatorReader:
+    reader = IndicatorReader({})
+    reader._connected = True
+
+    async def _mock_fetch(*_args: object) -> list[dict[str, object]]:
+        return data
+
+    reader.fetch_range = _mock_fetch
+    return reader
+
+
+def test_backtest_config_default_round_trip_cost_pct() -> None:
+    config = BacktestConfig(
+        symbol="BTCUSDT",
+        timeframe="1h",
+        start_date="2023-01-01",
+        end_date="2023-01-02",
+    )
+    round_trip = 2.0 * (config.fee_rate + config.slippage_pct) * 100.0
+    assert config.fee_rate == REALISTIC_FEE_RATE == 0.0004
+    assert config.slippage_pct == REALISTIC_SLIPPAGE_PCT == 0.0002
+    assert round_trip == pytest.approx(0.12)
+
+
+def test_backtest_config_overrides_still_win() -> None:
+    config = BacktestConfig(
+        symbol="BTCUSDT",
+        timeframe="1h",
+        start_date="2023-01-01",
+        end_date="2023-01-02",
+        fee_rate=LEGACY_FEE_RATE,
+        slippage_pct=LEGACY_SLIPPAGE_PCT,
+        funding_cadence="per_bar",
+        futures_funding_rate=0.0002,
+    )
+    assert config.fee_rate == 0.001
+    assert config.slippage_pct == 0.001
+    assert config.funding_cadence == "per_bar"
+    assert config.futures_funding_rate == 0.0002
+
+
+def test_resolved_cost_audit_logs_new_defaults() -> None:
+    config = BacktestConfig(
+        symbol="SOLUSDT",
+        timeframe="1h",
+        start_date="2023-01-01",
+        end_date="2023-01-02",
+        futures_mode=True,
+    )
+    engine = BacktestEngine(config, IndicatorReader({}))
+    audit = engine._resolved_cost_audit()
+
+    assert audit["round_trip_cost_pct"] == pytest.approx(0.12)
+    assert audit["funding_cadence"] == "scaled_8h"
+    assert audit["effective_futures_funding_rate_per_bar"] == pytest.approx(0.0001 / 8.0)
+
+
+@pytest.mark.asyncio
+async def test_funding_scaled_8h_is_one_eighth_of_legacy_per_bar_over_1h_window() -> None:
+    """24 open 1h bars: scaled cadence should charge 1/8 of legacy per-bar total."""
+    start = datetime(2023, 1, 1, 0, 0, tzinfo=UTC)
+    data = [
+        {
+            "time": (start + timedelta(hours=idx)).isoformat(),
+            "close_price": 100.0,
+            "atr_14": 10.0,
+        }
+        for idx in range(25)
+    ]
+    base_kwargs = {
+        "symbol": "SOLUSDT",
+        "timeframe": "1h",
+        "start_date": "2023-01-01",
+        "end_date": "2023-01-03",
+        "initial_capital": 10_000.0,
+        "fee_rate": 0.0,
+        "slippage_pct": 0.0,
+        "use_atr_sizing": True,
+        "risk_per_trade": 0.02,
+        "atr_multiplier": 2.0,
+        "futures_mode": True,
+        "futures_leverage": 5,
+        "futures_funding_rate": 0.0001,
+        "apply_global_trend_filter": False,
+        "strategy_classes": [BuyOnceStrategy],
+        "aggregator_config": {"min_agreement": 1, "buy_threshold": 0.5},
+    }
+
+    legacy_engine = BacktestEngine(
+        BacktestConfig(**base_kwargs, funding_cadence="per_bar"),
+        _build_reader(data),
+    )
+    scaled_engine = BacktestEngine(
+        BacktestConfig(**base_kwargs, funding_cadence="scaled_8h"),
+        _build_reader(data),
+    )
+
+    legacy_result = await legacy_engine.run()
+    scaled_result = await scaled_engine.run()
+
+    assert legacy_result.total_trades == 1
+    assert scaled_result.total_trades == 1
+    assert scaled_result.trades[0].pnl == pytest.approx(legacy_result.trades[0].pnl / 8.0, rel=1e-6)
+
+
+def test_effective_futures_funding_rate_per_bar_matches_cost_profile_helper() -> None:
+    assert effective_futures_funding_rate_per_bar(
+        0.0001, "1h", cadence="scaled_8h"
+    ) == pytest.approx(0.0001 / 8.0)
+    assert effective_futures_funding_rate_per_bar(0.0001, "1h", cadence="per_bar") == 0.0001
+
+
+@pytest.mark.asyncio
+async def test_sentiment_macro_replay_path_runs_with_new_cost_defaults(
+    tmp_path: Path,
+) -> None:
+    """Regression: sentiment replay wiring still completes under corrected engine defaults."""
+    replay_log = tmp_path / "sentiment_replay.jsonl"
+    replay_log.write_text(
+        json.dumps(
+            {
+                "type": "sentiment_score",
+                "ts": "2023-01-01T00:00:00+00:00",
+                "payload": {"symbol": "SOLUSDT", "score": 55.0},
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    data = [
+        {
+            "time": "2023-01-01T00:00:00+00:00",
+            "close_price": 100.0,
+            "rsi_14": 30.0,
+            "bb_lower_dist": 0.001,
+            "atr_pct": 0.01,
+            "ema_200": 90.0,
+        },
+        {
+            "time": "2023-01-01T01:00:00+00:00",
+            "close_price": 101.0,
+            "rsi_14": 50.0,
+            "bb_lower_dist": 0.05,
+            "atr_pct": 0.01,
+            "ema_200": 90.0,
+        },
+    ]
+    config = BacktestConfig(
+        symbol="SOLUSDT",
+        timeframe="1h",
+        start_date="2023-01-01",
+        end_date="2023-01-02",
+        initial_capital=1000.0,
+        futures_mode=True,
+        futures_leverage=3,
+        fixed_notional_usdt=22.0,
+        apply_global_trend_filter=False,
+        replay_sentiment_path=str(replay_log),
+        replay_sentiment_max_age_seconds=24 * 3600,
+        strategy_classes=[SentimentMeanReversionStrategy],
+        strategy_configs=[
+            {
+                "rsi_oversold": 35.0,
+                "rsi_overbought": 65.0,
+                "bb_distance_threshold": 0.005,
+                "sentiment_gate_threshold": 35.0,
+                "sentiment_panic_threshold": 20.0,
+                "sentiment_boost_threshold": 65.0,
+                "volatility_regime_filter": False,
+            }
+        ],
+        aggregator_config={"min_agreement": 1, "buy_threshold": 0.5, "sell_threshold": -0.5},
+    )
+
+    result = await BacktestEngine(config, _build_reader(data)).run()
+
+    assert result.total_trades >= 0
+    assert result.final_equity > 0

--- a/tests/test_backtest_futures.py
+++ b/tests/test_backtest_futures.py
@@ -115,6 +115,7 @@ def test_margin_is_reserved_on_open_and_returned_on_close():
 
 @pytest.mark.asyncio
 async def test_funding_is_deducted_per_open_candle():
+    """Legacy per-bar funding cadence remains opt-in via funding_cadence='per_bar'."""
     data = [
         {"time": "2023-01-01T00:00:00", "close_price": 100.0, "atr_14": 10.0},
         {"time": "2023-01-01T00:01:00", "close_price": 100.0, "atr_14": 10.0},
@@ -134,6 +135,7 @@ async def test_funding_is_deducted_per_open_candle():
         futures_mode=True,
         futures_leverage=5,
         futures_funding_rate=0.01,
+        funding_cadence="per_bar",
         apply_global_trend_filter=False,
         strategy_classes=[BuyOnceStrategy],
         aggregator_config={"min_agreement": 1, "buy_threshold": 0.5},


### PR DESCRIPTION
## Summary

Surgical correctness fix for backtest engine cost defaults and futures funding cadence, per `docs/specs/backtest-cost-funding-fix-brief-v0.md` and the [integrity audit](docs/reports/backtest-engine-integrity-audit-2026-06-18.md) (Findings A & B).

**Task 1 of 3** — must land before Tasks 2 (cost-realism re-run) and 3 (trend-filter logging) to avoid merge conflicts on `engine.py` / `cost_overrides.py`.

## Changes

### Default costs (`BacktestConfig`)
- `fee_rate`: `0.001` → `0.0004` (0.04%/side)
- `slippage_pct`: `0.001` → `0.0002` (0.02%/side)
- Round-trip default ≈ **0.12%** (was ~0.4%)
- **Config/CLI overrides still win** when explicitly set

### Funding cadence fix
- New `funding_cadence: FundingCadence = "scaled_8h"` on `BacktestConfig`
- `_apply_funding` reuses shared `effective_futures_funding_rate_per_bar()` from `cost_overrides.py` (no duplication)
- Scales per-bar charge by `timeframe_hours / 8` (equivalent to 8h settlement on 00/08/16 UTC)
- Base rate unchanged (`0.0001`); legacy `per_bar` cadence kept **opt-in** for regression tests

### Autopilot wiring
- `experiment_autopilot.py` passes **base rate + cadence** (not pre-scaled rate) → avoids double-scaling with realistic profiles

### Observability
- Logs resolved cost config at backtest start (`_resolved_cost_audit()`)

### Tests
- `tests/test_backtest_cost_defaults.py`: round-trip ≈ 0.12%, funding 1/8 ratio over 24×1h bars, override preservation, sentiment-macro replay regression
- `test_backtest_futures.py`: legacy per-bar cadence annotated + opt-in via `funding_cadence="per_bar"`

### Docs
- One-line dated note added to audit report (defaults corrected; no retro-edit of old reports)

## Out of scope
- Per-symbol empirical costs
- Global trend filter default change
- Sharpe-on-flat-bars metric

## Verification
```bash
uv run python -m pytest -v   # 1014 passed
uv run ruff check .
uv run ruff format --check .
```

## Review focus
1. Defaults-only change — overrides still win
2. Funding fix correctness — no double-scaling in autopilot
3. Live-replay regression (sentiment-macro path)
4. Audit note present