### PR TITLE
feat(backtest): closed-family cost-corrected re-screen (#97)

### DIFF
--- a/config/autoresearch/overlays/rescreen-avax-4h-bollinger-strategy.yaml
+++ b/config/autoresearch/overlays/rescreen-avax-4h-bollinger-strategy.yaml
@@ -1,0 +1,33 @@
+# Frozen standalone bollinger_bounce lane (AVAX WFO best-shape config BB_D0.0_RSI30_70).
+trading:
+  pairs:
+    - AVAXUSDT
+  timeframe: 4h
+
+trading_execution:
+  sl_atr_multiplier: 2.0
+  tp_atr_multiplier: 3.0
+  trailing_activate_atr: 2.0
+  trailing_offset_atr: 1.0
+  exit_rules:
+    backtest_use_executor_exit_model: true
+    time_stop_minutes: 720
+
+strategy:
+  strategies:
+    - name: bollinger_bounce
+      config:
+        band_distance_threshold: 0.0
+        rsi_oversold: 30
+        rsi_overbought: 70
+  aggregator:
+    buy_threshold: 0.55
+    buy_threshold_uptrend: 0.50
+    sell_threshold: -0.55
+    min_confidence: 0.10
+  per_symbol_aggregator_config:
+    AVAXUSDT:
+      min_agreement: 1
+      buy_threshold: 0.55
+      sell_threshold: -0.55
+      sell_min_agreement: 1

--- a/config/autoresearch/overlays/rescreen-sol-4h-rsi-reversal.yaml
+++ b/config/autoresearch/overlays/rescreen-sol-4h-rsi-reversal.yaml
@@ -1,0 +1,30 @@
+# Frozen standalone rsi_reversal lane (SOLUSDT 4h autoresearch base params).
+trading:
+  pairs:
+    - SOLUSDT
+  timeframe: 4h
+
+trading_execution:
+  sl_atr_multiplier: 2.0
+  tp_atr_multiplier: 3.0
+  trailing_activate_atr: 1.5
+  trailing_offset_atr: 0.8
+
+strategy:
+  strategies:
+    - name: rsi_reversal
+      config:
+        rsi_period: 7
+        oversold_threshold: 35
+        overbought_threshold: 65
+  aggregator:
+    buy_threshold: 0.55
+    buy_threshold_uptrend: 0.50
+    sell_threshold: -0.55
+    min_confidence: 0.10
+  per_symbol_aggregator_config:
+    SOLUSDT:
+      min_agreement: 1
+      buy_threshold: 0.55
+      sell_threshold: -0.55
+      sell_min_agreement: 1

--- a/docs/reports/closed-family-cost-corrected-rescreen-2026-06-18.md
+++ b/docs/reports/closed-family-cost-corrected-rescreen-2026-06-18.md
@@ -1,0 +1,332 @@
+# Closed-Family Cost-Corrected Re-Screen — 2026-06-18
+
+**Spec:** [closed-family-cost-corrected-rescreen-v0.md](../specs/closed-family-cost-corrected-rescreen-v0.md)
+**Audit:** [backtest-engine-integrity-audit-2026-06-18.md](backtest-engine-integrity-audit-2026-06-18.md)
+**Predecessors:** [cost-realism-rerun-2026-06-18.md](cost-realism-rerun-2026-06-18.md), [dislocation-cost-isolation-2026-06-18.md](dislocation-cost-isolation-2026-06-18.md)
+
+## Frozen lane set (pre-registered)
+
+- **sol-4h-rsi-reversal** [RUN] — SOLUSDT 4h rsi_reversal standalone: Production/autoresearch mean-reversion vote on SOL 4h (BASE_STRATEGY_CONFIGS params). Original closure: five-strategy stack 0/704 config-search passes.
+- **avax-4h-bollinger-strategy** [RUN] — AVAXUSDT 4h bollinger_bounce standalone: AVAX 4h WFO sweep best-shape config BB_D0.0_RSI30_70_TS720_SL2.0_TP3.0 (docs/reports/avax-wfo-bollinger-20260408-153456.json).
+- **avax-4h-mean-reversion** [SKIP] — AVAXUSDT 4h mean_reversion standalone: AVAX 4h WFO best candidate MR_L120_ZE2.0_ZX0.25_TS1440_SL2.5_TP3.0 — positive OOS return but sparse trades.
+- **eth-4h-range-reversion-bounded** [RUN] — ETHUSDT 4h range_reversion_bounded (bollinger_bounce): Wave 7 near-miss (+13.55% OOS, 24 WFO trades, Sharpe 0.48). Same overlay as cost-realism rerun #92.
+
+Costs: **main defaults post #94** (fee 0.04%/side, slippage 0.02%/side, `scaled_8h` funding). Only the global trend filter is swept (Cell A OFF, Cell B ON).
+
+## Skipped lanes
+
+### `avax-4h-mean-reversion`
+
+Config not runnable on current harness: MeanReversionStrategy is not registered in settings YAML registry and indicators table lacks pair_close_price required by src/strategy/mean_reversion.py. Per brief: document and skip — no new param search.
+
+**Original legacy verdict (reference):** FAIL — docs/reports/avax-wfo-mean_reversion-20260408-153450.json (legacy costs)
+_Failed oos_trades / oos_win_rate gates; pair-spread strategy._
+
+## Lane: `avax-4h-bollinger-strategy`
+
+**Best-of screen:** cell_a (corrected cost + filter OFF) → **FAIL**
+
+| Metric | Cell A (filter OFF) | Cell B (filter ON) | Original (legacy) |
+|---|---:|---:|---:|
+| wfo_return_pct | 11.14 | -3.45 | -25.27 |
+| wfo_sharpe | 0.81 | -0.21 | -1.45 |
+| wfo_trades | 26 | 7 | 65 |
+| max_drawdown_pct | 22.28 | 7.17 | 60.31 |
+| profit_concentration | 69.92 | 100.00 | — |
+| verdict | FAIL | FAIL | FAIL |
+
+_Original reference: docs/reports/avax-wfo-bollinger-20260408-153456.json (legacy costs). AVAX WFO oos_* metrics under pre-#94 engine defaults._
+
+### cell_a — resolved cost + filter audit
+
+**Cost audit:**
+
+```json
+{
+  "name": "corrected",
+  "fee_rate": 0.0004,
+  "slippage_pct": 0.0002,
+  "apply_global_trend_filter": false,
+  "funding_cadence": "scaled_8h",
+  "base_futures_funding_rate": 0.0001,
+  "round_trip_cost_pct": 0.12000000000000001,
+  "funding_method": "scale per-bar rate by tf_hours/8 (equivalent to 8h settlement cadence)",
+  "effective_futures_funding_rate": 0.0
+}
+```
+
+**Global trend filter audit:**
+
+```json
+{
+  "active": false,
+  "buffer_pct": 0.0,
+  "source": "cost_profile_override",
+  "config_explicit": null
+}
+```
+
+**BacktestConfig (key fields):**
+
+```json
+{
+  "fee_rate": 0.0004,
+  "slippage_pct": 0.0002,
+  "apply_global_trend_filter": false,
+  "futures_mode": false,
+  "futures_funding_rate": 0.0001,
+  "funding_cadence": "scaled_8h",
+  "global_trend_filter_buffer_pct": 0.0
+}
+```
+
+### cell_b — resolved cost + filter audit
+
+**Cost audit:**
+
+```json
+{
+  "name": "corrected",
+  "fee_rate": 0.0004,
+  "slippage_pct": 0.0002,
+  "apply_global_trend_filter": true,
+  "funding_cadence": "scaled_8h",
+  "base_futures_funding_rate": 0.0001,
+  "round_trip_cost_pct": 0.12000000000000001,
+  "funding_method": "scale per-bar rate by tf_hours/8 (equivalent to 8h settlement cadence)",
+  "effective_futures_funding_rate": 0.0
+}
+```
+
+**Global trend filter audit:**
+
+```json
+{
+  "active": true,
+  "buffer_pct": 0.0,
+  "source": "cost_profile_override",
+  "config_explicit": null
+}
+```
+
+**BacktestConfig (key fields):**
+
+```json
+{
+  "fee_rate": 0.0004,
+  "slippage_pct": 0.0002,
+  "apply_global_trend_filter": true,
+  "futures_mode": false,
+  "futures_funding_rate": 0.0001,
+  "funding_cadence": "scaled_8h",
+  "global_trend_filter_buffer_pct": 0.0
+}
+```
+
+## Lane: `eth-4h-range-reversion-bounded`
+
+**Best-of screen:** cell_b (corrected cost + filter ON) → **FAIL**
+
+| Metric | Cell A (filter OFF) | Cell B (filter ON) | Original (legacy) |
+|---|---:|---:|---:|
+| wfo_return_pct | -46.52 | 3.66 | 1.27 |
+| wfo_sharpe | -1.84 | -0.29 | -0.71 |
+| wfo_trades | 66 | 14 | 15 |
+| max_drawdown_pct | 71.53 | 28.06 | 28.69 |
+| profit_concentration | 100.00 | 100.00 | 100.00 |
+| verdict | FAIL | FAIL | FAIL |
+
+_Original reference: research/cost-realism-rerun/eth-4h-range-reversion-bounded-legacy.json. Ledger Wave 7 NEAR_MISS: +13.55% OOS at b=100 but DD/P(loss)/Sharpe fail._
+
+### cell_a — resolved cost + filter audit
+
+**Cost audit:**
+
+```json
+{
+  "name": "corrected",
+  "fee_rate": 0.0004,
+  "slippage_pct": 0.0002,
+  "apply_global_trend_filter": false,
+  "funding_cadence": "scaled_8h",
+  "base_futures_funding_rate": 0.0001,
+  "round_trip_cost_pct": 0.12000000000000001,
+  "funding_method": "scale per-bar rate by tf_hours/8 (equivalent to 8h settlement cadence)",
+  "effective_futures_funding_rate": 0.0
+}
+```
+
+**Global trend filter audit:**
+
+```json
+{
+  "active": false,
+  "buffer_pct": 0.0025,
+  "source": "cost_profile_override",
+  "config_explicit": null
+}
+```
+
+**BacktestConfig (key fields):**
+
+```json
+{
+  "fee_rate": 0.0004,
+  "slippage_pct": 0.0002,
+  "apply_global_trend_filter": false,
+  "futures_mode": false,
+  "futures_funding_rate": 0.0001,
+  "funding_cadence": "scaled_8h",
+  "global_trend_filter_buffer_pct": 0.0025
+}
+```
+
+### cell_b — resolved cost + filter audit
+
+**Cost audit:**
+
+```json
+{
+  "name": "corrected",
+  "fee_rate": 0.0004,
+  "slippage_pct": 0.0002,
+  "apply_global_trend_filter": true,
+  "funding_cadence": "scaled_8h",
+  "base_futures_funding_rate": 0.0001,
+  "round_trip_cost_pct": 0.12000000000000001,
+  "funding_method": "scale per-bar rate by tf_hours/8 (equivalent to 8h settlement cadence)",
+  "effective_futures_funding_rate": 0.0
+}
+```
+
+**Global trend filter audit:**
+
+```json
+{
+  "active": true,
+  "buffer_pct": 0.0025,
+  "source": "cost_profile_override",
+  "config_explicit": null
+}
+```
+
+**BacktestConfig (key fields):**
+
+```json
+{
+  "fee_rate": 0.0004,
+  "slippage_pct": 0.0002,
+  "apply_global_trend_filter": true,
+  "futures_mode": false,
+  "futures_funding_rate": 0.0001,
+  "funding_cadence": "scaled_8h",
+  "global_trend_filter_buffer_pct": 0.0025
+}
+```
+
+## Lane: `sol-4h-rsi-reversal`
+
+**Best-of screen:** cell_b (corrected cost + filter ON) → **FAIL**
+
+| Metric | Cell A (filter OFF) | Cell B (filter ON) | Original (legacy) |
+|---|---:|---:|---:|
+| wfo_return_pct | -4.42 | -4.03 | — |
+| wfo_sharpe | 0.09 | 0.41 | — |
+| wfo_trades | 120 | 51 | — |
+| max_drawdown_pct | 23.97 | 20.46 | 20.66 |
+| profit_concentration | 100.00 | 45.96 | — |
+| verdict | FAIL | FAIL | FAIL |
+
+_Original reference: docs/reports/current-strategy-review-2026-03-03.md (SOL 4h stack). Standalone legacy WFO not archived; ensemble best-cluster DD ~20.7%, bootstrap P(loss) 48–56%, concentration fail, 0/704 passes._
+
+### cell_a — resolved cost + filter audit
+
+**Cost audit:**
+
+```json
+{
+  "name": "corrected",
+  "fee_rate": 0.0004,
+  "slippage_pct": 0.0002,
+  "apply_global_trend_filter": false,
+  "funding_cadence": "scaled_8h",
+  "base_futures_funding_rate": 0.0001,
+  "round_trip_cost_pct": 0.12000000000000001,
+  "funding_method": "scale per-bar rate by tf_hours/8 (equivalent to 8h settlement cadence)",
+  "effective_futures_funding_rate": 0.0
+}
+```
+
+**Global trend filter audit:**
+
+```json
+{
+  "active": false,
+  "buffer_pct": 0.0,
+  "source": "cost_profile_override",
+  "config_explicit": null
+}
+```
+
+**BacktestConfig (key fields):**
+
+```json
+{
+  "fee_rate": 0.0004,
+  "slippage_pct": 0.0002,
+  "apply_global_trend_filter": false,
+  "futures_mode": false,
+  "futures_funding_rate": 0.0001,
+  "funding_cadence": "scaled_8h",
+  "global_trend_filter_buffer_pct": 0.0
+}
+```
+
+### cell_b — resolved cost + filter audit
+
+**Cost audit:**
+
+```json
+{
+  "name": "corrected",
+  "fee_rate": 0.0004,
+  "slippage_pct": 0.0002,
+  "apply_global_trend_filter": true,
+  "funding_cadence": "scaled_8h",
+  "base_futures_funding_rate": 0.0001,
+  "round_trip_cost_pct": 0.12000000000000001,
+  "funding_method": "scale per-bar rate by tf_hours/8 (equivalent to 8h settlement cadence)",
+  "effective_futures_funding_rate": 0.0
+}
+```
+
+**Global trend filter audit:**
+
+```json
+{
+  "active": true,
+  "buffer_pct": 0.0,
+  "source": "cost_profile_override",
+  "config_explicit": null
+}
+```
+
+**BacktestConfig (key fields):**
+
+```json
+{
+  "fee_rate": 0.0004,
+  "slippage_pct": 0.0002,
+  "apply_global_trend_filter": true,
+  "futures_mode": false,
+  "futures_funding_rate": 0.0001,
+  "funding_cadence": "scaled_8h",
+  "global_trend_filter_buffer_pct": 0.0
+}
+```
+
+## Decision
+
+**MEAN-REVERSION FAMILY GENUINELY CLOSED** — no runnable lane's best cell passes the standard gate at corrected main defaults under either trend-filter setting. Combined with dislocation isolation (#95), the cost bug hid **no deployable edge** in fee-marginal / trend-filter-confounded families.
+
+**Recommendation:** Stop the structural-probe program and consolidate on sentiment-macro / SOL overlay Phase 0 forward validation.

--- a/research/closed-family-cost-rescreen/avax-4h-bollinger-strategy-cell_a.json
+++ b/research/closed-family-cost-rescreen/avax-4h-bollinger-strategy-cell_a.json
@@ -1,0 +1,173 @@
+{
+  "lane_id": "avax-4h-bollinger-strategy",
+  "cell_id": "cell_a",
+  "label": "corrected cost + filter OFF",
+  "summary": {
+    "symbol": "AVAXUSDT",
+    "timeframe": "4h",
+    "start": "2024-02-11",
+    "end": "2026-04-08",
+    "total_trades": 81,
+    "win_rate": 58.0246913580247,
+    "total_return_pct": 46.754032378087324,
+    "max_drawdown_pct": 22.277221569986512,
+    "sharpe_ratio": 0.9255218518607923,
+    "wfo_windows": 3,
+    "wfo_total_trades": 26,
+    "wfo_mean_sharpe": 0.8070804504689949,
+    "wfo_total_return_pct": 11.144621058948756,
+    "bootstrap_p_loss_pct": 16.6,
+    "mc_drawdown_p95_pct": 42.63342643491706,
+    "mc_drawdown_p50_pct": 22.90495239226439,
+    "profit_concentration_pct": 69.9154424913016,
+    "passes_gates": false,
+    "failure_reasons": [
+      "max_drawdown_pct failed (22.28% > 10.00%)",
+      "max_profit_concentration_pct failed (69.92% > 50.00%)"
+    ],
+    "blocked_buy_count": 0,
+    "basis_blocked_buy_count": 0,
+    "dislocation_blocked_buy_count": 0
+  },
+  "gates": {
+    "min_trades": 0,
+    "min_wfo_trades": 20,
+    "min_wfo_sharpe": 0.5,
+    "max_drawdown_pct": 10.0,
+    "max_bootstrap_p_loss_pct": 25.0,
+    "min_oos_return_pct": 0.0,
+    "max_profit_concentration_pct": 50.0,
+    "max_mc_drawdown_p95_pct": 0.0
+  },
+  "windows": [
+    {
+      "window_index": 1,
+      "train_start": "2024-02-11T00:00:00",
+      "train_end": "2024-08-11T00:00:00",
+      "test_start": "2024-08-11T00:00:00",
+      "test_end": "2024-11-11T00:00:00",
+      "total_trades": 8,
+      "win_rate": 75.0,
+      "total_return_pct": 3.8406259373717693,
+      "max_drawdown_pct": 7.470272746601372,
+      "sharpe_ratio": 1.0434146367904473
+    },
+    {
+      "window_index": 2,
+      "train_start": "2024-08-11T00:00:00",
+      "train_end": "2025-02-11T00:00:00",
+      "test_start": "2025-02-11T00:00:00",
+      "test_end": "2025-05-11T00:00:00",
+      "total_trades": 9,
+      "win_rate": 44.44444444444444,
+      "total_return_pct": -1.7366249038081698,
+      "max_drawdown_pct": 11.460835743842988,
+      "sharpe_ratio": -0.12695001624570731
+    },
+    {
+      "window_index": 3,
+      "train_start": "2025-02-11T00:00:00",
+      "train_end": "2025-08-11T00:00:00",
+      "test_start": "2025-08-11T00:00:00",
+      "test_end": "2025-11-11T00:00:00",
+      "total_trades": 9,
+      "win_rate": 55.55555555555556,
+      "total_return_pct": 8.925478188511825,
+      "max_drawdown_pct": 6.289725337642067,
+      "sharpe_ratio": 1.5047767308622448
+    }
+  ],
+  "resolved_backtest_config": {
+    "symbol": "AVAXUSDT",
+    "timeframe": "4h",
+    "start_date": "2024-02-11",
+    "end_date": "2026-04-08",
+    "initial_capital": 10000.0,
+    "fee_rate": 0.0004,
+    "stop_loss_pct": 0.01,
+    "take_profit_pct": 0.03,
+    "sl_atr_multiplier": 2.0,
+    "tp_atr_multiplier": 3.0,
+    "trailing_activate_atr": 2.0,
+    "trailing_offset_atr": 1.0,
+    "slippage_pct": 0.0002,
+    "risk_per_trade": 0.02,
+    "use_atr_sizing": false,
+    "atr_multiplier": 1.0,
+    "apply_global_trend_filter": false,
+    "global_trend_filter_buffer_pct": 0.0,
+    "global_trend_filter_source": "cost_profile_override",
+    "config_global_trend_filter_enabled": null,
+    "session_liquidity_router": {
+      "enabled": false,
+      "allowed_windows": [
+        "americas"
+      ],
+      "block_entries_outside_windows": true
+    },
+    "basis_premium_filter": {
+      "enabled": false,
+      "exchange": "binance_usdm",
+      "tail_metric": "basis_bps",
+      "positive_tail_pct": 0.05,
+      "block_positive_tail_longs": true,
+      "missing_data_policy": "allow",
+      "calibrated_positive_threshold": null
+    },
+    "cross_venue_dislocation": {
+      "enabled": false,
+      "metric": "basis_spread",
+      "mode": "require",
+      "min_spread_bps": 5.0,
+      "side": "both",
+      "missing_data_policy": "allow"
+    },
+    "allow_short": false,
+    "use_executor_exit_model": true,
+    "ignore_signal_sells": false,
+    "strategy_configs": [
+      {
+        "band_distance_threshold": 0.0,
+        "rsi_oversold": 30,
+        "rsi_overbought": 70
+      }
+    ],
+    "aggregator_config": {
+      "buy_threshold": 0.55,
+      "buy_threshold_uptrend": 0.5,
+      "sell_threshold": -0.55,
+      "btc_regime_filter_enabled": true,
+      "btc_reference_symbol": "BTCUSDT",
+      "btc_dump_threshold_pct": -1.0,
+      "btc_dump_require_below_ema200": true,
+      "min_confidence": 0.1
+    },
+    "time_stop_minutes": 720.0,
+    "replay_sentiment_path": null,
+    "replay_sentiment_max_age_seconds": null,
+    "futures_mode": false,
+    "futures_leverage": 5,
+    "futures_funding_rate": 0.0001,
+    "funding_cadence": "scaled_8h",
+    "fixed_notional_usdt": 0.0,
+    "quantity_step_size": 0.0,
+    "min_notional_usdt": 0.0
+  },
+  "cost_audit": {
+    "name": "corrected",
+    "fee_rate": 0.0004,
+    "slippage_pct": 0.0002,
+    "apply_global_trend_filter": false,
+    "funding_cadence": "scaled_8h",
+    "base_futures_funding_rate": 0.0001,
+    "round_trip_cost_pct": 0.12000000000000001,
+    "funding_method": "scale per-bar rate by tf_hours/8 (equivalent to 8h settlement cadence)",
+    "effective_futures_funding_rate": 0.0
+  },
+  "global_trend_filter_audit": {
+    "active": false,
+    "buffer_pct": 0.0,
+    "source": "cost_profile_override",
+    "config_explicit": null
+  }
+}

--- a/research/closed-family-cost-rescreen/avax-4h-bollinger-strategy-cell_b.json
+++ b/research/closed-family-cost-rescreen/avax-4h-bollinger-strategy-cell_b.json
@@ -1,0 +1,176 @@
+{
+  "lane_id": "avax-4h-bollinger-strategy",
+  "cell_id": "cell_b",
+  "label": "corrected cost + filter ON",
+  "summary": {
+    "symbol": "AVAXUSDT",
+    "timeframe": "4h",
+    "start": "2024-02-11",
+    "end": "2026-04-08",
+    "total_trades": 13,
+    "win_rate": 61.53846153846154,
+    "total_return_pct": 6.734541064927743,
+    "max_drawdown_pct": 7.170733930822514,
+    "sharpe_ratio": 0.3958082816462312,
+    "wfo_windows": 3,
+    "wfo_total_trades": 7,
+    "wfo_mean_sharpe": -0.2099624414659996,
+    "wfo_total_return_pct": -3.4469189375277987,
+    "bootstrap_p_loss_pct": 31.0,
+    "mc_drawdown_p95_pct": 16.597665042952226,
+    "mc_drawdown_p50_pct": 7.361053551664051,
+    "profit_concentration_pct": 100.0,
+    "passes_gates": false,
+    "failure_reasons": [
+      "min_wfo_trades failed (7 < 20)",
+      "min_wfo_sharpe failed (-0.21 < 0.50)",
+      "max_bootstrap_p_loss_pct failed (31.00% > 25.00%)",
+      "min_oos_return_pct failed (-3.45% < 0.00%)",
+      "max_profit_concentration_pct failed (100.00% > 50.00%)"
+    ],
+    "blocked_buy_count": 0,
+    "basis_blocked_buy_count": 0,
+    "dislocation_blocked_buy_count": 0
+  },
+  "gates": {
+    "min_trades": 0,
+    "min_wfo_trades": 20,
+    "min_wfo_sharpe": 0.5,
+    "max_drawdown_pct": 10.0,
+    "max_bootstrap_p_loss_pct": 25.0,
+    "min_oos_return_pct": 0.0,
+    "max_profit_concentration_pct": 50.0,
+    "max_mc_drawdown_p95_pct": 0.0
+  },
+  "windows": [
+    {
+      "window_index": 1,
+      "train_start": "2024-02-11T00:00:00",
+      "train_end": "2024-08-11T00:00:00",
+      "test_start": "2024-08-11T00:00:00",
+      "test_end": "2024-11-11T00:00:00",
+      "total_trades": 3,
+      "win_rate": 66.66666666666666,
+      "total_return_pct": 0.7260680595560733,
+      "max_drawdown_pct": 4.261752813883015,
+      "sharpe_ratio": 0.2749583734319949
+    },
+    {
+      "window_index": 2,
+      "train_start": "2024-08-11T00:00:00",
+      "train_end": "2025-02-11T00:00:00",
+      "test_start": "2025-02-11T00:00:00",
+      "test_end": "2025-05-11T00:00:00",
+      "total_trades": 0,
+      "win_rate": 0.0,
+      "total_return_pct": 0.0,
+      "max_drawdown_pct": 0.0,
+      "sharpe_ratio": 0.0
+    },
+    {
+      "window_index": 3,
+      "train_start": "2025-02-11T00:00:00",
+      "train_end": "2025-08-11T00:00:00",
+      "test_start": "2025-08-11T00:00:00",
+      "test_end": "2025-11-11T00:00:00",
+      "total_trades": 4,
+      "win_rate": 25.0,
+      "total_return_pct": -4.14290667497964,
+      "max_drawdown_pct": 5.907452511710836,
+      "sharpe_ratio": -0.9048456978299937
+    }
+  ],
+  "resolved_backtest_config": {
+    "symbol": "AVAXUSDT",
+    "timeframe": "4h",
+    "start_date": "2024-02-11",
+    "end_date": "2026-04-08",
+    "initial_capital": 10000.0,
+    "fee_rate": 0.0004,
+    "stop_loss_pct": 0.01,
+    "take_profit_pct": 0.03,
+    "sl_atr_multiplier": 2.0,
+    "tp_atr_multiplier": 3.0,
+    "trailing_activate_atr": 2.0,
+    "trailing_offset_atr": 1.0,
+    "slippage_pct": 0.0002,
+    "risk_per_trade": 0.02,
+    "use_atr_sizing": false,
+    "atr_multiplier": 1.0,
+    "apply_global_trend_filter": true,
+    "global_trend_filter_buffer_pct": 0.0,
+    "global_trend_filter_source": "cost_profile_override",
+    "config_global_trend_filter_enabled": null,
+    "session_liquidity_router": {
+      "enabled": false,
+      "allowed_windows": [
+        "americas"
+      ],
+      "block_entries_outside_windows": true
+    },
+    "basis_premium_filter": {
+      "enabled": false,
+      "exchange": "binance_usdm",
+      "tail_metric": "basis_bps",
+      "positive_tail_pct": 0.05,
+      "block_positive_tail_longs": true,
+      "missing_data_policy": "allow",
+      "calibrated_positive_threshold": null
+    },
+    "cross_venue_dislocation": {
+      "enabled": false,
+      "metric": "basis_spread",
+      "mode": "require",
+      "min_spread_bps": 5.0,
+      "side": "both",
+      "missing_data_policy": "allow"
+    },
+    "allow_short": false,
+    "use_executor_exit_model": true,
+    "ignore_signal_sells": false,
+    "strategy_configs": [
+      {
+        "band_distance_threshold": 0.0,
+        "rsi_oversold": 30,
+        "rsi_overbought": 70
+      }
+    ],
+    "aggregator_config": {
+      "buy_threshold": 0.55,
+      "buy_threshold_uptrend": 0.5,
+      "sell_threshold": -0.55,
+      "btc_regime_filter_enabled": true,
+      "btc_reference_symbol": "BTCUSDT",
+      "btc_dump_threshold_pct": -1.0,
+      "btc_dump_require_below_ema200": true,
+      "min_confidence": 0.1
+    },
+    "time_stop_minutes": 720.0,
+    "replay_sentiment_path": null,
+    "replay_sentiment_max_age_seconds": null,
+    "futures_mode": false,
+    "futures_leverage": 5,
+    "futures_funding_rate": 0.0001,
+    "funding_cadence": "scaled_8h",
+    "fixed_notional_usdt": 0.0,
+    "quantity_step_size": 0.0,
+    "min_notional_usdt": 0.0
+  },
+  "cost_audit": {
+    "name": "corrected",
+    "fee_rate": 0.0004,
+    "slippage_pct": 0.0002,
+    "apply_global_trend_filter": true,
+    "funding_cadence": "scaled_8h",
+    "base_futures_funding_rate": 0.0001,
+    "round_trip_cost_pct": 0.12000000000000001,
+    "funding_method": "scale per-bar rate by tf_hours/8 (equivalent to 8h settlement cadence)",
+    "effective_futures_funding_rate": 0.0
+  },
+  "global_trend_filter_audit": {
+    "active": true,
+    "buffer_pct": 0.0,
+    "source": "cost_profile_override",
+    "config_explicit": null
+  }
+}

--- a/research/closed-family-cost-rescreen/combined_results.json
+++ b/research/closed-family-cost-rescreen/combined_results.json
@@ -1,0 +1,1102 @@
+[
+  {
+    "lane_id": "sol-4h-rsi-reversal",
+    "cell_id": "cell_a",
+    "label": "corrected cost + filter OFF",
+    "summary": {
+      "symbol": "SOLUSDT",
+      "timeframe": "4h",
+      "start": "2024-01-01",
+      "end": "2026-06-01",
+      "total_trades": 274,
+      "win_rate": 28.467153284671532,
+      "total_return_pct": -11.31478606247736,
+      "max_drawdown_pct": 23.971953365838733,
+      "sharpe_ratio": -0.18010269219020852,
+      "wfo_windows": 4,
+      "wfo_total_trades": 120,
+      "wfo_mean_sharpe": 0.09479586298573628,
+      "wfo_total_return_pct": -4.423129900791444,
+      "bootstrap_p_loss_pct": 65.8,
+      "mc_drawdown_p95_pct": 51.931921058766086,
+      "mc_drawdown_p50_pct": 30.83043380308141,
+      "profit_concentration_pct": 100.0,
+      "passes_gates": false,
+      "failure_reasons": [
+        "min_wfo_sharpe failed (0.09 < 0.50)",
+        "max_drawdown_pct failed (23.97% > 10.00%)",
+        "max_bootstrap_p_loss_pct failed (65.80% > 25.00%)",
+        "min_oos_return_pct failed (-4.42% < 0.00%)",
+        "max_profit_concentration_pct failed (100.00% > 50.00%)"
+      ],
+      "blocked_buy_count": 0,
+      "basis_blocked_buy_count": 0,
+      "dislocation_blocked_buy_count": 0
+    },
+    "gates": {
+      "min_trades": 0,
+      "min_wfo_trades": 20,
+      "min_wfo_sharpe": 0.5,
+      "max_drawdown_pct": 10.0,
+      "max_bootstrap_p_loss_pct": 25.0,
+      "min_oos_return_pct": 0.0,
+      "max_profit_concentration_pct": 50.0,
+      "max_mc_drawdown_p95_pct": 0.0
+    },
+    "windows": [
+      {
+        "window_index": 1,
+        "train_start": "2024-01-01T00:00:00",
+        "train_end": "2024-07-01T00:00:00",
+        "test_start": "2024-07-01T00:00:00",
+        "test_end": "2024-10-01T00:00:00",
+        "total_trades": 31,
+        "win_rate": 32.25806451612903,
+        "total_return_pct": -3.002039270201058,
+        "max_drawdown_pct": 12.457678746973498,
+        "sharpe_ratio": -0.6311825984051977
+      },
+      {
+        "window_index": 2,
+        "train_start": "2024-07-01T00:00:00",
+        "train_end": "2025-01-01T00:00:00",
+        "test_start": "2025-01-01T00:00:00",
+        "test_end": "2025-04-01T00:00:00",
+        "total_trades": 33,
+        "win_rate": 24.242424242424242,
+        "total_return_pct": -7.266852150962786,
+        "max_drawdown_pct": 13.141133175805495,
+        "sharpe_ratio": -1.4695552683899025
+      },
+      {
+        "window_index": 3,
+        "train_start": "2025-01-01T00:00:00",
+        "train_end": "2025-07-01T00:00:00",
+        "test_start": "2025-07-01T00:00:00",
+        "test_end": "2025-10-01T00:00:00",
+        "total_trades": 34,
+        "win_rate": 23.52941176470588,
+        "total_return_pct": -4.72364634153826,
+        "max_drawdown_pct": 9.570149809256343,
+        "sharpe_ratio": -0.8504893161859002
+      },
+      {
+        "window_index": 4,
+        "train_start": "2025-07-01T00:00:00",
+        "train_end": "2026-01-01T00:00:00",
+        "test_start": "2026-01-01T00:00:00",
+        "test_end": "2026-04-01T00:00:00",
+        "total_trades": 22,
+        "win_rate": 45.45454545454545,
+        "total_return_pct": 11.52444495153708,
+        "max_drawdown_pct": 5.78979812757769,
+        "sharpe_ratio": 3.3304106349239455
+      }
+    ],
+    "resolved_backtest_config": {
+      "symbol": "SOLUSDT",
+      "timeframe": "4h",
+      "start_date": "2024-01-01",
+      "end_date": "2026-06-01",
+      "initial_capital": 10000.0,
+      "fee_rate": 0.0004,
+      "stop_loss_pct": 0.01,
+      "take_profit_pct": 0.03,
+      "sl_atr_multiplier": 2.0,
+      "tp_atr_multiplier": 3.0,
+      "trailing_activate_atr": 1.5,
+      "trailing_offset_atr": 0.8,
+      "slippage_pct": 0.0002,
+      "risk_per_trade": 0.02,
+      "use_atr_sizing": false,
+      "atr_multiplier": 1.0,
+      "apply_global_trend_filter": false,
+      "global_trend_filter_buffer_pct": 0.0,
+      "global_trend_filter_source": "cost_profile_override",
+      "config_global_trend_filter_enabled": null,
+      "session_liquidity_router": {
+        "enabled": false,
+        "allowed_windows": [
+          "americas"
+        ],
+        "block_entries_outside_windows": true
+      },
+      "basis_premium_filter": {
+        "enabled": false,
+        "exchange": "binance_usdm",
+        "tail_metric": "basis_bps",
+        "positive_tail_pct": 0.05,
+        "block_positive_tail_longs": true,
+        "missing_data_policy": "allow",
+        "calibrated_positive_threshold": null
+      },
+      "cross_venue_dislocation": {
+        "enabled": false,
+        "metric": "basis_spread",
+        "mode": "require",
+        "min_spread_bps": 5.0,
+        "side": "both",
+        "missing_data_policy": "allow"
+      },
+      "allow_short": false,
+      "use_executor_exit_model": false,
+      "ignore_signal_sells": false,
+      "strategy_configs": [
+        {
+          "rsi_period": 7,
+          "oversold_threshold": 35,
+          "overbought_threshold": 65
+        }
+      ],
+      "aggregator_config": {
+        "buy_threshold": 0.55,
+        "buy_threshold_uptrend": 0.5,
+        "sell_threshold": -0.55,
+        "btc_regime_filter_enabled": true,
+        "btc_reference_symbol": "BTCUSDT",
+        "btc_dump_threshold_pct": -1.0,
+        "btc_dump_require_below_ema200": true,
+        "min_confidence": 0.1
+      },
+      "time_stop_minutes": 0.0,
+      "replay_sentiment_path": null,
+      "replay_sentiment_max_age_seconds": null,
+      "futures_mode": false,
+      "futures_leverage": 5,
+      "futures_funding_rate": 0.0001,
+      "funding_cadence": "scaled_8h",
+      "fixed_notional_usdt": 0.0,
+      "quantity_step_size": 0.0,
+      "min_notional_usdt": 0.0
+    },
+    "cost_audit": {
+      "name": "corrected",
+      "fee_rate": 0.0004,
+      "slippage_pct": 0.0002,
+      "apply_global_trend_filter": false,
+      "funding_cadence": "scaled_8h",
+      "base_futures_funding_rate": 0.0001,
+      "round_trip_cost_pct": 0.12000000000000001,
+      "funding_method": "scale per-bar rate by tf_hours/8 (equivalent to 8h settlement cadence)",
+      "effective_futures_funding_rate": 0.0
+    },
+    "global_trend_filter_audit": {
+      "active": false,
+      "buffer_pct": 0.0,
+      "source": "cost_profile_override",
+      "config_explicit": null
+    }
+  },
+  {
+    "lane_id": "sol-4h-rsi-reversal",
+    "cell_id": "cell_b",
+    "label": "corrected cost + filter ON",
+    "summary": {
+      "symbol": "SOLUSDT",
+      "timeframe": "4h",
+      "start": "2024-01-01",
+      "end": "2026-06-01",
+      "total_trades": 127,
+      "win_rate": 25.196850393700785,
+      "total_return_pct": -19.063566631687152,
+      "max_drawdown_pct": 20.45685845913771,
+      "sharpe_ratio": -0.703012501731618,
+      "wfo_windows": 4,
+      "wfo_total_trades": 51,
+      "wfo_mean_sharpe": 0.40525169992519006,
+      "wfo_total_return_pct": -4.025028325496438,
+      "bootstrap_p_loss_pct": 87.2,
+      "mc_drawdown_p95_pct": 43.073265352407276,
+      "mc_drawdown_p50_pct": 27.280318573312396,
+      "profit_concentration_pct": 45.960633387657005,
+      "passes_gates": false,
+      "failure_reasons": [
+        "min_wfo_sharpe failed (0.41 < 0.50)",
+        "max_drawdown_pct failed (20.46% > 10.00%)",
+        "max_bootstrap_p_loss_pct failed (87.20% > 25.00%)",
+        "min_oos_return_pct failed (-4.03% < 0.00%)"
+      ],
+      "blocked_buy_count": 0,
+      "basis_blocked_buy_count": 0,
+      "dislocation_blocked_buy_count": 0
+    },
+    "gates": {
+      "min_trades": 0,
+      "min_wfo_trades": 20,
+      "min_wfo_sharpe": 0.5,
+      "max_drawdown_pct": 10.0,
+      "max_bootstrap_p_loss_pct": 25.0,
+      "min_oos_return_pct": 0.0,
+      "max_profit_concentration_pct": 50.0,
+      "max_mc_drawdown_p95_pct": 0.0
+    },
+    "windows": [
+      {
+        "window_index": 1,
+        "train_start": "2024-01-01T00:00:00",
+        "train_end": "2024-07-01T00:00:00",
+        "test_start": "2024-07-01T00:00:00",
+        "test_end": "2024-10-01T00:00:00",
+        "total_trades": 12,
+        "win_rate": 41.66666666666667,
+        "total_return_pct": 2.2480564010348463,
+        "max_drawdown_pct": 2.969522053626899,
+        "sharpe_ratio": 0.9065602336969906
+      },
+      {
+        "window_index": 2,
+        "train_start": "2024-07-01T00:00:00",
+        "train_end": "2025-01-01T00:00:00",
+        "test_start": "2025-01-01T00:00:00",
+        "test_end": "2025-04-01T00:00:00",
+        "total_trades": 9,
+        "win_rate": 33.33333333333333,
+        "total_return_pct": 1.9563106266796786,
+        "max_drawdown_pct": 3.318775263353249,
+        "sharpe_ratio": 0.7698270834198112
+      },
+      {
+        "window_index": 3,
+        "train_start": "2025-01-01T00:00:00",
+        "train_end": "2025-07-01T00:00:00",
+        "test_start": "2025-07-01T00:00:00",
+        "test_end": "2025-10-01T00:00:00",
+        "total_trades": 25,
+        "win_rate": 16.0,
+        "total_return_pct": -11.114603497463142,
+        "max_drawdown_pct": 11.739745193495073,
+        "sharpe_ratio": -2.6738257972259265
+      },
+      {
+        "window_index": 4,
+        "train_start": "2025-07-01T00:00:00",
+        "train_end": "2026-01-01T00:00:00",
+        "test_start": "2026-01-01T00:00:00",
+        "test_end": "2026-04-01T00:00:00",
+        "total_trades": 5,
+        "win_rate": 60.0,
+        "total_return_pct": 3.575825989489003,
+        "max_drawdown_pct": 1.3593133577460055,
+        "sharpe_ratio": 2.618445279809885
+      }
+    ],
+    "resolved_backtest_config": {
+      "symbol": "SOLUSDT",
+      "timeframe": "4h",
+      "start_date": "2024-01-01",
+      "end_date": "2026-06-01",
+      "initial_capital": 10000.0,
+      "fee_rate": 0.0004,
+      "stop_loss_pct": 0.01,
+      "take_profit_pct": 0.03,
+      "sl_atr_multiplier": 2.0,
+      "tp_atr_multiplier": 3.0,
+      "trailing_activate_atr": 1.5,
+      "trailing_offset_atr": 0.8,
+      "slippage_pct": 0.0002,
+      "risk_per_trade": 0.02,
+      "use_atr_sizing": false,
+      "atr_multiplier": 1.0,
+      "apply_global_trend_filter": true,
+      "global_trend_filter_buffer_pct": 0.0,
+      "global_trend_filter_source": "cost_profile_override",
+      "config_global_trend_filter_enabled": null,
+      "session_liquidity_router": {
+        "enabled": false,
+        "allowed_windows": [
+          "americas"
+        ],
+        "block_entries_outside_windows": true
+      },
+      "basis_premium_filter": {
+        "enabled": false,
+        "exchange": "binance_usdm",
+        "tail_metric": "basis_bps",
+        "positive_tail_pct": 0.05,
+        "block_positive_tail_longs": true,
+        "missing_data_policy": "allow",
+        "calibrated_positive_threshold": null
+      },
+      "cross_venue_dislocation": {
+        "enabled": false,
+        "metric": "basis_spread",
+        "mode": "require",
+        "min_spread_bps": 5.0,
+        "side": "both",
+        "missing_data_policy": "allow"
+      },
+      "allow_short": false,
+      "use_executor_exit_model": false,
+      "ignore_signal_sells": false,
+      "strategy_configs": [
+        {
+          "rsi_period": 7,
+          "oversold_threshold": 35,
+          "overbought_threshold": 65
+        }
+      ],
+      "aggregator_config": {
+        "buy_threshold": 0.55,
+        "buy_threshold_uptrend": 0.5,
+        "sell_threshold": -0.55,
+        "btc_regime_filter_enabled": true,
+        "btc_reference_symbol": "BTCUSDT",
+        "btc_dump_threshold_pct": -1.0,
+        "btc_dump_require_below_ema200": true,
+        "min_confidence": 0.1
+      },
+      "time_stop_minutes": 0.0,
+      "replay_sentiment_path": null,
+      "replay_sentiment_max_age_seconds": null,
+      "futures_mode": false,
+      "futures_leverage": 5,
+      "futures_funding_rate": 0.0001,
+      "funding_cadence": "scaled_8h",
+      "fixed_notional_usdt": 0.0,
+      "quantity_step_size": 0.0,
+      "min_notional_usdt": 0.0
+    },
+    "cost_audit": {
+      "name": "corrected",
+      "fee_rate": 0.0004,
+      "slippage_pct": 0.0002,
+      "apply_global_trend_filter": true,
+      "funding_cadence": "scaled_8h",
+      "base_futures_funding_rate": 0.0001,
+      "round_trip_cost_pct": 0.12000000000000001,
+      "funding_method": "scale per-bar rate by tf_hours/8 (equivalent to 8h settlement cadence)",
+      "effective_futures_funding_rate": 0.0
+    },
+    "global_trend_filter_audit": {
+      "active": true,
+      "buffer_pct": 0.0,
+      "source": "cost_profile_override",
+      "config_explicit": null
+    }
+  },
+  {
+    "lane_id": "avax-4h-bollinger-strategy",
+    "cell_id": "cell_a",
+    "label": "corrected cost + filter OFF",
+    "summary": {
+      "symbol": "AVAXUSDT",
+      "timeframe": "4h",
+      "start": "2024-02-11",
+      "end": "2026-04-08",
+      "total_trades": 81,
+      "win_rate": 58.0246913580247,
+      "total_return_pct": 46.754032378087324,
+      "max_drawdown_pct": 22.277221569986512,
+      "sharpe_ratio": 0.9255218518607923,
+      "wfo_windows": 3,
+      "wfo_total_trades": 26,
+      "wfo_mean_sharpe": 0.8070804504689949,
+      "wfo_total_return_pct": 11.144621058948756,
+      "bootstrap_p_loss_pct": 16.6,
+      "mc_drawdown_p95_pct": 42.63342643491706,
+      "mc_drawdown_p50_pct": 22.90495239226439,
+      "profit_concentration_pct": 69.9154424913016,
+      "passes_gates": false,
+      "failure_reasons": [
+        "max_drawdown_pct failed (22.28% > 10.00%)",
+        "max_profit_concentration_pct failed (69.92% > 50.00%)"
+      ],
+      "blocked_buy_count": 0,
+      "basis_blocked_buy_count": 0,
+      "dislocation_blocked_buy_count": 0
+    },
+    "gates": {
+      "min_trades": 0,
+      "min_wfo_trades": 20,
+      "min_wfo_sharpe": 0.5,
+      "max_drawdown_pct": 10.0,
+      "max_bootstrap_p_loss_pct": 25.0,
+      "min_oos_return_pct": 0.0,
+      "max_profit_concentration_pct": 50.0,
+      "max_mc_drawdown_p95_pct": 0.0
+    },
+    "windows": [
+      {
+        "window_index": 1,
+        "train_start": "2024-02-11T00:00:00",
+        "train_end": "2024-08-11T00:00:00",
+        "test_start": "2024-08-11T00:00:00",
+        "test_end": "2024-11-11T00:00:00",
+        "total_trades": 8,
+        "win_rate": 75.0,
+        "total_return_pct": 3.8406259373717693,
+        "max_drawdown_pct": 7.470272746601372,
+        "sharpe_ratio": 1.0434146367904473
+      },
+      {
+        "window_index": 2,
+        "train_start": "2024-08-11T00:00:00",
+        "train_end": "2025-02-11T00:00:00",
+        "test_start": "2025-02-11T00:00:00",
+        "test_end": "2025-05-11T00:00:00",
+        "total_trades": 9,
+        "win_rate": 44.44444444444444,
+        "total_return_pct": -1.7366249038081698,
+        "max_drawdown_pct": 11.460835743842988,
+        "sharpe_ratio": -0.12695001624570731
+      },
+      {
+        "window_index": 3,
+        "train_start": "2025-02-11T00:00:00",
+        "train_end": "2025-08-11T00:00:00",
+        "test_start": "2025-08-11T00:00:00",
+        "test_end": "2025-11-11T00:00:00",
+        "total_trades": 9,
+        "win_rate": 55.55555555555556,
+        "total_return_pct": 8.925478188511825,
+        "max_drawdown_pct": 6.289725337642067,
+        "sharpe_ratio": 1.5047767308622448
+      }
+    ],
+    "resolved_backtest_config": {
+      "symbol": "AVAXUSDT",
+      "timeframe": "4h",
+      "start_date": "2024-02-11",
+      "end_date": "2026-04-08",
+      "initial_capital": 10000.0,
+      "fee_rate": 0.0004,
+      "stop_loss_pct": 0.01,
+      "take_profit_pct": 0.03,
+      "sl_atr_multiplier": 2.0,
+      "tp_atr_multiplier": 3.0,
+      "trailing_activate_atr": 2.0,
+      "trailing_offset_atr": 1.0,
+      "slippage_pct": 0.0002,
+      "risk_per_trade": 0.02,
+      "use_atr_sizing": false,
+      "atr_multiplier": 1.0,
+      "apply_global_trend_filter": false,
+      "global_trend_filter_buffer_pct": 0.0,
+      "global_trend_filter_source": "cost_profile_override",
+      "config_global_trend_filter_enabled": null,
+      "session_liquidity_router": {
+        "enabled": false,
+        "allowed_windows": [
+          "americas"
+        ],
+        "block_entries_outside_windows": true
+      },
+      "basis_premium_filter": {
+        "enabled": false,
+        "exchange": "binance_usdm",
+        "tail_metric": "basis_bps",
+        "positive_tail_pct": 0.05,
+        "block_positive_tail_longs": true,
+        "missing_data_policy": "allow",
+        "calibrated_positive_threshold": null
+      },
+      "cross_venue_dislocation": {
+        "enabled": false,
+        "metric": "basis_spread",
+        "mode": "require",
+        "min_spread_bps": 5.0,
+        "side": "both",
+        "missing_data_policy": "allow"
+      },
+      "allow_short": false,
+      "use_executor_exit_model": true,
+      "ignore_signal_sells": false,
+      "strategy_configs": [
+        {
+          "band_distance_threshold": 0.0,
+          "rsi_oversold": 30,
+          "rsi_overbought": 70
+        }
+      ],
+      "aggregator_config": {
+        "buy_threshold": 0.55,
+        "buy_threshold_uptrend": 0.5,
+        "sell_threshold": -0.55,
+        "btc_regime_filter_enabled": true,
+        "btc_reference_symbol": "BTCUSDT",
+        "btc_dump_threshold_pct": -1.0,
+        "btc_dump_require_below_ema200": true,
+        "min_confidence": 0.1
+      },
+      "time_stop_minutes": 720.0,
+      "replay_sentiment_path": null,
+      "replay_sentiment_max_age_seconds": null,
+      "futures_mode": false,
+      "futures_leverage": 5,
+      "futures_funding_rate": 0.0001,
+      "funding_cadence": "scaled_8h",
+      "fixed_notional_usdt": 0.0,
+      "quantity_step_size": 0.0,
+      "min_notional_usdt": 0.0
+    },
+    "cost_audit": {
+      "name": "corrected",
+      "fee_rate": 0.0004,
+      "slippage_pct": 0.0002,
+      "apply_global_trend_filter": false,
+      "funding_cadence": "scaled_8h",
+      "base_futures_funding_rate": 0.0001,
+      "round_trip_cost_pct": 0.12000000000000001,
+      "funding_method": "scale per-bar rate by tf_hours/8 (equivalent to 8h settlement cadence)",
+      "effective_futures_funding_rate": 0.0
+    },
+    "global_trend_filter_audit": {
+      "active": false,
+      "buffer_pct": 0.0,
+      "source": "cost_profile_override",
+      "config_explicit": null
+    }
+  },
+  {
+    "lane_id": "avax-4h-bollinger-strategy",
+    "cell_id": "cell_b",
+    "label": "corrected cost + filter ON",
+    "summary": {
+      "symbol": "AVAXUSDT",
+      "timeframe": "4h",
+      "start": "2024-02-11",
+      "end": "2026-04-08",
+      "total_trades": 13,
+      "win_rate": 61.53846153846154,
+      "total_return_pct": 6.734541064927743,
+      "max_drawdown_pct": 7.170733930822514,
+      "sharpe_ratio": 0.3958082816462312,
+      "wfo_windows": 3,
+      "wfo_total_trades": 7,
+      "wfo_mean_sharpe": -0.2099624414659996,
+      "wfo_total_return_pct": -3.4469189375277987,
+      "bootstrap_p_loss_pct": 31.0,
+      "mc_drawdown_p95_pct": 16.597665042952226,
+      "mc_drawdown_p50_pct": 7.361053551664051,
+      "profit_concentration_pct": 100.0,
+      "passes_gates": false,
+      "failure_reasons": [
+        "min_wfo_trades failed (7 < 20)",
+        "min_wfo_sharpe failed (-0.21 < 0.50)",
+        "max_bootstrap_p_loss_pct failed (31.00% > 25.00%)",
+        "min_oos_return_pct failed (-3.45% < 0.00%)",
+        "max_profit_concentration_pct failed (100.00% > 50.00%)"
+      ],
+      "blocked_buy_count": 0,
+      "basis_blocked_buy_count": 0,
+      "dislocation_blocked_buy_count": 0
+    },
+    "gates": {
+      "min_trades": 0,
+      "min_wfo_trades": 20,
+      "min_wfo_sharpe": 0.5,
+      "max_drawdown_pct": 10.0,
+      "max_bootstrap_p_loss_pct": 25.0,
+      "min_oos_return_pct": 0.0,
+      "max_profit_concentration_pct": 50.0,
+      "max_mc_drawdown_p95_pct": 0.0
+    },
+    "windows": [
+      {
+        "window_index": 1,
+        "train_start": "2024-02-11T00:00:00",
+        "train_end": "2024-08-11T00:00:00",
+        "test_start": "2024-08-11T00:00:00",
+        "test_end": "2024-11-11T00:00:00",
+        "total_trades": 3,
+        "win_rate": 66.66666666666666,
+        "total_return_pct": 0.7260680595560733,
+        "max_drawdown_pct": 4.261752813883015,
+        "sharpe_ratio": 0.2749583734319949
+      },
+      {
+        "window_index": 2,
+        "train_start": "2024-08-11T00:00:00",
+        "train_end": "2025-02-11T00:00:00",
+        "test_start": "2025-02-11T00:00:00",
+        "test_end": "2025-05-11T00:00:00",
+        "total_trades": 0,
+        "win_rate": 0.0,
+        "total_return_pct": 0.0,
+        "max_drawdown_pct": 0.0,
+        "sharpe_ratio": 0.0
+      },
+      {
+        "window_index": 3,
+        "train_start": "2025-02-11T00:00:00",
+        "train_end": "2025-08-11T00:00:00",
+        "test_start": "2025-08-11T00:00:00",
+        "test_end": "2025-11-11T00:00:00",
+        "total_trades": 4,
+        "win_rate": 25.0,
+        "total_return_pct": -4.14290667497964,
+        "max_drawdown_pct": 5.907452511710836,
+        "sharpe_ratio": -0.9048456978299937
+      }
+    ],
+    "resolved_backtest_config": {
+      "symbol": "AVAXUSDT",
+      "timeframe": "4h",
+      "start_date": "2024-02-11",
+      "end_date": "2026-04-08",
+      "initial_capital": 10000.0,
+      "fee_rate": 0.0004,
+      "stop_loss_pct": 0.01,
+      "take_profit_pct": 0.03,
+      "sl_atr_multiplier": 2.0,
+      "tp_atr_multiplier": 3.0,
+      "trailing_activate_atr": 2.0,
+      "trailing_offset_atr": 1.0,
+      "slippage_pct": 0.0002,
+      "risk_per_trade": 0.02,
+      "use_atr_sizing": false,
+      "atr_multiplier": 1.0,
+      "apply_global_trend_filter": true,
+      "global_trend_filter_buffer_pct": 0.0,
+      "global_trend_filter_source": "cost_profile_override",
+      "config_global_trend_filter_enabled": null,
+      "session_liquidity_router": {
+        "enabled": false,
+        "allowed_windows": [
+          "americas"
+        ],
+        "block_entries_outside_windows": true
+      },
+      "basis_premium_filter": {
+        "enabled": false,
+        "exchange": "binance_usdm",
+        "tail_metric": "basis_bps",
+        "positive_tail_pct": 0.05,
+        "block_positive_tail_longs": true,
+        "missing_data_policy": "allow",
+        "calibrated_positive_threshold": null
+      },
+      "cross_venue_dislocation": {
+        "enabled": false,
+        "metric": "basis_spread",
+        "mode": "require",
+        "min_spread_bps": 5.0,
+        "side": "both",
+        "missing_data_policy": "allow"
+      },
+      "allow_short": false,
+      "use_executor_exit_model": true,
+      "ignore_signal_sells": false,
+      "strategy_configs": [
+        {
+          "band_distance_threshold": 0.0,
+          "rsi_oversold": 30,
+          "rsi_overbought": 70
+        }
+      ],
+      "aggregator_config": {
+        "buy_threshold": 0.55,
+        "buy_threshold_uptrend": 0.5,
+        "sell_threshold": -0.55,
+        "btc_regime_filter_enabled": true,
+        "btc_reference_symbol": "BTCUSDT",
+        "btc_dump_threshold_pct": -1.0,
+        "btc_dump_require_below_ema200": true,
+        "min_confidence": 0.1
+      },
+      "time_stop_minutes": 720.0,
+      "replay_sentiment_path": null,
+      "replay_sentiment_max_age_seconds": null,
+      "futures_mode": false,
+      "futures_leverage": 5,
+      "futures_funding_rate": 0.0001,
+      "funding_cadence": "scaled_8h",
+      "fixed_notional_usdt": 0.0,
+      "quantity_step_size": 0.0,
+      "min_notional_usdt": 0.0
+    },
+    "cost_audit": {
+      "name": "corrected",
+      "fee_rate": 0.0004,
+      "slippage_pct": 0.0002,
+      "apply_global_trend_filter": true,
+      "funding_cadence": "scaled_8h",
+      "base_futures_funding_rate": 0.0001,
+      "round_trip_cost_pct": 0.12000000000000001,
+      "funding_method": "scale per-bar rate by tf_hours/8 (equivalent to 8h settlement cadence)",
+      "effective_futures_funding_rate": 0.0
+    },
+    "global_trend_filter_audit": {
+      "active": true,
+      "buffer_pct": 0.0,
+      "source": "cost_profile_override",
+      "config_explicit": null
+    }
+  },
+  {
+    "lane_id": "eth-4h-range-reversion-bounded",
+    "cell_id": "cell_a",
+    "label": "corrected cost + filter OFF",
+    "summary": {
+      "symbol": "ETHUSDT",
+      "timeframe": "4h",
+      "start": "2024-01-01",
+      "end": "2026-06-01",
+      "total_trades": 131,
+      "win_rate": 49.61832061068702,
+      "total_return_pct": -65.88493139899496,
+      "max_drawdown_pct": 71.52601896009385,
+      "sharpe_ratio": -1.4093515849991738,
+      "wfo_windows": 4,
+      "wfo_total_trades": 66,
+      "wfo_mean_sharpe": -1.8386434854105729,
+      "wfo_total_return_pct": -46.51796867913662,
+      "bootstrap_p_loss_pct": 98.0,
+      "mc_drawdown_p95_pct": 85.27730913494725,
+      "mc_drawdown_p50_pct": 70.76285282314392,
+      "profit_concentration_pct": 100.0,
+      "passes_gates": false,
+      "failure_reasons": [
+        "min_wfo_sharpe failed (-1.84 < 0.50)",
+        "max_drawdown_pct failed (71.53% > 10.00%)",
+        "max_bootstrap_p_loss_pct failed (98.00% > 25.00%)",
+        "min_oos_return_pct failed (-46.52% < 0.00%)",
+        "max_profit_concentration_pct failed (100.00% > 50.00%)"
+      ],
+      "blocked_buy_count": 0,
+      "basis_blocked_buy_count": 0,
+      "dislocation_blocked_buy_count": 0
+    },
+    "gates": {
+      "min_trades": 0,
+      "min_wfo_trades": 20,
+      "min_wfo_sharpe": 0.5,
+      "max_drawdown_pct": 10.0,
+      "max_bootstrap_p_loss_pct": 25.0,
+      "min_oos_return_pct": 0.0,
+      "max_profit_concentration_pct": 50.0,
+      "max_mc_drawdown_p95_pct": 0.0
+    },
+    "windows": [
+      {
+        "window_index": 1,
+        "train_start": "2024-01-01T00:00:00",
+        "train_end": "2024-07-01T00:00:00",
+        "test_start": "2024-07-01T00:00:00",
+        "test_end": "2024-10-01T00:00:00",
+        "total_trades": 23,
+        "win_rate": 47.82608695652174,
+        "total_return_pct": -17.69773941784477,
+        "max_drawdown_pct": 25.68525547070852,
+        "sharpe_ratio": -1.8939859233462055
+      },
+      {
+        "window_index": 2,
+        "train_start": "2024-07-01T00:00:00",
+        "train_end": "2025-01-01T00:00:00",
+        "test_start": "2025-01-01T00:00:00",
+        "test_end": "2025-04-01T00:00:00",
+        "total_trades": 18,
+        "win_rate": 44.44444444444444,
+        "total_return_pct": -18.898251761855573,
+        "max_drawdown_pct": 21.406951936342935,
+        "sharpe_ratio": -2.0002690013792788
+      },
+      {
+        "window_index": 3,
+        "train_start": "2025-01-01T00:00:00",
+        "train_end": "2025-07-01T00:00:00",
+        "test_start": "2025-07-01T00:00:00",
+        "test_end": "2025-10-01T00:00:00",
+        "total_trades": 13,
+        "win_rate": 61.53846153846154,
+        "total_return_pct": 0.7684898080006496,
+        "max_drawdown_pct": 8.928810703402657,
+        "sharpe_ratio": 0.25005549921667436
+      },
+      {
+        "window_index": 4,
+        "train_start": "2025-07-01T00:00:00",
+        "train_end": "2026-01-01T00:00:00",
+        "test_start": "2026-01-01T00:00:00",
+        "test_end": "2026-04-01T00:00:00",
+        "total_trades": 12,
+        "win_rate": 41.66666666666667,
+        "total_return_pct": -20.48644627139671,
+        "max_drawdown_pct": 32.60858501241407,
+        "sharpe_ratio": -3.710374516133482
+      }
+    ],
+    "resolved_backtest_config": {
+      "symbol": "ETHUSDT",
+      "timeframe": "4h",
+      "start_date": "2024-01-01",
+      "end_date": "2026-06-01",
+      "initial_capital": 10000.0,
+      "fee_rate": 0.0004,
+      "stop_loss_pct": 0.01,
+      "take_profit_pct": 0.03,
+      "sl_atr_multiplier": 2.1,
+      "tp_atr_multiplier": 3.0,
+      "trailing_activate_atr": 1.6,
+      "trailing_offset_atr": 0.8,
+      "slippage_pct": 0.0002,
+      "risk_per_trade": 0.02,
+      "use_atr_sizing": false,
+      "atr_multiplier": 1.0,
+      "apply_global_trend_filter": false,
+      "global_trend_filter_buffer_pct": 0.0025,
+      "global_trend_filter_source": "cost_profile_override",
+      "config_global_trend_filter_enabled": null,
+      "session_liquidity_router": {
+        "enabled": false,
+        "allowed_windows": [
+          "americas"
+        ],
+        "block_entries_outside_windows": true
+      },
+      "basis_premium_filter": {
+        "enabled": false,
+        "exchange": "binance_usdm",
+        "tail_metric": "basis_bps",
+        "positive_tail_pct": 0.05,
+        "block_positive_tail_longs": true,
+        "missing_data_policy": "allow",
+        "calibrated_positive_threshold": null
+      },
+      "cross_venue_dislocation": {
+        "enabled": false,
+        "metric": "basis_spread",
+        "mode": "require",
+        "min_spread_bps": 5.0,
+        "side": "both",
+        "missing_data_policy": "allow"
+      },
+      "allow_short": false,
+      "use_executor_exit_model": true,
+      "ignore_signal_sells": false,
+      "strategy_configs": [
+        {
+          "band_distance_threshold": 0.0045,
+          "rsi_oversold": 38,
+          "rsi_overbought": 62
+        }
+      ],
+      "aggregator_config": {
+        "buy_threshold": 0.6,
+        "buy_threshold_uptrend": 0.55,
+        "sell_threshold": -0.58,
+        "btc_regime_filter_enabled": true,
+        "btc_reference_symbol": "BTCUSDT",
+        "btc_dump_threshold_pct": -1.0,
+        "btc_dump_require_below_ema200": true,
+        "min_confidence": 0.1
+      },
+      "time_stop_minutes": 4320.0,
+      "replay_sentiment_path": null,
+      "replay_sentiment_max_age_seconds": null,
+      "futures_mode": false,
+      "futures_leverage": 5,
+      "futures_funding_rate": 0.0001,
+      "funding_cadence": "scaled_8h",
+      "fixed_notional_usdt": 0.0,
+      "quantity_step_size": 0.0,
+      "min_notional_usdt": 0.0
+    },
+    "cost_audit": {
+      "name": "corrected",
+      "fee_rate": 0.0004,
+      "slippage_pct": 0.0002,
+      "apply_global_trend_filter": false,
+      "funding_cadence": "scaled_8h",
+      "base_futures_funding_rate": 0.0001,
+      "round_trip_cost_pct": 0.12000000000000001,
+      "funding_method": "scale per-bar rate by tf_hours/8 (equivalent to 8h settlement cadence)",
+      "effective_futures_funding_rate": 0.0
+    },
+    "global_trend_filter_audit": {
+      "active": false,
+      "buffer_pct": 0.0025,
+      "source": "cost_profile_override",
+      "config_explicit": null
+    }
+  },
+  {
+    "lane_id": "eth-4h-range-reversion-bounded",
+    "cell_id": "cell_b",
+    "label": "corrected cost + filter ON",
+    "summary": {
+      "symbol": "ETHUSDT",
+      "timeframe": "4h",
+      "start": "2024-01-01",
+      "end": "2026-06-01",
+      "total_trades": 35,
+      "win_rate": 57.14285714285714,
+      "total_return_pct": -17.371135463806823,
+      "max_drawdown_pct": 28.05831490101427,
+      "sharpe_ratio": -0.5211381138451376,
+      "wfo_windows": 4,
+      "wfo_total_trades": 14,
+      "wfo_mean_sharpe": -0.29227240639889007,
+      "wfo_total_return_pct": 3.6575344219441863,
+      "bootstrap_p_loss_pct": 88.0,
+      "mc_drawdown_p95_pct": 41.51470768838381,
+      "mc_drawdown_p50_pct": 25.038129793647272,
+      "profit_concentration_pct": 100.0,
+      "passes_gates": false,
+      "failure_reasons": [
+        "min_wfo_trades failed (14 < 20)",
+        "min_wfo_sharpe failed (-0.29 < 0.50)",
+        "max_drawdown_pct failed (28.06% > 10.00%)",
+        "max_bootstrap_p_loss_pct failed (88.00% > 25.00%)",
+        "max_profit_concentration_pct failed (100.00% > 50.00%)"
+      ],
+      "blocked_buy_count": 0,
+      "basis_blocked_buy_count": 0,
+      "dislocation_blocked_buy_count": 0
+    },
+    "gates": {
+      "min_trades": 0,
+      "min_wfo_trades": 20,
+      "min_wfo_sharpe": 0.5,
+      "max_drawdown_pct": 10.0,
+      "max_bootstrap_p_loss_pct": 25.0,
+      "min_oos_return_pct": 0.0,
+      "max_profit_concentration_pct": 50.0,
+      "max_mc_drawdown_p95_pct": 0.0
+    },
+    "windows": [
+      {
+        "window_index": 1,
+        "train_start": "2024-01-01T00:00:00",
+        "train_end": "2024-07-01T00:00:00",
+        "test_start": "2024-07-01T00:00:00",
+        "test_end": "2024-10-01T00:00:00",
+        "total_trades": 3,
+        "win_rate": 66.66666666666666,
+        "total_return_pct": -1.4155911623963948,
+        "max_drawdown_pct": 4.148128971679798,
+        "sharpe_ratio": -0.658526527867147
+      },
+      {
+        "window_index": 2,
+        "train_start": "2024-07-01T00:00:00",
+        "train_end": "2025-01-01T00:00:00",
+        "test_start": "2025-01-01T00:00:00",
+        "test_end": "2025-04-01T00:00:00",
+        "total_trades": 0,
+        "win_rate": 0.0,
+        "total_return_pct": 0.0,
+        "max_drawdown_pct": 0.0,
+        "sharpe_ratio": 0.0
+      },
+      {
+        "window_index": 3,
+        "train_start": "2025-01-01T00:00:00",
+        "train_end": "2025-07-01T00:00:00",
+        "test_start": "2025-07-01T00:00:00",
+        "test_end": "2025-10-01T00:00:00",
+        "total_trades": 9,
+        "win_rate": 77.77777777777779,
+        "total_return_pct": 7.1746394921003045,
+        "max_drawdown_pct": 7.268913456093655,
+        "sharpe_ratio": 1.4187662895996729
+      },
+      {
+        "window_index": 4,
+        "train_start": "2025-07-01T00:00:00",
+        "train_end": "2026-01-01T00:00:00",
+        "test_start": "2026-01-01T00:00:00",
+        "test_end": "2026-04-01T00:00:00",
+        "total_trades": 2,
+        "win_rate": 50.0,
+        "total_return_pct": -1.892861967691024,
+        "max_drawdown_pct": 2.6569545285684923,
+        "sharpe_ratio": -1.9293293873280861
+      }
+    ],
+    "resolved_backtest_config": {
+      "symbol": "ETHUSDT",
+      "timeframe": "4h",
+      "start_date": "2024-01-01",
+      "end_date": "2026-06-01",
+      "initial_capital": 10000.0,
+      "fee_rate": 0.0004,
+      "stop_loss_pct": 0.01,
+      "take_profit_pct": 0.03,
+      "sl_atr_multiplier": 2.1,
+      "tp_atr_multiplier": 3.0,
+      "trailing_activate_atr": 1.6,
+      "trailing_offset_atr": 0.8,
+      "slippage_pct": 0.0002,
+      "risk_per_trade": 0.02,
+      "use_atr_sizing": false,
+      "atr_multiplier": 1.0,
+      "apply_global_trend_filter": true,
+      "global_trend_filter_buffer_pct": 0.0025,
+      "global_trend_filter_source": "cost_profile_override",
+      "config_global_trend_filter_enabled": null,
+      "session_liquidity_router": {
+        "enabled": false,
+        "allowed_windows": [
+          "americas"
+        ],
+        "block_entries_outside_windows": true
+      },
+      "basis_premium_filter": {
+        "enabled": false,
+        "exchange": "binance_usdm",
+        "tail_metric": "basis_bps",
+        "positive_tail_pct": 0.05,
+        "block_positive_tail_longs": true,
+        "missing_data_policy": "allow",
+        "calibrated_positive_threshold": null
+      },
+      "cross_venue_dislocation": {
+        "enabled": false,
+        "metric": "basis_spread",
+        "mode": "require",
+        "min_spread_bps": 5.0,
+        "side": "both",
+        "missing_data_policy": "allow"
+      },
+      "allow_short": false,
+      "use_executor_exit_model": true,
+      "ignore_signal_sells": false,
+      "strategy_configs": [
+        {
+          "band_distance_threshold": 0.0045,
+          "rsi_oversold": 38,
+          "rsi_overbought": 62
+        }
+      ],
+      "aggregator_config": {
+        "buy_threshold": 0.6,
+        "buy_threshold_uptrend": 0.55,
+        "sell_threshold": -0.58,
+        "btc_regime_filter_enabled": true,
+        "btc_reference_symbol": "BTCUSDT",
+        "btc_dump_threshold_pct": -1.0,
+        "btc_dump_require_below_ema200": true,
+        "min_confidence": 0.1
+      },
+      "time_stop_minutes": 4320.0,
+      "replay_sentiment_path": null,
+      "replay_sentiment_max_age_seconds": null,
+      "futures_mode": false,
+      "futures_leverage": 5,
+      "futures_funding_rate": 0.0001,
+      "funding_cadence": "scaled_8h",
+      "fixed_notional_usdt": 0.0,
+      "quantity_step_size": 0.0,
+      "min_notional_usdt": 0.0
+    },
+    "cost_audit": {
+      "name": "corrected",
+      "fee_rate": 0.0004,
+      "slippage_pct": 0.0002,
+      "apply_global_trend_filter": true,
+      "funding_cadence": "scaled_8h",
+      "base_futures_funding_rate": 0.0001,
+      "round_trip_cost_pct": 0.12000000000000001,
+      "funding_method": "scale per-bar rate by tf_hours/8 (equivalent to 8h settlement cadence)",
+      "effective_futures_funding_rate": 0.0
+    },
+    "global_trend_filter_audit": {
+      "active": true,
+      "buffer_pct": 0.0025,
+      "source": "cost_profile_override",
+      "config_explicit": null
+    }
+  }
+]

--- a/research/closed-family-cost-rescreen/eth-4h-range-reversion-bounded-cell_a.json
+++ b/research/closed-family-cost-rescreen/eth-4h-range-reversion-bounded-cell_a.json
@@ -1,0 +1,188 @@
+{
+  "lane_id": "eth-4h-range-reversion-bounded",
+  "cell_id": "cell_a",
+  "label": "corrected cost + filter OFF",
+  "summary": {
+    "symbol": "ETHUSDT",
+    "timeframe": "4h",
+    "start": "2024-01-01",
+    "end": "2026-06-01",
+    "total_trades": 131,
+    "win_rate": 49.61832061068702,
+    "total_return_pct": -65.88493139899496,
+    "max_drawdown_pct": 71.52601896009385,
+    "sharpe_ratio": -1.4093515849991738,
+    "wfo_windows": 4,
+    "wfo_total_trades": 66,
+    "wfo_mean_sharpe": -1.8386434854105729,
+    "wfo_total_return_pct": -46.51796867913662,
+    "bootstrap_p_loss_pct": 98.0,
+    "mc_drawdown_p95_pct": 85.27730913494725,
+    "mc_drawdown_p50_pct": 70.76285282314392,
+    "profit_concentration_pct": 100.0,
+    "passes_gates": false,
+    "failure_reasons": [
+      "min_wfo_sharpe failed (-1.84 < 0.50)",
+      "max_drawdown_pct failed (71.53% > 10.00%)",
+      "max_bootstrap_p_loss_pct failed (98.00% > 25.00%)",
+      "min_oos_return_pct failed (-46.52% < 0.00%)",
+      "max_profit_concentration_pct failed (100.00% > 50.00%)"
+    ],
+    "blocked_buy_count": 0,
+    "basis_blocked_buy_count": 0,
+    "dislocation_blocked_buy_count": 0
+  },
+  "gates": {
+    "min_trades": 0,
+    "min_wfo_trades": 20,
+    "min_wfo_sharpe": 0.5,
+    "max_drawdown_pct": 10.0,
+    "max_bootstrap_p_loss_pct": 25.0,
+    "min_oos_return_pct": 0.0,
+    "max_profit_concentration_pct": 50.0,
+    "max_mc_drawdown_p95_pct": 0.0
+  },
+  "windows": [
+    {
+      "window_index": 1,
+      "train_start": "2024-01-01T00:00:00",
+      "train_end": "2024-07-01T00:00:00",
+      "test_start": "2024-07-01T00:00:00",
+      "test_end": "2024-10-01T00:00:00",
+      "total_trades": 23,
+      "win_rate": 47.82608695652174,
+      "total_return_pct": -17.69773941784477,
+      "max_drawdown_pct": 25.68525547070852,
+      "sharpe_ratio": -1.8939859233462055
+    },
+    {
+      "window_index": 2,
+      "train_start": "2024-07-01T00:00:00",
+      "train_end": "2025-01-01T00:00:00",
+      "test_start": "2025-01-01T00:00:00",
+      "test_end": "2025-04-01T00:00:00",
+      "total_trades": 18,
+      "win_rate": 44.44444444444444,
+      "total_return_pct": -18.898251761855573,
+      "max_drawdown_pct": 21.406951936342935,
+      "sharpe_ratio": -2.0002690013792788
+    },
+    {
+      "window_index": 3,
+      "train_start": "2025-01-01T00:00:00",
+      "train_end": "2025-07-01T00:00:00",
+      "test_start": "2025-07-01T00:00:00",
+      "test_end": "2025-10-01T00:00:00",
+      "total_trades": 13,
+      "win_rate": 61.53846153846154,
+      "total_return_pct": 0.7684898080006496,
+      "max_drawdown_pct": 8.928810703402657,
+      "sharpe_ratio": 0.25005549921667436
+    },
+    {
+      "window_index": 4,
+      "train_start": "2025-07-01T00:00:00",
+      "train_end": "2026-01-01T00:00:00",
+      "test_start": "2026-01-01T00:00:00",
+      "test_end": "2026-04-01T00:00:00",
+      "total_trades": 12,
+      "win_rate": 41.66666666666667,
+      "total_return_pct": -20.48644627139671,
+      "max_drawdown_pct": 32.60858501241407,
+      "sharpe_ratio": -3.710374516133482
+    }
+  ],
+  "resolved_backtest_config": {
+    "symbol": "ETHUSDT",
+    "timeframe": "4h",
+    "start_date": "2024-01-01",
+    "end_date": "2026-06-01",
+    "initial_capital": 10000.0,
+    "fee_rate": 0.0004,
+    "stop_loss_pct": 0.01,
+    "take_profit_pct": 0.03,
+    "sl_atr_multiplier": 2.1,
+    "tp_atr_multiplier": 3.0,
+    "trailing_activate_atr": 1.6,
+    "trailing_offset_atr": 0.8,
+    "slippage_pct": 0.0002,
+    "risk_per_trade": 0.02,
+    "use_atr_sizing": false,
+    "atr_multiplier": 1.0,
+    "apply_global_trend_filter": false,
+    "global_trend_filter_buffer_pct": 0.0025,
+    "global_trend_filter_source": "cost_profile_override",
+    "config_global_trend_filter_enabled": null,
+    "session_liquidity_router": {
+      "enabled": false,
+      "allowed_windows": [
+        "americas"
+      ],
+      "block_entries_outside_windows": true
+    },
+    "basis_premium_filter": {
+      "enabled": false,
+      "exchange": "binance_usdm",
+      "tail_metric": "basis_bps",
+      "positive_tail_pct": 0.05,
+      "block_positive_tail_longs": true,
+      "missing_data_policy": "allow",
+      "calibrated_positive_threshold": null
+    },
+    "cross_venue_dislocation": {
+      "enabled": false,
+      "metric": "basis_spread",
+      "mode": "require",
+      "min_spread_bps": 5.0,
+      "side": "both",
+      "missing_data_policy": "allow"
+    },
+    "allow_short": false,
+    "use_executor_exit_model": true,
+    "ignore_signal_sells": false,
+    "strategy_configs": [
+      {
+        "band_distance_threshold": 0.0045,
+        "rsi_oversold": 38,
+        "rsi_overbought": 62
+      }
+    ],
+    "aggregator_config": {
+      "buy_threshold": 0.6,
+      "buy_threshold_uptrend": 0.55,
+      "sell_threshold": -0.58,
+      "btc_regime_filter_enabled": true,
+      "btc_reference_symbol": "BTCUSDT",
+      "btc_dump_threshold_pct": -1.0,
+      "btc_dump_require_below_ema200": true,
+      "min_confidence": 0.1
+    },
+    "time_stop_minutes": 4320.0,
+    "replay_sentiment_path": null,
+    "replay_sentiment_max_age_seconds": null,
+    "futures_mode": false,
+    "futures_leverage": 5,
+    "futures_funding_rate": 0.0001,
+    "funding_cadence": "scaled_8h",
+    "fixed_notional_usdt": 0.0,
+    "quantity_step_size": 0.0,
+    "min_notional_usdt": 0.0
+  },
+  "cost_audit": {
+    "name": "corrected",
+    "fee_rate": 0.0004,
+    "slippage_pct": 0.0002,
+    "apply_global_trend_filter": false,
+    "funding_cadence": "scaled_8h",
+    "base_futures_funding_rate": 0.0001,
+    "round_trip_cost_pct": 0.12000000000000001,
+    "funding_method": "scale per-bar rate by tf_hours/8 (equivalent to 8h settlement cadence)",
+    "effective_futures_funding_rate": 0.0
+  },
+  "global_trend_filter_audit": {
+    "active": false,
+    "buffer_pct": 0.0025,
+    "source": "cost_profile_override",
+    "config_explicit": null
+  }
+}

--- a/research/closed-family-cost-rescreen/eth-4h-range-reversion-bounded-cell_b.json
+++ b/research/closed-family-cost-rescreen/eth-4h-range-reversion-bounded-cell_b.json
@@ -1,0 +1,188 @@
+{
+  "lane_id": "eth-4h-range-reversion-bounded",
+  "cell_id": "cell_b",
+  "label": "corrected cost + filter ON",
+  "summary": {
+    "symbol": "ETHUSDT",
+    "timeframe": "4h",
+    "start": "2024-01-01",
+    "end": "2026-06-01",
+    "total_trades": 35,
+    "win_rate": 57.14285714285714,
+    "total_return_pct": -17.371135463806823,
+    "max_drawdown_pct": 28.05831490101427,
+    "sharpe_ratio": -0.5211381138451376,
+    "wfo_windows": 4,
+    "wfo_total_trades": 14,
+    "wfo_mean_sharpe": -0.29227240639889007,
+    "wfo_total_return_pct": 3.6575344219441863,
+    "bootstrap_p_loss_pct": 88.0,
+    "mc_drawdown_p95_pct": 41.51470768838381,
+    "mc_drawdown_p50_pct": 25.038129793647272,
+    "profit_concentration_pct": 100.0,
+    "passes_gates": false,
+    "failure_reasons": [
+      "min_wfo_trades failed (14 < 20)",
+      "min_wfo_sharpe failed (-0.29 < 0.50)",
+      "max_drawdown_pct failed (28.06% > 10.00%)",
+      "max_bootstrap_p_loss_pct failed (88.00% > 25.00%)",
+      "max_profit_concentration_pct failed (100.00% > 50.00%)"
+    ],
+    "blocked_buy_count": 0,
+    "basis_blocked_buy_count": 0,
+    "dislocation_blocked_buy_count": 0
+  },
+  "gates": {
+    "min_trades": 0,
+    "min_wfo_trades": 20,
+    "min_wfo_sharpe": 0.5,
+    "max_drawdown_pct": 10.0,
+    "max_bootstrap_p_loss_pct": 25.0,
+    "min_oos_return_pct": 0.0,
+    "max_profit_concentration_pct": 50.0,
+    "max_mc_drawdown_p95_pct": 0.0
+  },
+  "windows": [
+    {
+      "window_index": 1,
+      "train_start": "2024-01-01T00:00:00",
+      "train_end": "2024-07-01T00:00:00",
+      "test_start": "2024-07-01T00:00:00",
+      "test_end": "2024-10-01T00:00:00",
+      "total_trades": 3,
+      "win_rate": 66.66666666666666,
+      "total_return_pct": -1.4155911623963948,
+      "max_drawdown_pct": 4.148128971679798,
+      "sharpe_ratio": -0.658526527867147
+    },
+    {
+      "window_index": 2,
+      "train_start": "2024-07-01T00:00:00",
+      "train_end": "2025-01-01T00:00:00",
+      "test_start": "2025-01-01T00:00:00",
+      "test_end": "2025-04-01T00:00:00",
+      "total_trades": 0,
+      "win_rate": 0.0,
+      "total_return_pct": 0.0,
+      "max_drawdown_pct": 0.0,
+      "sharpe_ratio": 0.0
+    },
+    {
+      "window_index": 3,
+      "train_start": "2025-01-01T00:00:00",
+      "train_end": "2025-07-01T00:00:00",
+      "test_start": "2025-07-01T00:00:00",
+      "test_end": "2025-10-01T00:00:00",
+      "total_trades": 9,
+      "win_rate": 77.77777777777779,
+      "total_return_pct": 7.1746394921003045,
+      "max_drawdown_pct": 7.268913456093655,
+      "sharpe_ratio": 1.4187662895996729
+    },
+    {
+      "window_index": 4,
+      "train_start": "2025-07-01T00:00:00",
+      "train_end": "2026-01-01T00:00:00",
+      "test_start": "2026-01-01T00:00:00",
+      "test_end": "2026-04-01T00:00:00",
+      "total_trades": 2,
+      "win_rate": 50.0,
+      "total_return_pct": -1.892861967691024,
+      "max_drawdown_pct": 2.6569545285684923,
+      "sharpe_ratio": -1.9293293873280861
+    }
+  ],
+  "resolved_backtest_config": {
+    "symbol": "ETHUSDT",
+    "timeframe": "4h",
+    "start_date": "2024-01-01",
+    "end_date": "2026-06-01",
+    "initial_capital": 10000.0,
+    "fee_rate": 0.0004,
+    "stop_loss_pct": 0.01,
+    "take_profit_pct": 0.03,
+    "sl_atr_multiplier": 2.1,
+    "tp_atr_multiplier": 3.0,
+    "trailing_activate_atr": 1.6,
+    "trailing_offset_atr": 0.8,
+    "slippage_pct": 0.0002,
+    "risk_per_trade": 0.02,
+    "use_atr_sizing": false,
+    "atr_multiplier": 1.0,
+    "apply_global_trend_filter": true,
+    "global_trend_filter_buffer_pct": 0.0025,
+    "global_trend_filter_source": "cost_profile_override",
+    "config_global_trend_filter_enabled": null,
+    "session_liquidity_router": {
+      "enabled": false,
+      "allowed_windows": [
+        "americas"
+      ],
+      "block_entries_outside_windows": true
+    },
+    "basis_premium_filter": {
+      "enabled": false,
+      "exchange": "binance_usdm",
+      "tail_metric": "basis_bps",
+      "positive_tail_pct": 0.05,
+      "block_positive_tail_longs": true,
+      "missing_data_policy": "allow",
+      "calibrated_positive_threshold": null
+    },
+    "cross_venue_dislocation": {
+      "enabled": false,
+      "metric": "basis_spread",
+      "mode": "require",
+      "min_spread_bps": 5.0,
+      "side": "both",
+      "missing_data_policy": "allow"
+    },
+    "allow_short": false,
+    "use_executor_exit_model": true,
+    "ignore_signal_sells": false,
+    "strategy_configs": [
+      {
+        "band_distance_threshold": 0.0045,
+        "rsi_oversold": 38,
+        "rsi_overbought": 62
+      }
+    ],
+    "aggregator_config": {
+      "buy_threshold": 0.6,
+      "buy_threshold_uptrend": 0.55,
+      "sell_threshold": -0.58,
+      "btc_regime_filter_enabled": true,
+      "btc_reference_symbol": "BTCUSDT",
+      "btc_dump_threshold_pct": -1.0,
+      "btc_dump_require_below_ema200": true,
+      "min_confidence": 0.1
+    },
+    "time_stop_minutes": 4320.0,
+    "replay_sentiment_path": null,
+    "replay_sentiment_max_age_seconds": null,
+    "futures_mode": false,
+    "futures_leverage": 5,
+    "futures_funding_rate": 0.0001,
+    "funding_cadence": "scaled_8h",
+    "fixed_notional_usdt": 0.0,
+    "quantity_step_size": 0.0,
+    "min_notional_usdt": 0.0
+  },
+  "cost_audit": {
+    "name": "corrected",
+    "fee_rate": 0.0004,
+    "slippage_pct": 0.0002,
+    "apply_global_trend_filter": true,
+    "funding_cadence": "scaled_8h",
+    "base_futures_funding_rate": 0.0001,
+    "round_trip_cost_pct": 0.12000000000000001,
+    "funding_method": "scale per-bar rate by tf_hours/8 (equivalent to 8h settlement cadence)",
+    "effective_futures_funding_rate": 0.0
+  },
+  "global_trend_filter_audit": {
+    "active": true,
+    "buffer_pct": 0.0025,
+    "source": "cost_profile_override",
+    "config_explicit": null
+  }
+}

--- a/research/closed-family-cost-rescreen/resolved/avax-4h-bollinger-strategy.yaml
+++ b/research/closed-family-cost-rescreen/resolved/avax-4h-bollinger-strategy.yaml
@@ -1,0 +1,54 @@
+agent_id: autoresearch
+trading:
+  pairs:
+  - AVAXUSDT
+  timeframe: 4h
+ingest:
+  use_websocket: false
+database:
+  host: 127.0.0.1
+  port: 15432
+telegram:
+  enabled: false
+trading_execution:
+  enabled: false
+  sl_atr_multiplier: 2.0
+  tp_atr_multiplier: 3.0
+  trailing_activate_atr: 2.0
+  trailing_offset_atr: 1.0
+  exit_rules:
+    backtest_use_executor_exit_model: true
+    time_stop_minutes: 720
+futures:
+  enabled: false
+strategy:
+  strategies:
+  - name: bollinger_bounce
+    config:
+      band_distance_threshold: 0.0
+      rsi_oversold: 30
+      rsi_overbought: 70
+  aggregator:
+    buy_threshold: 0.55
+    buy_threshold_uptrend: 0.5
+    sell_threshold: -0.55
+    btc_regime_filter_enabled: true
+    btc_reference_symbol: BTCUSDT
+    btc_dump_threshold_pct: -1.0
+    btc_dump_require_below_ema200: true
+    min_confidence: 0.1
+  per_symbol_aggregator_config:
+    SOLUSDT:
+      min_agreement: 1
+      buy_threshold: 0.8
+      sell_threshold: -0.6
+      sell_min_agreement: 2
+    BNBUSDT:
+      min_agreement: 1
+      buy_threshold: 1.1
+      sell_threshold: -0.5
+    AVAXUSDT:
+      min_agreement: 1
+      buy_threshold: 0.55
+      sell_threshold: -0.55
+      sell_min_agreement: 1

--- a/research/closed-family-cost-rescreen/resolved/eth-4h-range-reversion-bounded.yaml
+++ b/research/closed-family-cost-rescreen/resolved/eth-4h-range-reversion-bounded.yaml
@@ -1,0 +1,55 @@
+agent_id: autoresearch
+trading:
+  pairs:
+  - ETHUSDT
+  timeframe: 4h
+ingest:
+  use_websocket: false
+database:
+  host: 127.0.0.1
+  port: 15432
+telegram:
+  enabled: false
+trading_execution:
+  enabled: false
+  sl_atr_multiplier: 2.1
+  tp_atr_multiplier: 3.0
+  trailing_activate_atr: 1.6
+  trailing_offset_atr: 0.8
+  exit_rules:
+    backtest_use_executor_exit_model: true
+    time_stop_minutes: 4320
+futures:
+  enabled: false
+strategy:
+  strategies:
+  - name: bollinger_bounce
+    config:
+      band_distance_threshold: 0.0045
+      rsi_oversold: 38
+      rsi_overbought: 62
+  aggregator:
+    buy_threshold: 0.6
+    buy_threshold_uptrend: 0.55
+    sell_threshold: -0.58
+    btc_regime_filter_enabled: true
+    btc_reference_symbol: BTCUSDT
+    btc_dump_threshold_pct: -1.0
+    btc_dump_require_below_ema200: true
+    min_confidence: 0.1
+  per_symbol_aggregator_config:
+    SOLUSDT:
+      min_agreement: 1
+      buy_threshold: 0.8
+      sell_threshold: -0.6
+      sell_min_agreement: 2
+    BNBUSDT:
+      min_agreement: 1
+      buy_threshold: 1.1
+      sell_threshold: -0.5
+    ETHUSDT:
+      min_agreement: 1
+      buy_threshold: 0.6
+      sell_threshold: -0.58
+      sell_min_agreement: 1
+  global_trend_filter_buffer_pct: 0.0025

--- a/research/closed-family-cost-rescreen/resolved/sol-4h-rsi-reversal.yaml
+++ b/research/closed-family-cost-rescreen/resolved/sol-4h-rsi-reversal.yaml
@@ -1,0 +1,46 @@
+agent_id: autoresearch
+trading:
+  pairs:
+  - SOLUSDT
+  timeframe: 4h
+ingest:
+  use_websocket: false
+database:
+  host: 127.0.0.1
+  port: 15432
+telegram:
+  enabled: false
+trading_execution:
+  enabled: false
+  sl_atr_multiplier: 2.0
+  tp_atr_multiplier: 3.0
+  trailing_activate_atr: 1.5
+  trailing_offset_atr: 0.8
+futures:
+  enabled: false
+strategy:
+  strategies:
+  - name: rsi_reversal
+    config:
+      rsi_period: 7
+      oversold_threshold: 35
+      overbought_threshold: 65
+  aggregator:
+    buy_threshold: 0.55
+    buy_threshold_uptrend: 0.5
+    sell_threshold: -0.55
+    btc_regime_filter_enabled: true
+    btc_reference_symbol: BTCUSDT
+    btc_dump_threshold_pct: -1.0
+    btc_dump_require_below_ema200: true
+    min_confidence: 0.1
+  per_symbol_aggregator_config:
+    SOLUSDT:
+      min_agreement: 1
+      buy_threshold: 0.55
+      sell_threshold: -0.55
+      sell_min_agreement: 1
+    BNBUSDT:
+      min_agreement: 1
+      buy_threshold: 1.1
+      sell_threshold: -0.5

--- a/research/closed-family-cost-rescreen/sol-4h-rsi-reversal-cell_a.json
+++ b/research/closed-family-cost-rescreen/sol-4h-rsi-reversal-cell_a.json
@@ -1,0 +1,188 @@
+{
+  "lane_id": "sol-4h-rsi-reversal",
+  "cell_id": "cell_a",
+  "label": "corrected cost + filter OFF",
+  "summary": {
+    "symbol": "SOLUSDT",
+    "timeframe": "4h",
+    "start": "2024-01-01",
+    "end": "2026-06-01",
+    "total_trades": 274,
+    "win_rate": 28.467153284671532,
+    "total_return_pct": -11.31478606247736,
+    "max_drawdown_pct": 23.971953365838733,
+    "sharpe_ratio": -0.18010269219020852,
+    "wfo_windows": 4,
+    "wfo_total_trades": 120,
+    "wfo_mean_sharpe": 0.09479586298573628,
+    "wfo_total_return_pct": -4.423129900791444,
+    "bootstrap_p_loss_pct": 65.8,
+    "mc_drawdown_p95_pct": 51.931921058766086,
+    "mc_drawdown_p50_pct": 30.83043380308141,
+    "profit_concentration_pct": 100.0,
+    "passes_gates": false,
+    "failure_reasons": [
+      "min_wfo_sharpe failed (0.09 < 0.50)",
+      "max_drawdown_pct failed (23.97% > 10.00%)",
+      "max_bootstrap_p_loss_pct failed (65.80% > 25.00%)",
+      "min_oos_return_pct failed (-4.42% < 0.00%)",
+      "max_profit_concentration_pct failed (100.00% > 50.00%)"
+    ],
+    "blocked_buy_count": 0,
+    "basis_blocked_buy_count": 0,
+    "dislocation_blocked_buy_count": 0
+  },
+  "gates": {
+    "min_trades": 0,
+    "min_wfo_trades": 20,
+    "min_wfo_sharpe": 0.5,
+    "max_drawdown_pct": 10.0,
+    "max_bootstrap_p_loss_pct": 25.0,
+    "min_oos_return_pct": 0.0,
+    "max_profit_concentration_pct": 50.0,
+    "max_mc_drawdown_p95_pct": 0.0
+  },
+  "windows": [
+    {
+      "window_index": 1,
+      "train_start": "2024-01-01T00:00:00",
+      "train_end": "2024-07-01T00:00:00",
+      "test_start": "2024-07-01T00:00:00",
+      "test_end": "2024-10-01T00:00:00",
+      "total_trades": 31,
+      "win_rate": 32.25806451612903,
+      "total_return_pct": -3.002039270201058,
+      "max_drawdown_pct": 12.457678746973498,
+      "sharpe_ratio": -0.6311825984051977
+    },
+    {
+      "window_index": 2,
+      "train_start": "2024-07-01T00:00:00",
+      "train_end": "2025-01-01T00:00:00",
+      "test_start": "2025-01-01T00:00:00",
+      "test_end": "2025-04-01T00:00:00",
+      "total_trades": 33,
+      "win_rate": 24.242424242424242,
+      "total_return_pct": -7.266852150962786,
+      "max_drawdown_pct": 13.141133175805495,
+      "sharpe_ratio": -1.4695552683899025
+    },
+    {
+      "window_index": 3,
+      "train_start": "2025-01-01T00:00:00",
+      "train_end": "2025-07-01T00:00:00",
+      "test_start": "2025-07-01T00:00:00",
+      "test_end": "2025-10-01T00:00:00",
+      "total_trades": 34,
+      "win_rate": 23.52941176470588,
+      "total_return_pct": -4.72364634153826,
+      "max_drawdown_pct": 9.570149809256343,
+      "sharpe_ratio": -0.8504893161859002
+    },
+    {
+      "window_index": 4,
+      "train_start": "2025-07-01T00:00:00",
+      "train_end": "2026-01-01T00:00:00",
+      "test_start": "2026-01-01T00:00:00",
+      "test_end": "2026-04-01T00:00:00",
+      "total_trades": 22,
+      "win_rate": 45.45454545454545,
+      "total_return_pct": 11.52444495153708,
+      "max_drawdown_pct": 5.78979812757769,
+      "sharpe_ratio": 3.3304106349239455
+    }
+  ],
+  "resolved_backtest_config": {
+    "symbol": "SOLUSDT",
+    "timeframe": "4h",
+    "start_date": "2024-01-01",
+    "end_date": "2026-06-01",
+    "initial_capital": 10000.0,
+    "fee_rate": 0.0004,
+    "stop_loss_pct": 0.01,
+    "take_profit_pct": 0.03,
+    "sl_atr_multiplier": 2.0,
+    "tp_atr_multiplier": 3.0,
+    "trailing_activate_atr": 1.5,
+    "trailing_offset_atr": 0.8,
+    "slippage_pct": 0.0002,
+    "risk_per_trade": 0.02,
+    "use_atr_sizing": false,
+    "atr_multiplier": 1.0,
+    "apply_global_trend_filter": false,
+    "global_trend_filter_buffer_pct": 0.0,
+    "global_trend_filter_source": "cost_profile_override",
+    "config_global_trend_filter_enabled": null,
+    "session_liquidity_router": {
+      "enabled": false,
+      "allowed_windows": [
+        "americas"
+      ],
+      "block_entries_outside_windows": true
+    },
+    "basis_premium_filter": {
+      "enabled": false,
+      "exchange": "binance_usdm",
+      "tail_metric": "basis_bps",
+      "positive_tail_pct": 0.05,
+      "block_positive_tail_longs": true,
+      "missing_data_policy": "allow",
+      "calibrated_positive_threshold": null
+    },
+    "cross_venue_dislocation": {
+      "enabled": false,
+      "metric": "basis_spread",
+      "mode": "require",
+      "min_spread_bps": 5.0,
+      "side": "both",
+      "missing_data_policy": "allow"
+    },
+    "allow_short": false,
+    "use_executor_exit_model": false,
+    "ignore_signal_sells": false,
+    "strategy_configs": [
+      {
+        "rsi_period": 7,
+        "oversold_threshold": 35,
+        "overbought_threshold": 65
+      }
+    ],
+    "aggregator_config": {
+      "buy_threshold": 0.55,
+      "buy_threshold_uptrend": 0.5,
+      "sell_threshold": -0.55,
+      "btc_regime_filter_enabled": true,
+      "btc_reference_symbol": "BTCUSDT",
+      "btc_dump_threshold_pct": -1.0,
+      "btc_dump_require_below_ema200": true,
+      "min_confidence": 0.1
+    },
+    "time_stop_minutes": 0.0,
+    "replay_sentiment_path": null,
+    "replay_sentiment_max_age_seconds": null,
+    "futures_mode": false,
+    "futures_leverage": 5,
+    "futures_funding_rate": 0.0001,
+    "funding_cadence": "scaled_8h",
+    "fixed_notional_usdt": 0.0,
+    "quantity_step_size": 0.0,
+    "min_notional_usdt": 0.0
+  },
+  "cost_audit": {
+    "name": "corrected",
+    "fee_rate": 0.0004,
+    "slippage_pct": 0.0002,
+    "apply_global_trend_filter": false,
+    "funding_cadence": "scaled_8h",
+    "base_futures_funding_rate": 0.0001,
+    "round_trip_cost_pct": 0.12000000000000001,
+    "funding_method": "scale per-bar rate by tf_hours/8 (equivalent to 8h settlement cadence)",
+    "effective_futures_funding_rate": 0.0
+  },
+  "global_trend_filter_audit": {
+    "active": false,
+    "buffer_pct": 0.0,
+    "source": "cost_profile_override",
+    "config_explicit": null
+  }
+}

--- a/research/closed-family-cost-rescreen/sol-4h-rsi-reversal-cell_b.json
+++ b/research/closed-family-cost-rescreen/sol-4h-rsi-reversal-cell_b.json
@@ -1,0 +1,187 @@
+{
+  "lane_id": "sol-4h-rsi-reversal",
+  "cell_id": "cell_b",
+  "label": "corrected cost + filter ON",
+  "summary": {
+    "symbol": "SOLUSDT",
+    "timeframe": "4h",
+    "start": "2024-01-01",
+    "end": "2026-06-01",
+    "total_trades": 127,
+    "win_rate": 25.196850393700785,
+    "total_return_pct": -19.063566631687152,
+    "max_drawdown_pct": 20.45685845913771,
+    "sharpe_ratio": -0.703012501731618,
+    "wfo_windows": 4,
+    "wfo_total_trades": 51,
+    "wfo_mean_sharpe": 0.40525169992519006,
+    "wfo_total_return_pct": -4.025028325496438,
+    "bootstrap_p_loss_pct": 87.2,
+    "mc_drawdown_p95_pct": 43.073265352407276,
+    "mc_drawdown_p50_pct": 27.280318573312396,
+    "profit_concentration_pct": 45.960633387657005,
+    "passes_gates": false,
+    "failure_reasons": [
+      "min_wfo_sharpe failed (0.41 < 0.50)",
+      "max_drawdown_pct failed (20.46% > 10.00%)",
+      "max_bootstrap_p_loss_pct failed (87.20% > 25.00%)",
+      "min_oos_return_pct failed (-4.03% < 0.00%)"
+    ],
+    "blocked_buy_count": 0,
+    "basis_blocked_buy_count": 0,
+    "dislocation_blocked_buy_count": 0
+  },
+  "gates": {
+    "min_trades": 0,
+    "min_wfo_trades": 20,
+    "min_wfo_sharpe": 0.5,
+    "max_drawdown_pct": 10.0,
+    "max_bootstrap_p_loss_pct": 25.0,
+    "min_oos_return_pct": 0.0,
+    "max_profit_concentration_pct": 50.0,
+    "max_mc_drawdown_p95_pct": 0.0
+  },
+  "windows": [
+    {
+      "window_index": 1,
+      "train_start": "2024-01-01T00:00:00",
+      "train_end": "2024-07-01T00:00:00",
+      "test_start": "2024-07-01T00:00:00",
+      "test_end": "2024-10-01T00:00:00",
+      "total_trades": 12,
+      "win_rate": 41.66666666666667,
+      "total_return_pct": 2.2480564010348463,
+      "max_drawdown_pct": 2.969522053626899,
+      "sharpe_ratio": 0.9065602336969906
+    },
+    {
+      "window_index": 2,
+      "train_start": "2024-07-01T00:00:00",
+      "train_end": "2025-01-01T00:00:00",
+      "test_start": "2025-01-01T00:00:00",
+      "test_end": "2025-04-01T00:00:00",
+      "total_trades": 9,
+      "win_rate": 33.33333333333333,
+      "total_return_pct": 1.9563106266796786,
+      "max_drawdown_pct": 3.318775263353249,
+      "sharpe_ratio": 0.7698270834198112
+    },
+    {
+      "window_index": 3,
+      "train_start": "2025-01-01T00:00:00",
+      "train_end": "2025-07-01T00:00:00",
+      "test_start": "2025-07-01T00:00:00",
+      "test_end": "2025-10-01T00:00:00",
+      "total_trades": 25,
+      "win_rate": 16.0,
+      "total_return_pct": -11.114603497463142,
+      "max_drawdown_pct": 11.739745193495073,
+      "sharpe_ratio": -2.6738257972259265
+    },
+    {
+      "window_index": 4,
+      "train_start": "2025-07-01T00:00:00",
+      "train_end": "2026-01-01T00:00:00",
+      "test_start": "2026-01-01T00:00:00",
+      "test_end": "2026-04-01T00:00:00",
+      "total_trades": 5,
+      "win_rate": 60.0,
+      "total_return_pct": 3.575825989489003,
+      "max_drawdown_pct": 1.3593133577460055,
+      "sharpe_ratio": 2.618445279809885
+    }
+  ],
+  "resolved_backtest_config": {
+    "symbol": "SOLUSDT",
+    "timeframe": "4h",
+    "start_date": "2024-01-01",
+    "end_date": "2026-06-01",
+    "initial_capital": 10000.0,
+    "fee_rate": 0.0004,
+    "stop_loss_pct": 0.01,
+    "take_profit_pct": 0.03,
+    "sl_atr_multiplier": 2.0,
+    "tp_atr_multiplier": 3.0,
+    "trailing_activate_atr": 1.5,
+    "trailing_offset_atr": 0.8,
+    "slippage_pct": 0.0002,
+    "risk_per_trade": 0.02,
+    "use_atr_sizing": false,
+    "atr_multiplier": 1.0,
+    "apply_global_trend_filter": true,
+    "global_trend_filter_buffer_pct": 0.0,
+    "global_trend_filter_source": "cost_profile_override",
+    "config_global_trend_filter_enabled": null,
+    "session_liquidity_router": {
+      "enabled": false,
+      "allowed_windows": [
+        "americas"
+      ],
+      "block_entries_outside_windows": true
+    },
+    "basis_premium_filter": {
+      "enabled": false,
+      "exchange": "binance_usdm",
+      "tail_metric": "basis_bps",
+      "positive_tail_pct": 0.05,
+      "block_positive_tail_longs": true,
+      "missing_data_policy": "allow",
+      "calibrated_positive_threshold": null
+    },
+    "cross_venue_dislocation": {
+      "enabled": false,
+      "metric": "basis_spread",
+      "mode": "require",
+      "min_spread_bps": 5.0,
+      "side": "both",
+      "missing_data_policy": "allow"
+    },
+    "allow_short": false,
+    "use_executor_exit_model": false,
+    "ignore_signal_sells": false,
+    "strategy_configs": [
+      {
+        "rsi_period": 7,
+        "oversold_threshold": 35,
+        "overbought_threshold": 65
+      }
+    ],
+    "aggregator_config": {
+      "buy_threshold": 0.55,
+      "buy_threshold_uptrend": 0.5,
+      "sell_threshold": -0.55,
+      "btc_regime_filter_enabled": true,
+      "btc_reference_symbol": "BTCUSDT",
+      "btc_dump_threshold_pct": -1.0,
+      "btc_dump_require_below_ema200": true,
+      "min_confidence": 0.1
+    },
+    "time_stop_minutes": 0.0,
+    "replay_sentiment_path": null,
+    "replay_sentiment_max_age_seconds": null,
+    "futures_mode": false,
+    "futures_leverage": 5,
+    "futures_funding_rate": 0.0001,
+    "funding_cadence": "scaled_8h",
+    "fixed_notional_usdt": 0.0,
+    "quantity_step_size": 0.0,
+    "min_notional_usdt": 0.0
+  },
+  "cost_audit": {
+    "name": "corrected",
+    "fee_rate": 0.0004,
+    "slippage_pct": 0.0002,
+    "apply_global_trend_filter": true,
+    "funding_cadence": "scaled_8h",
+    "base_futures_funding_rate": 0.0001,
+    "round_trip_cost_pct": 0.12000000000000001,
+    "funding_method": "scale per-bar rate by tf_hours/8 (equivalent to 8h settlement cadence)",
+    "effective_futures_funding_rate": 0.0
+  },
+  "global_trend_filter_audit": {
+    "active": true,
+    "buffer_pct": 0.0,
+    "source": "cost_profile_override",
+    "config_explicit": null
+  }
+}

--- a/scripts/run_closed_family_cost_rescreen.py
+++ b/scripts/run_closed_family_cost_rescreen.py
@@ -1,0 +1,548 @@
+#!/usr/bin/env python3
+"""Closed-family cost-corrected re-screen per closed-family-cost-corrected-rescreen-v0.md.
+
+Re-runs frozen mean-reversion lanes at corrected main defaults (fee 0.04%, slippage
+0.02%, 8h funding) with trend filter OFF (Cell A) vs ON (Cell B). Best-of per lane.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from scripts.experiment_autopilot import (  # noqa: E402
+    _db_config_from_settings,
+    run_experiment_evaluation,
+)
+from scripts.run_autoresearch import _gate_config_from_profile  # noqa: E402
+from scripts.run_cost_realism_rerun import _resolve_lane_config  # noqa: E402
+from src.backtest.cost_overrides import CostProfile, corrected_main_cost_profile  # noqa: E402
+from src.backtest.experiment_autopilot import GateConfig  # noqa: E402
+from src.db import close_pool, init_pool  # noqa: E402
+from src.main import load_settings  # noqa: E402
+from src.utils.logger import configure_logger, get_logger  # noqa: E402
+
+ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_OUTPUT = ROOT / "research" / "closed-family-cost-rescreen"
+DEFAULT_REPORT = ROOT / "docs" / "reports" / "closed-family-cost-corrected-rescreen-2026-06-18.md"
+
+
+@dataclass(frozen=True)
+class OriginalVerdict:
+    """Legacy-cost reference verdict (cited, not re-run)."""
+
+    wfo_return_pct: float | None
+    wfo_sharpe: float | None
+    wfo_trades: int | None
+    max_drawdown_pct: float | None
+    profit_concentration: float | None
+    verdict: str
+    source: str
+    note: str = ""
+
+
+@dataclass(frozen=True)
+class LaneSpec:
+    """Frozen mean-reversion lane (pre-registered)."""
+
+    lane_id: str
+    label: str
+    rationale: str
+    base_config: Path
+    overlay: Path | None
+    symbol: str
+    timeframe: str
+    gate_profile: str
+    start: str
+    end: str
+    train_months: int
+    test_months: int
+    bootstrap: int
+    original: OriginalVerdict
+    skipped: bool = False
+    skip_reason: str = ""
+
+
+FROZEN_LANES: tuple[LaneSpec, ...] = (
+    LaneSpec(
+        lane_id="sol-4h-rsi-reversal",
+        label="SOLUSDT 4h rsi_reversal standalone",
+        rationale=(
+            "Production/autoresearch mean-reversion vote on SOL 4h (BASE_STRATEGY_CONFIGS "
+            "params). Original closure: five-strategy stack 0/704 config-search passes."
+        ),
+        base_config=ROOT / "config" / "settings.autoresearch.yaml",
+        overlay=ROOT / "config" / "autoresearch" / "overlays" / "rescreen-sol-4h-rsi-reversal.yaml",
+        symbol="SOLUSDT",
+        timeframe="4h",
+        gate_profile="standard",
+        start="2024-01-01",
+        end="2026-06-01",
+        train_months=6,
+        test_months=3,
+        bootstrap=500,
+        original=OriginalVerdict(
+            wfo_return_pct=None,
+            wfo_sharpe=None,
+            wfo_trades=None,
+            max_drawdown_pct=20.66,
+            profit_concentration=None,
+            verdict="FAIL",
+            source="docs/reports/current-strategy-review-2026-03-03.md (SOL 4h stack)",
+            note=(
+                "Standalone legacy WFO not archived; ensemble best-cluster DD ~20.7%, "
+                "bootstrap P(loss) 48–56%, concentration fail, 0/704 passes."
+            ),
+        ),
+    ),
+    LaneSpec(
+        lane_id="avax-4h-bollinger-strategy",
+        label="AVAXUSDT 4h bollinger_bounce standalone",
+        rationale=(
+            "AVAX 4h WFO sweep best-shape config BB_D0.0_RSI30_70_TS720_SL2.0_TP3.0 "
+            "(docs/reports/avax-wfo-bollinger-20260408-153456.json)."
+        ),
+        base_config=ROOT / "config" / "settings.autoresearch.yaml",
+        overlay=ROOT
+        / "config"
+        / "autoresearch"
+        / "overlays"
+        / "rescreen-avax-4h-bollinger-strategy.yaml",
+        symbol="AVAXUSDT",
+        timeframe="4h",
+        gate_profile="standard",
+        start="2024-02-11",
+        end="2026-04-08",
+        train_months=6,
+        test_months=3,
+        bootstrap=500,
+        original=OriginalVerdict(
+            wfo_return_pct=-25.27,
+            wfo_sharpe=-1.45,
+            wfo_trades=65,
+            max_drawdown_pct=60.31,
+            profit_concentration=None,
+            verdict="FAIL",
+            source="docs/reports/avax-wfo-bollinger-20260408-153456.json (legacy costs)",
+            note="AVAX WFO oos_* metrics under pre-#94 engine defaults.",
+        ),
+    ),
+    LaneSpec(
+        lane_id="avax-4h-mean-reversion",
+        label="AVAXUSDT 4h mean_reversion standalone",
+        rationale=(
+            "AVAX 4h WFO best candidate MR_L120_ZE2.0_ZX0.25_TS1440_SL2.5_TP3.0 — "
+            "positive OOS return but sparse trades."
+        ),
+        base_config=ROOT / "config" / "settings.autoresearch.yaml",
+        overlay=None,
+        symbol="AVAXUSDT",
+        timeframe="4h",
+        gate_profile="standard",
+        start="2024-02-11",
+        end="2026-04-08",
+        train_months=6,
+        test_months=3,
+        bootstrap=500,
+        original=OriginalVerdict(
+            wfo_return_pct=14.31,
+            wfo_sharpe=1.61,
+            wfo_trades=4,
+            max_drawdown_pct=5.29,
+            profit_concentration=None,
+            verdict="FAIL",
+            source="docs/reports/avax-wfo-mean_reversion-20260408-153450.json (legacy costs)",
+            note="Failed oos_trades / oos_win_rate gates; pair-spread strategy.",
+        ),
+        skipped=True,
+        skip_reason=(
+            "Config not runnable on current harness: MeanReversionStrategy is not registered "
+            "in settings YAML registry and indicators table lacks pair_close_price required by "
+            "src/strategy/mean_reversion.py. Per brief: document and skip — no new param search."
+        ),
+    ),
+    LaneSpec(
+        lane_id="eth-4h-range-reversion-bounded",
+        label="ETHUSDT 4h range_reversion_bounded (bollinger_bounce)",
+        rationale=(
+            "Wave 7 near-miss (+13.55% OOS, 24 WFO trades, Sharpe 0.48). "
+            "Same overlay as cost-realism rerun #92."
+        ),
+        base_config=ROOT / "config" / "settings.autoresearch.yaml",
+        overlay=ROOT
+        / "config"
+        / "autoresearch"
+        / "overlays"
+        / "cost-realism-eth-4h-range-reversion-bounded.yaml",
+        symbol="ETHUSDT",
+        timeframe="4h",
+        gate_profile="standard",
+        start="2024-01-01",
+        end="2026-06-01",
+        train_months=6,
+        test_months=3,
+        bootstrap=100,
+        original=OriginalVerdict(
+            wfo_return_pct=1.27,
+            wfo_sharpe=-0.71,
+            wfo_trades=15,
+            max_drawdown_pct=28.69,
+            profit_concentration=100.0,
+            verdict="FAIL",
+            source="research/cost-realism-rerun/eth-4h-range-reversion-bounded-legacy.json",
+            note="Ledger Wave 7 NEAR_MISS: +13.55% OOS at b=100 but DD/P(loss)/Sharpe fail.",
+        ),
+    ),
+)
+
+
+@dataclass(frozen=True)
+class FilterCell:
+    """One trend-filter cell at corrected main costs."""
+
+    cell_id: str
+    label: str
+    cost_profile: CostProfile
+
+
+FILTER_CELLS: tuple[FilterCell, ...] = (
+    FilterCell(
+        cell_id="cell_a",
+        label="corrected cost + filter OFF",
+        cost_profile=corrected_main_cost_profile(apply_global_trend_filter=False),
+    ),
+    FilterCell(
+        cell_id="cell_b",
+        label="corrected cost + filter ON",
+        cost_profile=corrected_main_cost_profile(apply_global_trend_filter=True),
+    ),
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Closed-family cost-corrected re-screen")
+    parser.add_argument("--output-dir", type=Path, default=DEFAULT_OUTPUT)
+    parser.add_argument("--write-report", type=Path, default=DEFAULT_REPORT)
+    parser.add_argument("--lane", action="append", dest="lanes", help="Run only these lane_ids")
+    return parser.parse_args()
+
+
+def _verdict_label(passes: bool) -> str:
+    return "PASS" if passes else "FAIL"
+
+
+def _summary_row(payload: dict[str, object]) -> dict[str, object]:
+    summary = payload["summary"]
+    assert isinstance(summary, dict)
+    return {
+        "cell_id": payload["cell_id"],
+        "label": payload["label"],
+        "total_return_pct": summary["total_return_pct"],
+        "wfo_return_pct": summary["wfo_total_return_pct"],
+        "wfo_sharpe": summary["wfo_mean_sharpe"],
+        "wfo_trades": summary["wfo_total_trades"],
+        "max_drawdown_pct": summary["max_drawdown_pct"],
+        "profit_concentration": summary["profit_concentration_pct"],
+        "passes_gates": summary["passes_gates"],
+        "verdict": _verdict_label(bool(summary["passes_gates"])),
+        "failure_reasons": summary.get("failure_reasons", []),
+    }
+
+
+def _fmt_metric(value: float | int | None, *, digits: int = 2) -> str:
+    if value is None:
+        return "—"
+    if isinstance(value, int):
+        return str(value)
+    return f"{value:.{digits}f}"
+
+
+def _pick_best_cell(rows: dict[str, dict[str, object]]) -> str:
+    """Best-of screen: PASS first, else highest wfo_sharpe."""
+
+    passing = [cid for cid, row in rows.items() if bool(row["passes_gates"])]
+    if passing:
+        return max(passing, key=lambda cid: float(rows[cid]["wfo_sharpe"]))
+    return max(rows, key=lambda cid: float(rows[cid]["wfo_sharpe"]))
+
+
+async def _run_cell(
+    *,
+    lane: LaneSpec,
+    resolved_config: Path,
+    cell: FilterCell,
+    db_config: dict[str, object],
+    gates: GateConfig,
+) -> dict[str, object]:
+    summary, _, windows, _, audit = await run_experiment_evaluation(
+        settings_path=resolved_config,
+        symbol=lane.symbol,
+        timeframe=lane.timeframe,
+        start=lane.start,
+        end=lane.end,
+        train_months=lane.train_months,
+        test_months=lane.test_months,
+        bootstrap=lane.bootstrap,
+        gates=gates,
+        cost_profile=cell.cost_profile,
+        db_config=db_config,
+        manage_pool=False,
+    )
+    return {
+        "lane_id": lane.lane_id,
+        "cell_id": cell.cell_id,
+        "label": cell.label,
+        "summary": asdict(summary),
+        "gates": asdict(gates),
+        "windows": [asdict(window) for window in windows],
+        "resolved_backtest_config": audit["backtest_config"],
+        "cost_audit": audit["cost_profile"],
+        "global_trend_filter_audit": audit["global_trend_filter"],
+    }
+
+
+def _render_report(
+    *,
+    results: list[dict[str, object]],
+    skipped_lanes: list[LaneSpec],
+    output_path: Path,
+) -> str:
+    lines: list[str] = []
+    lines.append("# Closed-Family Cost-Corrected Re-Screen — 2026-06-18")
+    lines.append("")
+    lines.append(
+        "**Spec:** [closed-family-cost-corrected-rescreen-v0.md]"
+        "(../specs/closed-family-cost-corrected-rescreen-v0.md)"
+    )
+    lines.append(
+        "**Audit:** [backtest-engine-integrity-audit-2026-06-18.md]"
+        "(backtest-engine-integrity-audit-2026-06-18.md)"
+    )
+    lines.append(
+        "**Predecessors:** [cost-realism-rerun-2026-06-18.md](cost-realism-rerun-2026-06-18.md), "
+        "[dislocation-cost-isolation-2026-06-18.md](dislocation-cost-isolation-2026-06-18.md)"
+    )
+    lines.append("")
+    lines.append("## Frozen lane set (pre-registered)")
+    lines.append("")
+    for lane in FROZEN_LANES:
+        status = "SKIP" if lane.skipped else "RUN"
+        lines.append(f"- **{lane.lane_id}** [{status}] — {lane.label}: {lane.rationale}")
+    lines.append("")
+    lines.append(
+        "Costs: **main defaults post #94** (fee 0.04%/side, slippage 0.02%/side, "
+        "`scaled_8h` funding). Only the global trend filter is swept (Cell A OFF, Cell B ON)."
+    )
+    lines.append("")
+
+    if skipped_lanes:
+        lines.append("## Skipped lanes")
+        lines.append("")
+        for lane in skipped_lanes:
+            lines.append(f"### `{lane.lane_id}`")
+            lines.append("")
+            lines.append(lane.skip_reason)
+            lines.append("")
+            lines.append(
+                f"**Original legacy verdict (reference):** {lane.original.verdict} — "
+                f"{lane.original.source}"
+            )
+            if lane.original.note:
+                lines.append(f"_{lane.original.note}_")
+            lines.append("")
+
+    lane_ids = sorted({str(r["lane_id"]) for r in results})
+    any_pass = False
+
+    for lane_id in lane_ids:
+        lane = next(item for item in FROZEN_LANES if item.lane_id == lane_id)
+        lane_rows = [item for item in results if item["lane_id"] == lane_id]
+        rows = {str(item["cell_id"]): _summary_row(item) for item in lane_rows}
+        best_id = _pick_best_cell(rows)
+        best = rows[best_id]
+        if bool(best["passes_gates"]):
+            any_pass = True
+
+        lines.append(f"## Lane: `{lane_id}`")
+        lines.append("")
+        lines.append(f"**Best-of screen:** {best_id} ({best['label']}) → **{best['verdict']}**")
+        lines.append("")
+        lines.append("| Metric | Cell A (filter OFF) | Cell B (filter ON) | Original (legacy) |")
+        lines.append("|---|---:|---:|---:|")
+        cell_a = rows["cell_a"]
+        cell_b = rows["cell_b"]
+        orig = lane.original
+        for key, label in (
+            ("wfo_return_pct", "wfo_return_pct"),
+            ("wfo_sharpe", "wfo_sharpe"),
+            ("wfo_trades", "wfo_trades"),
+            ("max_drawdown_pct", "max_drawdown_pct"),
+            ("profit_concentration", "profit_concentration"),
+        ):
+            orig_val = getattr(orig, key)
+            a_val = cell_a[key]
+            b_val = cell_b[key]
+            if key == "wfo_trades":
+                lines.append(
+                    f"| {label} | {int(a_val)} | {int(b_val)} | {_fmt_metric(orig_val, digits=0)} |"
+                )
+            else:
+                lines.append(
+                    f"| {label} | {float(a_val):.2f} | {float(b_val):.2f} | "
+                    f"{_fmt_metric(orig_val)} |"
+                )
+        lines.append(f"| verdict | {cell_a['verdict']} | {cell_b['verdict']} | {orig.verdict} |")
+        lines.append("")
+        if orig.note:
+            lines.append(f"_Original reference: {orig.source}. {orig.note}_")
+        else:
+            lines.append(f"_Original reference: {orig.source}_")
+        lines.append("")
+
+        for payload in lane_rows:
+            cell_id = payload["cell_id"]
+            lines.append(f"### {cell_id} — resolved cost + filter audit")
+            lines.append("")
+            lines.append("**Cost audit:**")
+            lines.append("")
+            lines.append("```json")
+            lines.append(json.dumps(payload["cost_audit"], indent=2))
+            lines.append("```")
+            lines.append("")
+            lines.append("**Global trend filter audit:**")
+            lines.append("")
+            lines.append("```json")
+            lines.append(json.dumps(payload["global_trend_filter_audit"], indent=2))
+            lines.append("```")
+            lines.append("")
+            cfg = payload["resolved_backtest_config"]
+            assert isinstance(cfg, dict)
+            lines.append("**BacktestConfig (key fields):**")
+            lines.append("")
+            lines.append("```json")
+            lines.append(
+                json.dumps(
+                    {
+                        "fee_rate": cfg["fee_rate"],
+                        "slippage_pct": cfg["slippage_pct"],
+                        "apply_global_trend_filter": cfg["apply_global_trend_filter"],
+                        "futures_mode": cfg["futures_mode"],
+                        "futures_funding_rate": cfg["futures_funding_rate"],
+                        "funding_cadence": cfg["funding_cadence"],
+                        "global_trend_filter_buffer_pct": cfg["global_trend_filter_buffer_pct"],
+                    },
+                    indent=2,
+                )
+            )
+            lines.append("```")
+            lines.append("")
+
+    lines.append("## Decision")
+    lines.append("")
+    if any_pass:
+        lines.append(
+            "**TOOLING WAS HIDING AN EDGE** — at least one lane's best cell passes the "
+            "standard gate at corrected costs. **Do not auto-promote.** Flag for focused "
+            "cost×filter attribution (like #95) before re-opening; notify for human review."
+        )
+    else:
+        lines.append(
+            "**MEAN-REVERSION FAMILY GENUINELY CLOSED** — no runnable lane's best cell passes "
+            "the standard gate at corrected main defaults under either trend-filter setting. "
+            "Combined with dislocation isolation (#95), the cost bug hid **no deployable edge** "
+            "in fee-marginal / trend-filter-confounded families."
+        )
+        lines.append("")
+        lines.append(
+            "**Recommendation:** Stop the structural-probe program and consolidate on "
+            "sentiment-macro / SOL overlay Phase 0 forward validation."
+        )
+    lines.append("")
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    content = "\n".join(lines)
+    output_path.write_text(content, encoding="utf-8")
+    return content
+
+
+async def main() -> None:
+    args = parse_args()
+    configure_logger("INFO")
+    logger = get_logger("closed_family_cost_rescreen")
+
+    runnable = tuple(
+        lane
+        for lane in FROZEN_LANES
+        if not lane.skipped and (args.lanes is None or lane.lane_id in args.lanes)
+    )
+    skipped = [lane for lane in FROZEN_LANES if lane.skipped]
+    if args.lanes:
+        skipped = [lane for lane in skipped if lane.lane_id in args.lanes]
+
+    if not runnable and not skipped:
+        raise SystemExit("No lanes matched --lane filter")
+
+    output_dir = args.output_dir
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    all_results: list[dict[str, object]] = []
+    if runnable:
+        settings = load_settings(runnable[0].base_config)
+        db_config = _db_config_from_settings(settings)
+        if not db_config.get("password"):
+            import os
+
+            db_config["password"] = os.getenv("POSTGRES_PASSWORD", "change_me")
+        logger.info("DB target: %s:%s", db_config["host"], db_config["port"])
+        await init_pool(db_config)
+
+        try:
+            for lane in runnable:
+                resolved_config = _resolve_lane_config(lane, output_dir)
+                gates = _gate_config_from_profile(lane.gate_profile)
+                logger.info("Lane %s resolved: %s", lane.lane_id, resolved_config)
+                for cell in FILTER_CELLS:
+                    logger.info("Running %s / %s", lane.lane_id, cell.cell_id)
+                    payload = await _run_cell(
+                        lane=lane,
+                        resolved_config=resolved_config,
+                        cell=cell,
+                        db_config=db_config,
+                        gates=gates,
+                    )
+                    artifact = output_dir / f"{lane.lane_id}-{cell.cell_id}.json"
+                    with artifact.open("w", encoding="utf-8") as handle:
+                        json.dump(payload, handle, indent=2)
+                    print(f"\n=== {lane.lane_id} / {cell.cell_id} ===")
+                    print(json.dumps(payload["cost_audit"], indent=2))
+                    print(json.dumps(payload["global_trend_filter_audit"], indent=2))
+                    row = _summary_row(payload)
+                    print(
+                        f"verdict={row['verdict']} wfo_return={row['wfo_return_pct']:.2f}% "
+                        f"sharpe={row['wfo_sharpe']:.2f} trades={row['wfo_trades']}"
+                    )
+                    all_results.append(payload)
+        finally:
+            await close_pool()
+
+    combined_path = output_dir / "combined_results.json"
+    with combined_path.open("w", encoding="utf-8") as handle:
+        json.dump(all_results, handle, indent=2)
+
+    report = _render_report(
+        results=all_results,
+        skipped_lanes=skipped,
+        output_path=args.write_report,
+    )
+    print(f"\nReport written: {args.write_report}")
+    print(report.split("## Decision")[-1].strip())
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/src/backtest/cost_overrides.py
+++ b/src/backtest/cost_overrides.py
@@ -25,7 +25,7 @@ TIMEFRAME_HOURS: dict[str, float] = {
 }
 
 FundingCadence = Literal["per_bar", "scaled_8h"]
-CostPassName = Literal["legacy", "realistic"]
+CostPassName = Literal["legacy", "realistic", "corrected"]
 
 LEGACY_FEE_RATE = 0.001
 LEGACY_SLIPPAGE_PCT = 0.001
@@ -102,6 +102,17 @@ def legacy_cost_profile(*, apply_global_trend_filter: bool = True) -> CostProfil
 def realistic_cost_profile(*, apply_global_trend_filter: bool = False) -> CostProfile:
     return CostProfile(
         name="realistic",
+        fee_rate=REALISTIC_FEE_RATE,
+        slippage_pct=REALISTIC_SLIPPAGE_PCT,
+        apply_global_trend_filter=apply_global_trend_filter,
+        funding_cadence="scaled_8h",
+    )
+
+
+def corrected_main_cost_profile(*, apply_global_trend_filter: bool) -> CostProfile:
+    """Main-branch defaults post #94 — only trend filter is swept."""
+    return CostProfile(
+        name="corrected",
         fee_rate=REALISTIC_FEE_RATE,
         slippage_pct=REALISTIC_SLIPPAGE_PCT,
         apply_global_trend_filter=apply_global_trend_filter,

--- a/tests/test_closed_family_cost_rescreen.py
+++ b/tests/test_closed_family_cost_rescreen.py
@@ -1,0 +1,66 @@
+"""Tests for closed-family cost-corrected re-screen harness."""
+
+from __future__ import annotations
+
+from scripts.run_closed_family_cost_rescreen import (
+    FILTER_CELLS,
+    FROZEN_LANES,
+    _pick_best_cell,
+)
+
+
+def test_frozen_lane_set_covers_mean_reversion_family() -> None:
+    lane_ids = {lane.lane_id for lane in FROZEN_LANES}
+    assert "sol-4h-rsi-reversal" in lane_ids
+    assert "avax-4h-bollinger-strategy" in lane_ids
+    assert "avax-4h-mean-reversion" in lane_ids
+    assert "eth-4h-range-reversion-bounded" in lane_ids
+
+
+def test_mean_reversion_lane_documented_skip() -> None:
+    lane = next(item for item in FROZEN_LANES if item.lane_id == "avax-4h-mean-reversion")
+    assert lane.skipped is True
+    assert "pair_close_price" in lane.skip_reason
+
+
+def test_filter_cells_use_corrected_costs_only() -> None:
+    assert len(FILTER_CELLS) == 2
+    combos = {
+        (cell.cost_profile.name, cell.cost_profile.apply_global_trend_filter)
+        for cell in FILTER_CELLS
+    }
+    assert combos == {("corrected", False), ("corrected", True)}
+    for cell in FILTER_CELLS:
+        assert cell.cost_profile.fee_rate == 0.0004
+        assert cell.cost_profile.slippage_pct == 0.0002
+        assert cell.cost_profile.funding_cadence == "scaled_8h"
+
+
+def test_pick_best_cell_prefers_pass_then_sharpe() -> None:
+    rows = {
+        "cell_a": {
+            "passes_gates": False,
+            "wfo_sharpe": 0.10,
+            "wfo_return_pct": 1.0,
+            "wfo_trades": 20,
+            "max_drawdown_pct": 5.0,
+            "profit_concentration": 40.0,
+            "verdict": "FAIL",
+        },
+        "cell_b": {
+            "passes_gates": True,
+            "wfo_sharpe": 0.55,
+            "wfo_return_pct": 2.0,
+            "wfo_trades": 25,
+            "max_drawdown_pct": 6.0,
+            "profit_concentration": 35.0,
+            "verdict": "PASS",
+        },
+    }
+    assert _pick_best_cell(rows) == "cell_b"
+
+
+def test_all_runnable_lanes_use_standard_gate() -> None:
+    for lane in FROZEN_LANES:
+        if not lane.skipped:
+            assert lane.gate_profile == "standard"


### PR DESCRIPTION
## Summary

Executes the last tooling test from [closed-family-cost-corrected-rescreen-v0.md](docs/specs/closed-family-cost-corrected-rescreen-v0.md): re-screen the frozen mean-reversion family at **corrected main defaults** (#94) with trend filter OFF (Cell A) vs ON (Cell B).

## Frozen lane set (no additions)

| Lane | Status | Best cell | Verdict |
|------|--------|-----------|---------|
| `sol-4h-rsi-reversal` | RUN | cell_b (Sharpe 0.41) | FAIL |
| `avax-4h-bollinger-strategy` | RUN | cell_a (+11.1% WFO, Sharpe 0.81) | FAIL (DD 22.3%, conc 70%) |
| `avax-4h-mean-reversion` | **SKIP** | — | unrecoverable (`pair_close_price` absent) |
| `eth-4h-range-reversion-bounded` | RUN | cell_b (+3.7% WFO) | FAIL |

## Decision

**All runnable lanes still FAIL** under either filter setting at corrected costs. Combined with dislocation isolation (#95), the cost bug hid no deployable edge in fee-marginal / trend-filter-confounded families.

**Recommendation:** Stop structural-probe program; consolidate on sentiment-macro / SOL overlay Phase 0.

## Artifacts

- Report: `docs/reports/closed-family-cost-corrected-rescreen-2026-06-18.md`
- Harness: `scripts/run_closed_family_cost_rescreen.py`
- JSON: `research/closed-family-cost-rescreen/`

## Verification

- `uv run python -m pytest -v` — 1028 passed
- `uv run ruff check .` — clean

## Reviewer checkpoints (Claude)

- [ ] Only frozen MR set re-run; cost-independent families excluded
- [ ] Corrected costs confirmed in per-run audit
- [ ] Both filter cells run; best-of taken per lane
- [ ] Standard gate unchanged
- [ ] Honest pass/fail + consolidation decision stated