### PR TITLE
Brief: closed-family cost-corrected re-screen (last tooling test before consolidation)

### DIFF
--- a/docs/RBI_AUTORESEARCH_LOOP.md
+++ b/docs/RBI_AUTORESEARCH_LOOP.md
@@ -90,6 +90,10 @@ Before code or sweeps, create or update a short brief in `docs/specs/` or `docs/
 - target trade density
 - independence expectation vs live agents
 - validation command plan
+- **`strategy.global_trend_filter_enabled` explicit choice** (`true` or `false`) —
+  state why the lane wants the global EMA200 BUY filter on or off; do not inherit
+  silently from `base.yaml`. The backtest audit logs the resolved filter state, buffer,
+  and source at run start.
 
 Kill immediately if the brief is just "try parameters".
 
@@ -119,6 +123,10 @@ No `HAS_PULSE`, no autoresearch.
 ### Gate 2: Bounded Autoresearch
 
 Autoresearch is config-only unless the lane brief explicitly requires a new strategy class.
+
+Every autoresearch overlay under `config/autoresearch/overlays/` must set
+`strategy.global_trend_filter_enabled: true` or `false` explicitly (not inherited from
+`base.yaml`). The experiment autopilot audit dump records the resolved filter state at run start.
 
 Primary tools:
 

--- a/docs/reports/backtest-engine-integrity-audit-2026-06-18.md
+++ b/docs/reports/backtest-engine-integrity-audit-2026-06-18.md
@@ -10,6 +10,13 @@ applied by the gate/WFO path. **No code changed.**
 **Update (2026-06-18):** Engine defaults corrected in `feat/backtest-cost-funding-fix` — fee
 0.04%/side, slippage 0.02%/side, 8h-scaled futures funding (`scaled_8h` cadence).
 
+**Update (2026-06-18, Task 3):** Global trend filter is now **audited at backtest start**
+(`BacktestEngine._resolved_cost_audit()` logs `global_trend_filter_active`, `buffer_pct`,
+`source`, and any explicit `config_global_trend_filter_enabled` from YAML). Mechanism and
+defaults unchanged (`base.yaml` stays `true`). RBI Gate 0 briefs and autoresearch overlays
+must set `strategy.global_trend_filter_enabled` explicitly — see
+[trend-filter-opt-in-brief-v0.md](../specs/trend-filter-opt-in-brief-v0.md).
+
 ---
 
 ## TL;DR

--- a/docs/specs/closed-family-cost-corrected-rescreen-v0.md
+++ b/docs/specs/closed-family-cost-corrected-rescreen-v0.md
@@ -1,0 +1,89 @@
+# Brief — Closed-Family Cost-Corrected Re-Screen (the last clean tooling test)
+
+**Status:** experiment spec — to be run by Grok; Claude reviews
+**Trigger:** Engine cost/funding defaults corrected (#94) and trend filter made explicit (#96). The
+dislocation isolation (#95) showed the cost bug was real but, for that lane, did **not** hide a
+deployable edge. This re-screen answers the remaining question **once**: *did the tooling
+(over-charged costs + the silent global trend filter) hide a deployable edge in the families most
+sensitive to it?* If no → the systematic hunt is genuinely exhausted and we consolidate.
+**Predecessors:** [backtest-engine-integrity-audit-2026-06-18.md](../reports/backtest-engine-integrity-audit-2026-06-18.md),
+[cost-realism-rerun-2026-06-18.md](../reports/cost-realism-rerun-2026-06-18.md),
+[dislocation-cost-isolation-2026-06-18.md](../reports/dislocation-cost-isolation-2026-06-18.md).
+
+---
+
+## Scope — only the cost/filter-suspect families (deliberately bounded)
+
+Re-screen **only** lanes whose closures are plausibly tooling artifacts: **frequent-trading and/or
+trend-filter-confounded.** That is the **mean-reversion / dip-buying family** — it trades often (most
+fee-sensitive) **and** was silently blocked from its core trade by the default-on global trend filter.
+
+**Do NOT re-run** the cost-independent closures (waste of runs, prior is ~0):
+- **Cross-asset / TradFi** — had *zero forward predictive signal* (cost-independent). Stays closed.
+- **Macro calendar / surprise** — no forward drift / priced in (cost-independent). Stays closed.
+- **Trend family** — daily-trend already re-tested at realistic cost (#92) → still FAIL; failed on
+  trade-count/concentration, not fees. Stays closed.
+- **Dislocation** — already isolated (#95) → stays closed.
+
+## Frozen lane set (defined ex-ante — no additions to find a winner)
+
+The mean-reversion family, on the symbols/timeframes they were originally closed at (document each
+from the ledger):
+1. `rsi_reversal`
+2. `bollinger_strategy`
+3. `mean_reversion`
+4. `range_reversion_bounded` (the ETH 4h lane used in the cost-realism run)
+
+(If a lane's original config/params aren't recoverable from the ledger/git, document and skip it —
+do not invent new params; this is a re-screen of *closed* configs, not a new search.)
+
+## Design — best-case screen at corrected costs (2 cells/lane)
+
+Costs are already corrected on `main` (fee 0.04%, slippage 0.02%, 8h funding) — just run on `main`,
+no overrides. The only swept variable is the **trend filter**, because it cuts both ways
+(range-reversion needed it; dip-buyers are blocked by it):
+
+| Cell | Cost | Trend filter |
+|------|------|--------------|
+| A | corrected (main default) | **OFF** (let the strategy trade its own logic) |
+| B | corrected (main default) | **ON** (native/base default) |
+
+Take **best of A/B per lane** as the screen. Rationale: if a lane can't clear the gate at corrected
+costs under *either* filter setting, it is genuinely dead — not a tooling artifact.
+
+Reference (no re-run needed): cite each lane's **original closed verdict** (legacy cost) from the
+ledger so the cost-corrected delta is visible.
+
+## Pulse / gate
+
+Use the **same gate profile** each lane was originally judged under (`standard` unless documented
+otherwise). **Do not loosen thresholds** — this isolates the tooling effect, not the bar.
+
+Same WFO setup (train/test, period) as the original closure. Print resolved cost + filter audit per
+run (now available from #94/#96).
+
+## Read-out & decision
+
+Per lane: table of `wfo_return_pct`, `wfo_sharpe`, `wfo_trades`, `max_drawdown_pct`,
+`profit_concentration`, verdict — Cell A, Cell B, and the original legacy verdict for reference.
+
+- **Any lane's best cell PASSES the gate** → the tooling *was* hiding an edge. Flag it; run a focused
+  cost×filter attribution (like #95) before re-opening, and notify for review. Do **not** auto-promote.
+- **All lanes still FAIL** → the mean-reversion family is genuinely closed at correct costs. Combined
+  with dislocation (#95), this **definitively answers** that the cost bug hid no deployable edge →
+  recommend **stop the structural-probe program and consolidate** (sentiment-macro / SOL overlay Phase 0).
+
+## Guardrails
+
+1. **Frozen lane set** — no adding/swapping lanes after seeing results.
+2. **Re-screen closed configs only** — no new parameter search; if params aren't recoverable, skip+document.
+3. **Don't loosen gates**; same profile/WFO as the original closure.
+4. **Corrected costs = main default**; do not reintroduce legacy except as the cited reference verdict.
+5. Print resolved cost+filter audit per run.
+
+## Reviewer (Claude) checkpoints
+
+(a) only the frozen mean-reversion set re-run; cost-independent families correctly excluded;
+(b) corrected costs confirmed in the per-run audit; (c) both filter cells run, best-of taken;
+(d) gate profile unchanged from original; (e) honest pass/fail per lane vs original verdict, and the
+**decision stated** (re-open-with-attribution vs family-closed-consolidate).

--- a/scripts/experiment_autopilot.py
+++ b/scripts/experiment_autopilot.py
@@ -136,6 +136,29 @@ def _futures_mode_from_raw(raw_config: dict[str, object]) -> bool:
     return bool(futures.get("enabled", False))
 
 
+def _config_explicit_trend_filter(raw_config: dict[str, object]) -> bool | None:
+    strategy = raw_config.get("strategy", {})
+    if not isinstance(strategy, dict):
+        return None
+    if "global_trend_filter_enabled" not in strategy:
+        return None
+    return bool(strategy["global_trend_filter_enabled"])
+
+
+def _resolve_global_trend_filter(
+    *,
+    raw_config: dict[str, object],
+    disable_trend_filter: bool,
+    cost_profile: CostProfile | None,
+) -> tuple[bool, str, bool | None]:
+    config_explicit = _config_explicit_trend_filter(raw_config)
+    if cost_profile is not None:
+        return cost_profile.apply_global_trend_filter, "cost_profile_override", config_explicit
+    if disable_trend_filter:
+        return False, "cli_override", config_explicit
+    return True, "engine_default", config_explicit
+
+
 def _build_backtest_config(
     *,
     settings: object,
@@ -165,10 +188,13 @@ def _build_backtest_config(
 
     fee_rate = cost_profile.fee_rate if cost_profile is not None else REALISTIC_FEE_RATE
     slippage_pct = cost_profile.slippage_pct if cost_profile is not None else REALISTIC_SLIPPAGE_PCT
-    if cost_profile is not None:
-        apply_global_trend_filter = cost_profile.apply_global_trend_filter
-    else:
-        apply_global_trend_filter = not disable_trend_filter
+    apply_global_trend_filter, trend_filter_source, config_trend_filter = (
+        _resolve_global_trend_filter(
+            raw_config=raw_config,
+            disable_trend_filter=disable_trend_filter,
+            cost_profile=cost_profile,
+        )
+    )
 
     futures_mode = _futures_mode_from_raw(raw_config)
     futures_settings = getattr(settings, "futures", None)
@@ -200,6 +226,8 @@ def _build_backtest_config(
         global_trend_filter_buffer_pct=float(
             raw_config.get("strategy", {}).get("global_trend_filter_buffer_pct", 0.0)
         ),
+        global_trend_filter_source=trend_filter_source,
+        config_global_trend_filter_enabled=config_trend_filter,
         session_liquidity_router=parse_session_liquidity_router(
             raw_config.get("strategy", {}).get("session_liquidity_router")
         ),
@@ -547,6 +575,12 @@ async def run_experiment_evaluation(
                 if cost_profile is not None
                 else None
             ),
+            "global_trend_filter": {
+                "active": base_config.apply_global_trend_filter,
+                "buffer_pct": base_config.global_trend_filter_buffer_pct,
+                "source": base_config.global_trend_filter_source,
+                "config_explicit": base_config.config_global_trend_filter_enabled,
+            },
         }
         return summary, gates, window_results, base_config, audit_payload
     finally:

--- a/scripts/run_backtest.py
+++ b/scripts/run_backtest.py
@@ -115,6 +115,16 @@ async def main():
         args.min_notional if args.min_notional is not None else (20.0 if futures_mode else 0.0)
     )
 
+    strategy_section = raw_config.get("strategy", {})
+    if not isinstance(strategy_section, dict):
+        strategy_section = {}
+    config_trend_filter = (
+        bool(strategy_section["global_trend_filter_enabled"])
+        if "global_trend_filter_enabled" in strategy_section
+        else None
+    )
+    trend_filter_source = "cli_override" if args.disable_trend_filter else "engine_default"
+
     config = BacktestConfig(
         symbol=args.symbol,
         timeframe=args.timeframe,
@@ -133,8 +143,10 @@ async def main():
         risk_per_trade=settings.trading_execution.risk_per_trade_pct,
         apply_global_trend_filter=not args.disable_trend_filter,
         global_trend_filter_buffer_pct=float(
-            raw_config.get("strategy", {}).get("global_trend_filter_buffer_pct", 0.05)
+            strategy_section.get("global_trend_filter_buffer_pct", 0.05)
         ),
+        global_trend_filter_source=trend_filter_source,
+        config_global_trend_filter_enabled=config_trend_filter,
         session_liquidity_router=parse_session_liquidity_router(
             raw_config.get("strategy", {}).get("session_liquidity_router")
         ),
@@ -182,7 +194,13 @@ async def main():
         f"trail_activate={config.trailing_activate_atr:.2f}, "
         f"trail_offset={config.trailing_offset_atr:.2f}"
     )
-    print(f"Trend Filter: {not args.disable_trend_filter}")
+    print(
+        "Trend Filter: "
+        f"active={config.apply_global_trend_filter}, "
+        f"buffer={config.global_trend_filter_buffer_pct:.4f}, "
+        f"source={config.global_trend_filter_source}, "
+        f"config_explicit={config.config_global_trend_filter_enabled}"
+    )
     print(
         "Session Router: "
         f"enabled={config.session_liquidity_router.enabled}, "

--- a/src/backtest/cost_overrides.py
+++ b/src/backtest/cost_overrides.py
@@ -56,6 +56,19 @@ class CostProfile:
             cadence=self.funding_cadence,
         )
 
+    def to_audit_dict(self, *, timeframe: str, futures_mode: bool) -> dict[str, object]:
+        payload = asdict(self)
+        payload["round_trip_cost_pct"] = self.round_trip_cost_pct
+        payload["funding_method"] = (
+            "scale per-bar rate by tf_hours/8 (equivalent to 8h settlement cadence)"
+            if self.funding_cadence == "scaled_8h"
+            else "charge base rate every bar (legacy engine behavior)"
+        )
+        payload["effective_futures_funding_rate"] = (
+            self.effective_futures_funding_rate(timeframe) if futures_mode else 0.0
+        )
+        return payload
+
 
 def effective_futures_funding_rate_per_bar(
     base_rate: float,
@@ -74,19 +87,6 @@ def effective_futures_funding_rate_per_bar(
     if tf_hours is None:
         raise ValueError(f"Unsupported timeframe for funding scale: {timeframe}")
     return base_rate * (tf_hours / 8.0)
-
-    def to_audit_dict(self, *, timeframe: str, futures_mode: bool) -> dict[str, object]:
-        payload = asdict(self)
-        payload["round_trip_cost_pct"] = self.round_trip_cost_pct
-        payload["funding_method"] = (
-            "scale per-bar rate by tf_hours/8 (equivalent to 8h settlement cadence)"
-            if self.funding_cadence == "scaled_8h"
-            else "charge base rate every bar (legacy engine behavior)"
-        )
-        payload["effective_futures_funding_rate"] = (
-            self.effective_futures_funding_rate(timeframe) if futures_mode else 0.0
-        )
-        return payload
 
 
 def legacy_cost_profile(*, apply_global_trend_filter: bool = True) -> CostProfile:

--- a/src/backtest/engine.py
+++ b/src/backtest/engine.py
@@ -55,6 +55,8 @@ class BacktestConfig:
     atr_multiplier: float = 1.5  # Stop distance = 1.5 * ATR
     apply_global_trend_filter: bool = True
     global_trend_filter_buffer_pct: float = 0.0
+    global_trend_filter_source: str = "engine_default"
+    config_global_trend_filter_enabled: bool | None = None
     session_liquidity_router: SessionLiquidityRouterConfig = field(
         default_factory=SessionLiquidityRouterConfig
     )
@@ -192,12 +194,17 @@ class BacktestEngine:
             "futures_funding_rate_base": self._config.futures_funding_rate,
             "effective_futures_funding_rate_per_bar": effective_funding,
             "futures_mode": self._config.futures_mode,
+            "apply_global_trend_filter": self._config.apply_global_trend_filter,
+            "global_trend_filter_active": self._config.apply_global_trend_filter,
+            "global_trend_filter_buffer_pct": self._config.global_trend_filter_buffer_pct,
+            "global_trend_filter_source": self._config.global_trend_filter_source,
+            "config_global_trend_filter_enabled": self._config.config_global_trend_filter_enabled,
         }
 
     async def run(self) -> BacktestResult:
         """Execute the backtest."""
         self._logger.info(f"Starting backtest for {self._config.symbol}...")
-        self._logger.info("Resolved backtest cost config: %s", self._resolved_cost_audit())
+        self._logger.info("Resolved backtest config audit: %s", self._resolved_cost_audit())
 
         # Instantiate strategies first to check if any require MTF
         strategies = []

--- a/tests/test_backtest_cost_defaults.py
+++ b/tests/test_backtest_cost_defaults.py
@@ -90,6 +90,8 @@ def test_resolved_cost_audit_logs_new_defaults() -> None:
     assert audit["round_trip_cost_pct"] == pytest.approx(0.12)
     assert audit["funding_cadence"] == "scaled_8h"
     assert audit["effective_futures_funding_rate_per_bar"] == pytest.approx(0.0001 / 8.0)
+    assert audit["apply_global_trend_filter"] is True
+    assert audit["global_trend_filter_source"] == "engine_default"
 
 
 @pytest.mark.asyncio

--- a/tests/test_trend_filter_audit.py
+++ b/tests/test_trend_filter_audit.py
@@ -1,0 +1,171 @@
+"""Global trend filter audit visibility tests (Task 3)."""
+
+from __future__ import annotations
+
+import pytest
+
+from scripts.experiment_autopilot import _build_backtest_config, _resolve_global_trend_filter
+from src.backtest.cost_overrides import legacy_cost_profile, realistic_cost_profile
+from src.backtest.engine import BacktestConfig, BacktestEngine
+from src.features.reader import IndicatorReader
+from src.strategy.base import BaseStrategy
+from src.strategy.signals import Signal, SignalType
+
+
+class BuyOnceStrategy(BaseStrategy):
+    def get_name(self) -> str:
+        return "BuyOnce"
+
+    async def evaluate(self, symbol: str, indicators: dict[str, object]) -> Signal:
+        price = float(indicators["close_price"])
+        if price == 100.0:
+            return Signal(SignalType.BUY, symbol, price, 1.0, "Buy", indicators)
+        return Signal(SignalType.HOLD, symbol, price, 0.0, "Hold", indicators)
+
+
+def _base_raw_config(*, trend_filter_enabled: bool | None = None) -> dict[str, object]:
+    strategy: dict[str, object] = {"global_trend_filter_buffer_pct": 0.01}
+    if trend_filter_enabled is not None:
+        strategy["global_trend_filter_enabled"] = trend_filter_enabled
+    return {"strategy": strategy, "trading_execution": {}, "futures": {"enabled": False}}
+
+
+class _StubSettings:
+    trading_execution = type(
+        "TE",
+        (),
+        {
+            "stop_loss_pct": 0.0,
+            "take_profit_pct": 0.0,
+            "use_atr_sizing": False,
+            "atr_multiplier": 1.5,
+            "risk_per_trade_pct": 0.02,
+        },
+    )()
+    futures = None
+
+
+def test_resolve_trend_filter_engine_default() -> None:
+    apply, source, explicit = _resolve_global_trend_filter(
+        raw_config=_base_raw_config(),
+        disable_trend_filter=False,
+        cost_profile=None,
+    )
+    assert apply is True
+    assert source == "engine_default"
+    assert explicit is None
+
+
+def test_resolve_trend_filter_cost_profile_override() -> None:
+    apply, source, explicit = _resolve_global_trend_filter(
+        raw_config=_base_raw_config(trend_filter_enabled=True),
+        disable_trend_filter=False,
+        cost_profile=realistic_cost_profile(apply_global_trend_filter=False),
+    )
+    assert apply is False
+    assert source == "cost_profile_override"
+    assert explicit is True
+
+
+def test_resolved_audit_includes_trend_filter_fields() -> None:
+    config = BacktestConfig(
+        symbol="SOLUSDT",
+        timeframe="1h",
+        start_date="2023-01-01",
+        end_date="2023-01-02",
+        apply_global_trend_filter=False,
+        global_trend_filter_buffer_pct=0.01,
+        global_trend_filter_source="cli_override",
+        config_global_trend_filter_enabled=False,
+    )
+    audit = BacktestEngine(config, IndicatorReader({}))._resolved_cost_audit()
+    assert audit["global_trend_filter_active"] is False
+    assert audit["global_trend_filter_buffer_pct"] == 0.01
+    assert audit["global_trend_filter_source"] == "cli_override"
+    assert audit["config_global_trend_filter_enabled"] is False
+
+
+@pytest.mark.asyncio
+async def test_explicit_true_blocks_buy_below_ema200() -> None:
+    reader = IndicatorReader({})
+    reader._connected = True
+    data = [
+        {"time": "2023-01-01T00:00:00", "close_price": 100.0, "ema_200": 120.0},
+        {"time": "2023-01-01T00:01:00", "close_price": 100.0, "ema_200": 120.0},
+    ]
+
+    async def _mock_fetch(*_args: object) -> list[dict[str, object]]:
+        return data
+
+    reader.fetch_range = _mock_fetch
+
+    config = BacktestConfig(
+        symbol="BTCUSDT",
+        timeframe="1m",
+        start_date="2023-01-01",
+        end_date="2023-01-02",
+        initial_capital=10000.0,
+        fee_rate=0.0,
+        slippage_pct=0.0,
+        apply_global_trend_filter=True,
+        global_trend_filter_buffer_pct=0.01,
+        global_trend_filter_source="engine_default",
+        strategy_classes=[BuyOnceStrategy],
+        aggregator_config={"min_agreement": 1, "buy_threshold": 0.5},
+    )
+    result = await BacktestEngine(config, reader).run()
+    assert result.total_trades == 0
+
+
+@pytest.mark.asyncio
+async def test_explicit_false_allows_buy_below_ema200() -> None:
+    reader = IndicatorReader({})
+    reader._connected = True
+    data = [
+        {"time": "2023-01-01T00:00:00", "close_price": 100.0, "ema_200": 120.0},
+        {"time": "2023-01-01T00:01:00", "close_price": 100.0, "ema_200": 120.0},
+    ]
+
+    async def _mock_fetch(*_args: object) -> list[dict[str, object]]:
+        return data
+
+    reader.fetch_range = _mock_fetch
+
+    config = BacktestConfig(
+        symbol="BTCUSDT",
+        timeframe="1m",
+        start_date="2023-01-01",
+        end_date="2023-01-02",
+        initial_capital=10000.0,
+        fee_rate=0.0,
+        slippage_pct=0.0,
+        apply_global_trend_filter=False,
+        global_trend_filter_source="cli_override",
+        strategy_classes=[BuyOnceStrategy],
+        aggregator_config={"min_agreement": 1, "buy_threshold": 0.5},
+    )
+    result = await BacktestEngine(config, reader).run()
+    assert result.total_trades == 1
+
+
+def test_build_backtest_config_records_explicit_yaml_value() -> None:
+    config = _build_backtest_config(
+        settings=_StubSettings(),
+        raw_config=_base_raw_config(trend_filter_enabled=False),
+        symbol="SOLUSDT",
+        timeframe="1h",
+        start="2024-01-01",
+        end="2024-06-01",
+        strategy_classes=[],
+        strategy_configs=[],
+        aggregator_config={},
+        initial_capital=10000.0,
+        disable_trend_filter=False,
+        replay_sentiment_path=None,
+        replay_sentiment_max_age_hours=None,
+        cost_profile=legacy_cost_profile(),
+    )
+    assert config.apply_global_trend_filter is True
+    assert config.global_trend_filter_source == "cost_profile_override"
+    assert config.config_global_trend_filter_enabled is False
+    assert config.global_trend_filter_buffer_pct == 0.01


### PR DESCRIPTION
## Summary

Planning brief (docs only) for the **last clean tooling test**: re-screen the cost/filter-suspect closed family at the now-corrected costs, to definitively answer "did the over-charged costs + silent trend filter hide a deployable edge?"

`docs/specs/closed-family-cost-corrected-rescreen-v0.md`.

## Bounded scope (deliberate)

Re-screens **only the mean-reversion family** (`rsi_reversal`, `bollinger`, `mean_reversion`, `range_reversion`) — frequent-trading (most fee-sensitive) **and** confounded by the default-on trend filter. **Excludes** cost-independent closures (cross-asset zero-signal, calendar no-drift, trend family already re-tested, dislocation already isolated) — re-running those would be wasted runs.

## Design

Costs are already corrected on `main`, so just run there; the only swept variable is the **trend filter** (cuts both ways): per lane run filter **OFF** and **ON**, take best-of as a best-case screen. Cite each lane's original legacy-cost verdict for the delta.

- **Any lane's best cell passes its original gate** → tooling *was* hiding an edge → attribute (cost vs filter) before re-opening, notify for review.
- **All still fail** → mean-reversion genuinely closed at correct costs → combined with dislocation, the cost bug hid nothing deployable → **stop structural probing, consolidate**.

## Guardrails

Frozen lane set; re-screen closed configs only (no new param search); don't loosen gates; corrected costs = main default; print resolved cost+filter audit per run.

## Sequence

Merge #95 + #96 first (corrected costs + filter audit on main), then Grok runs this off updated main. Claude reviews the decision honesty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
