### PR TITLE
feat(backtest): overlay buy_threshold frequency sweep

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,9 @@ data/*
 !data/macro_events/**
 !data/tradfi/
 !data/tradfi/**
+# Local agent scratch (drafts/plans/run-continuation)
+.omo/
+
 research/run.log
 research/last_result.json
 research/archive/

--- a/config/autoresearch/overlays/rescreen-avax-4h-bollinger-strategy.yaml
+++ b/config/autoresearch/overlays/rescreen-avax-4h-bollinger-strategy.yaml
@@ -1,0 +1,33 @@
+# Frozen standalone bollinger_bounce lane (AVAX WFO best-shape config BB_D0.0_RSI30_70).
+trading:
+  pairs:
+    - AVAXUSDT
+  timeframe: 4h
+
+trading_execution:
+  sl_atr_multiplier: 2.0
+  tp_atr_multiplier: 3.0
+  trailing_activate_atr: 2.0
+  trailing_offset_atr: 1.0
+  exit_rules:
+    backtest_use_executor_exit_model: true
+    time_stop_minutes: 720
+
+strategy:
+  strategies:
+    - name: bollinger_bounce
+      config:
+        band_distance_threshold: 0.0
+        rsi_oversold: 30
+        rsi_overbought: 70
+  aggregator:
+    buy_threshold: 0.55
+    buy_threshold_uptrend: 0.50
+    sell_threshold: -0.55
+    min_confidence: 0.10
+  per_symbol_aggregator_config:
+    AVAXUSDT:
+      min_agreement: 1
+      buy_threshold: 0.55
+      sell_threshold: -0.55
+      sell_min_agreement: 1

--- a/config/autoresearch/overlays/rescreen-sol-4h-rsi-reversal.yaml
+++ b/config/autoresearch/overlays/rescreen-sol-4h-rsi-reversal.yaml
@@ -1,0 +1,30 @@
+# Frozen standalone rsi_reversal lane (SOLUSDT 4h autoresearch base params).
+trading:
+  pairs:
+    - SOLUSDT
+  timeframe: 4h
+
+trading_execution:
+  sl_atr_multiplier: 2.0
+  tp_atr_multiplier: 3.0
+  trailing_activate_atr: 1.5
+  trailing_offset_atr: 0.8
+
+strategy:
+  strategies:
+    - name: rsi_reversal
+      config:
+        rsi_period: 7
+        oversold_threshold: 35
+        overbought_threshold: 65
+  aggregator:
+    buy_threshold: 0.55
+    buy_threshold_uptrend: 0.50
+    sell_threshold: -0.55
+    min_confidence: 0.10
+  per_symbol_aggregator_config:
+    SOLUSDT:
+      min_agreement: 1
+      buy_threshold: 0.55
+      sell_threshold: -0.55
+      sell_min_agreement: 1

--- a/docs/reports/closed-family-cost-corrected-rescreen-2026-06-18.md
+++ b/docs/reports/closed-family-cost-corrected-rescreen-2026-06-18.md
@@ -1,0 +1,332 @@
+# Closed-Family Cost-Corrected Re-Screen — 2026-06-18
+
+**Spec:** [closed-family-cost-corrected-rescreen-v0.md](../specs/closed-family-cost-corrected-rescreen-v0.md)
+**Audit:** [backtest-engine-integrity-audit-2026-06-18.md](backtest-engine-integrity-audit-2026-06-18.md)
+**Predecessors:** [cost-realism-rerun-2026-06-18.md](cost-realism-rerun-2026-06-18.md), [dislocation-cost-isolation-2026-06-18.md](dislocation-cost-isolation-2026-06-18.md)
+
+## Frozen lane set (pre-registered)
+
+- **sol-4h-rsi-reversal** [RUN] — SOLUSDT 4h rsi_reversal standalone: Production/autoresearch mean-reversion vote on SOL 4h (BASE_STRATEGY_CONFIGS params). Original closure: five-strategy stack 0/704 config-search passes.
+- **avax-4h-bollinger-strategy** [RUN] — AVAXUSDT 4h bollinger_bounce standalone: AVAX 4h WFO sweep best-shape config BB_D0.0_RSI30_70_TS720_SL2.0_TP3.0 (docs/reports/avax-wfo-bollinger-20260408-153456.json).
+- **avax-4h-mean-reversion** [SKIP] — AVAXUSDT 4h mean_reversion standalone: AVAX 4h WFO best candidate MR_L120_ZE2.0_ZX0.25_TS1440_SL2.5_TP3.0 — positive OOS return but sparse trades.
+- **eth-4h-range-reversion-bounded** [RUN] — ETHUSDT 4h range_reversion_bounded (bollinger_bounce): Wave 7 near-miss (+13.55% OOS, 24 WFO trades, Sharpe 0.48). Same overlay as cost-realism rerun #92.
+
+Costs: **main defaults post #94** (fee 0.04%/side, slippage 0.02%/side, `scaled_8h` funding). Only the global trend filter is swept (Cell A OFF, Cell B ON).
+
+## Skipped lanes
+
+### `avax-4h-mean-reversion`
+
+Config not runnable on current harness: MeanReversionStrategy is not registered in settings YAML registry and indicators table lacks pair_close_price required by src/strategy/mean_reversion.py. Per brief: document and skip — no new param search.
+
+**Original legacy verdict (reference):** FAIL — docs/reports/avax-wfo-mean_reversion-20260408-153450.json (legacy costs)
+_Failed oos_trades / oos_win_rate gates; pair-spread strategy._
+
+## Lane: `avax-4h-bollinger-strategy`
+
+**Best-of screen:** cell_a (corrected cost + filter OFF) → **FAIL**
+
+| Metric | Cell A (filter OFF) | Cell B (filter ON) | Original (legacy) |
+|---|---:|---:|---:|
+| wfo_return_pct | 11.14 | -3.45 | -25.27 |
+| wfo_sharpe | 0.81 | -0.21 | -1.45 |
+| wfo_trades | 26 | 7 | 65 |
+| max_drawdown_pct | 22.28 | 7.17 | 60.31 |
+| profit_concentration | 69.92 | 100.00 | — |
+| verdict | FAIL | FAIL | FAIL |
+
+_Original reference: docs/reports/avax-wfo-bollinger-20260408-153456.json (legacy costs). AVAX WFO oos_* metrics under pre-#94 engine defaults._
+
+### cell_a — resolved cost + filter audit
+
+**Cost audit:**
+
+```json
+{
+  "name": "corrected",
+  "fee_rate": 0.0004,
+  "slippage_pct": 0.0002,
+  "apply_global_trend_filter": false,
+  "funding_cadence": "scaled_8h",
+  "base_futures_funding_rate": 0.0001,
+  "round_trip_cost_pct": 0.12000000000000001,
+  "funding_method": "scale per-bar rate by tf_hours/8 (equivalent to 8h settlement cadence)",
+  "effective_futures_funding_rate": 0.0
+}
+```
+
+**Global trend filter audit:**
+
+```json
+{
+  "active": false,
+  "buffer_pct": 0.0,
+  "source": "cost_profile_override",
+  "config_explicit": null
+}
+```
+
+**BacktestConfig (key fields):**
+
+```json
+{
+  "fee_rate": 0.0004,
+  "slippage_pct": 0.0002,
+  "apply_global_trend_filter": false,
+  "futures_mode": false,
+  "futures_funding_rate": 0.0001,
+  "funding_cadence": "scaled_8h",
+  "global_trend_filter_buffer_pct": 0.0
+}
+```
+
+### cell_b — resolved cost + filter audit
+
+**Cost audit:**
+
+```json
+{
+  "name": "corrected",
+  "fee_rate": 0.0004,
+  "slippage_pct": 0.0002,
+  "apply_global_trend_filter": true,
+  "funding_cadence": "scaled_8h",
+  "base_futures_funding_rate": 0.0001,
+  "round_trip_cost_pct": 0.12000000000000001,
+  "funding_method": "scale per-bar rate by tf_hours/8 (equivalent to 8h settlement cadence)",
+  "effective_futures_funding_rate": 0.0
+}
+```
+
+**Global trend filter audit:**
+
+```json
+{
+  "active": true,
+  "buffer_pct": 0.0,
+  "source": "cost_profile_override",
+  "config_explicit": null
+}
+```
+
+**BacktestConfig (key fields):**
+
+```json
+{
+  "fee_rate": 0.0004,
+  "slippage_pct": 0.0002,
+  "apply_global_trend_filter": true,
+  "futures_mode": false,
+  "futures_funding_rate": 0.0001,
+  "funding_cadence": "scaled_8h",
+  "global_trend_filter_buffer_pct": 0.0
+}
+```
+
+## Lane: `eth-4h-range-reversion-bounded`
+
+**Best-of screen:** cell_b (corrected cost + filter ON) → **FAIL**
+
+| Metric | Cell A (filter OFF) | Cell B (filter ON) | Original (legacy) |
+|---|---:|---:|---:|
+| wfo_return_pct | -46.52 | 3.66 | 1.27 |
+| wfo_sharpe | -1.84 | -0.29 | -0.71 |
+| wfo_trades | 66 | 14 | 15 |
+| max_drawdown_pct | 71.53 | 28.06 | 28.69 |
+| profit_concentration | 100.00 | 100.00 | 100.00 |
+| verdict | FAIL | FAIL | FAIL |
+
+_Original reference: research/cost-realism-rerun/eth-4h-range-reversion-bounded-legacy.json. Ledger Wave 7 NEAR_MISS: +13.55% OOS at b=100 but DD/P(loss)/Sharpe fail._
+
+### cell_a — resolved cost + filter audit
+
+**Cost audit:**
+
+```json
+{
+  "name": "corrected",
+  "fee_rate": 0.0004,
+  "slippage_pct": 0.0002,
+  "apply_global_trend_filter": false,
+  "funding_cadence": "scaled_8h",
+  "base_futures_funding_rate": 0.0001,
+  "round_trip_cost_pct": 0.12000000000000001,
+  "funding_method": "scale per-bar rate by tf_hours/8 (equivalent to 8h settlement cadence)",
+  "effective_futures_funding_rate": 0.0
+}
+```
+
+**Global trend filter audit:**
+
+```json
+{
+  "active": false,
+  "buffer_pct": 0.0025,
+  "source": "cost_profile_override",
+  "config_explicit": null
+}
+```
+
+**BacktestConfig (key fields):**
+
+```json
+{
+  "fee_rate": 0.0004,
+  "slippage_pct": 0.0002,
+  "apply_global_trend_filter": false,
+  "futures_mode": false,
+  "futures_funding_rate": 0.0001,
+  "funding_cadence": "scaled_8h",
+  "global_trend_filter_buffer_pct": 0.0025
+}
+```
+
+### cell_b — resolved cost + filter audit
+
+**Cost audit:**
+
+```json
+{
+  "name": "corrected",
+  "fee_rate": 0.0004,
+  "slippage_pct": 0.0002,
+  "apply_global_trend_filter": true,
+  "funding_cadence": "scaled_8h",
+  "base_futures_funding_rate": 0.0001,
+  "round_trip_cost_pct": 0.12000000000000001,
+  "funding_method": "scale per-bar rate by tf_hours/8 (equivalent to 8h settlement cadence)",
+  "effective_futures_funding_rate": 0.0
+}
+```
+
+**Global trend filter audit:**
+
+```json
+{
+  "active": true,
+  "buffer_pct": 0.0025,
+  "source": "cost_profile_override",
+  "config_explicit": null
+}
+```
+
+**BacktestConfig (key fields):**
+
+```json
+{
+  "fee_rate": 0.0004,
+  "slippage_pct": 0.0002,
+  "apply_global_trend_filter": true,
+  "futures_mode": false,
+  "futures_funding_rate": 0.0001,
+  "funding_cadence": "scaled_8h",
+  "global_trend_filter_buffer_pct": 0.0025
+}
+```
+
+## Lane: `sol-4h-rsi-reversal`
+
+**Best-of screen:** cell_b (corrected cost + filter ON) → **FAIL**
+
+| Metric | Cell A (filter OFF) | Cell B (filter ON) | Original (legacy) |
+|---|---:|---:|---:|
+| wfo_return_pct | -4.42 | -4.03 | — |
+| wfo_sharpe | 0.09 | 0.41 | — |
+| wfo_trades | 120 | 51 | — |
+| max_drawdown_pct | 23.97 | 20.46 | 20.66 |
+| profit_concentration | 100.00 | 45.96 | — |
+| verdict | FAIL | FAIL | FAIL |
+
+_Original reference: docs/reports/current-strategy-review-2026-03-03.md (SOL 4h stack). Standalone legacy WFO not archived; ensemble best-cluster DD ~20.7%, bootstrap P(loss) 48–56%, concentration fail, 0/704 passes._
+
+### cell_a — resolved cost + filter audit
+
+**Cost audit:**
+
+```json
+{
+  "name": "corrected",
+  "fee_rate": 0.0004,
+  "slippage_pct": 0.0002,
+  "apply_global_trend_filter": false,
+  "funding_cadence": "scaled_8h",
+  "base_futures_funding_rate": 0.0001,
+  "round_trip_cost_pct": 0.12000000000000001,
+  "funding_method": "scale per-bar rate by tf_hours/8 (equivalent to 8h settlement cadence)",
+  "effective_futures_funding_rate": 0.0
+}
+```
+
+**Global trend filter audit:**
+
+```json
+{
+  "active": false,
+  "buffer_pct": 0.0,
+  "source": "cost_profile_override",
+  "config_explicit": null
+}
+```
+
+**BacktestConfig (key fields):**
+
+```json
+{
+  "fee_rate": 0.0004,
+  "slippage_pct": 0.0002,
+  "apply_global_trend_filter": false,
+  "futures_mode": false,
+  "futures_funding_rate": 0.0001,
+  "funding_cadence": "scaled_8h",
+  "global_trend_filter_buffer_pct": 0.0
+}
+```
+
+### cell_b — resolved cost + filter audit
+
+**Cost audit:**
+
+```json
+{
+  "name": "corrected",
+  "fee_rate": 0.0004,
+  "slippage_pct": 0.0002,
+  "apply_global_trend_filter": true,
+  "funding_cadence": "scaled_8h",
+  "base_futures_funding_rate": 0.0001,
+  "round_trip_cost_pct": 0.12000000000000001,
+  "funding_method": "scale per-bar rate by tf_hours/8 (equivalent to 8h settlement cadence)",
+  "effective_futures_funding_rate": 0.0
+}
+```
+
+**Global trend filter audit:**
+
+```json
+{
+  "active": true,
+  "buffer_pct": 0.0,
+  "source": "cost_profile_override",
+  "config_explicit": null
+}
+```
+
+**BacktestConfig (key fields):**
+
+```json
+{
+  "fee_rate": 0.0004,
+  "slippage_pct": 0.0002,
+  "apply_global_trend_filter": true,
+  "futures_mode": false,
+  "futures_funding_rate": 0.0001,
+  "funding_cadence": "scaled_8h",
+  "global_trend_filter_buffer_pct": 0.0
+}
+```
+
+## Decision
+
+**MEAN-REVERSION FAMILY GENUINELY CLOSED** — no runnable lane's best cell passes the standard gate at corrected main defaults under either trend-filter setting. Combined with dislocation isolation (#95), the cost bug hid **no deployable edge** in fee-marginal / trend-filter-confounded families.
+
+**Recommendation:** Stop the structural-probe program and consolidate on sentiment-macro / SOL overlay Phase 0 forward validation.

--- a/docs/reports/overlay-threshold-sweep-2026-06-18.md
+++ b/docs/reports/overlay-threshold-sweep-2026-06-18.md
@@ -1,0 +1,30 @@
+# Overlay Threshold × Frequency Sweep — 2026-06-18
+
+**Spec:** [overlay-threshold-frequency-sweep-v0.md](../specs/overlay-threshold-frequency-sweep-v0.md)
+**Lane:** `sol-1h-trend-pullback-overlay-live` — SOLUSDT 1h, corrected costs, global trend filter ON (production mirror).
+
+## Data coverage
+
+- Requested span: 2024-01-01 → 2026-06-01
+- DB coverage: 2024-01-09 → 2026-02-23
+- **Effective span used:** 2024-01-09 → 2026-02-23
+- Clamped: start=True, end=True
+
+## Frontier (corrected costs, filter ON)
+
+| buy_threshold | trades | trades/mo | wfo_return% | Sharpe | max_DD% | profit_conc% | p_loss% | passes |
+|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| 0.50 | 158 | 17.56 | -75.37 | -0.90 | 99.74 | 100.0 | 100.0 | FAIL |
+| 0.60 | 121 | 13.44 | -50.73 | -0.49 | 97.51 | 100.0 | 99.6 | FAIL |
+| 0.70 | 70 | 7.78 | -26.08 | -0.33 | 93.90 | 100.0 | 98.6 | FAIL |
+| 0.80 | 51 | 5.67 | -17.45 | -0.40 | 79.15 | 100.0 | 91.2 | FAIL |
+| 0.90 | 41 | 4.56 | 3.42 | 0.36 | 76.67 | 60.4 | 86.8 | FAIL |
+| 1.00 | 27 | 3.00 | -21.58 | -0.36 | 79.14 | 100.0 | 94.8 | FAIL |
+| 1.07 | 11 | 1.22 | 53.47 | 1.00 | 29.17 | 95.2 | 24.6 | FAIL |
+| 1.27 | 6 | 0.67 | 19.42 | 1.05 | 28.43 | 54.0 | 30.4 | FAIL |
+
+## Decision
+
+**OVERLAY NOT A VIABLE FORWARD VEHICLE** — tradeable frequency appears only where the standard gate fails. The overlay edge depends on a confluence gate that is live-untradeable at corrected costs. Consolidation direction: document/accept or pivot.
+
+_Pre-registered frequency floor: trades_per_month ≥ 2._

--- a/docs/specs/overlay-threshold-frequency-sweep-v0.md
+++ b/docs/specs/overlay-threshold-frequency-sweep-v0.md
@@ -1,0 +1,181 @@
+# Overlay Threshold × Frequency Sweep — v0 (spec)
+
+**Status:** spec — ready to build (Grok)
+**Author:** Claude (planner)
+**Date:** 2026-06-18
+**Related:**
+[closed-family-cost-corrected-rescreen-v0.md](./closed-family-cost-corrected-rescreen-v0.md),
+[backtest-engine-integrity-audit-2026-06-18.md](../reports/backtest-engine-integrity-audit-2026-06-18.md),
+memory `phase0-overlay-zero-trades`, `backtest-cost-tooling-finding`.
+
+---
+
+## Why
+
+The only deployable technical agent — `sol-1h-trend-pullback-overlay-live` — has **0
+fills, ever**, despite the service being healthy for weeks. Live-log diagnosis (2026-06-18)
+shows the cause is **not** a broken signal path and **not** market sparsity at the strategy
+level. The 6-strategy SOL stack emits BUY votes constantly (RSIReversal, MACDHistogram,
+BollingerBounce up to confidence **1.00**), but **every one resolves to `Consensus HOLD,
+signals=0`**.
+
+Root cause — the aggregator gate:
+
+```yaml
+# config/settings.sol_1h_trend_pullback_overlay_live.yaml
+aggregator:
+  buy_threshold: 1.27          # 1.07 in an uptrend
+per_symbol_aggregator_config:
+  SOLUSDT:
+    buy_threshold: 1.27
+    buy_threshold_uptrend: 1.07
+```
+
+A single strategy vote caps at confidence **1.0**, so one strategy can never cross
+1.07/1.27 — entry requires **≥2 strategies BUYing the same 1h bar** with summed weighted
+confidence > 1.07. On live SOL 1h that almost never co-occurs → ~0 trades → **Phase 0
+forward validation can never accumulate its 5→10→20-trade milestones.**
+
+Two confounds make this worth a backtest rather than a blind config tweak:
+
+1. **The overlay was WFO-validated under the cost bug** (pre-#94: ~0.4% round-trip, ~3×
+   too high; funding ~8× over). "WFO-passed" was established under wrong physics.
+2. **The >1.0 gate is part of what made it pass.** A stricter confluence gate cherry-picks
+   the cleanest historical setups → flattering backtest, near-zero live frequency.
+   Relaxing it is a *new strategy*, not a tweak.
+
+## Question (single, falsifiable)
+
+> Is there a `buy_threshold` that delivers **both** (a) enough live frequency to forward-
+> validate **and** (b) a surviving edge under the standard gate at **corrected costs (#94)**?
+
+## Non-goals
+
+- Not a new structural-probe lane (the probe program is exhausted). This validates the
+  **existing deployable asset**, which is consolidation work.
+- No auto-promotion. The sweep produces a frontier + recommendation for human review.
+- No live config change in this task.
+
+---
+
+## Method
+
+Clone `scripts/run_closed_family_cost_rescreen.py` → `scripts/run_overlay_threshold_sweep.py`.
+Reuse `run_experiment_evaluation()` from `scripts/experiment_autopilot.py` verbatim — it
+already returns the gate summary and an `audit` dump (cost + filter + BacktestConfig).
+**Swept axis = `buy_threshold`** (instead of the trend-filter cells).
+
+### Fixed lane
+
+| Field | Value |
+|---|---|
+| base_config | `config/settings.sol_1h_trend_pullback_overlay_live.yaml` |
+| symbol | `SOLUSDT` |
+| timeframe | `1h` |
+| start / end | `2024-01-01` → `2026-06-01` (assert candle coverage first; clamp to earliest SOL 1h candle if needed) |
+| train_months / test_months | 6 / 3 |
+| bootstrap | 500 (match siblings) |
+| gate_profile | `standard` (`_gate_config_from_profile("standard")`) |
+| trading mode | **futures** (config-native: `default_trading_mode: futures`, leverage 3, funding applies) |
+| exits | config-native ATR SL/TP/trailing (`backtest_use_executor_exit_model: true`) — preserve from resolved config |
+
+### Swept grid
+
+```
+buy_threshold ∈ {0.50, 0.60, 0.70, 0.80, 0.90, 1.00, 1.07, 1.27}
+```
+
+For each value `v`, the resolved config MUST set **all four** keys to `v` so the swept
+value actually binds (per-symbol config otherwise wins, and the uptrend discount otherwise
+masks the effect):
+
+- `aggregator.buy_threshold = v`
+- `aggregator.buy_threshold_uptrend = v`
+- `per_symbol_aggregator_config.SOLUSDT.buy_threshold = v`
+- `per_symbol_aggregator_config.SOLUSDT.buy_threshold_uptrend = v`
+
+Leave `sell_threshold`, `min_agreement`, `min_confidence`, and `btc_regime_filter_*` at
+their native config values. Collapsing `buy_threshold_uptrend` to `v` (rather than keeping
+the 1.07/1.27 ratio) is intentional: it makes "effective entry bar" a single interpretable
+axis. (`1.07` and `1.27` are included so the production points appear on the frontier.)
+
+### Costs & filters (held constant — mirror production)
+
+- `cost_profile = corrected_main_cost_profile(apply_global_trend_filter=True)` — corrected
+  fee 0.04%/side, slippage 0.02%/side, `scaled_8h` funding, **global trend filter at the
+  production/base default (ON), buffer 0.0**. The point is "would *production* have traded
+  at threshold `v`," so every non-swept knob matches prod.
+- Emit the same `cost_audit` + `global_trend_filter_audit` + BacktestConfig dump per run as
+  the closed-family report, to prove costs/filters resolved as intended.
+- **Follow-up only if the whole grid still yields ~0 trades:** rerun with
+  `apply_global_trend_filter=False` to test whether the EMA200 filter (not the aggregator)
+  is the binding constraint. Do not run this second axis preemptively.
+
+### Per-threshold outputs
+
+For each `v`, record from `summary`:
+
+- `wfo_total_trades`, and **`trades_per_month` = wfo_total_trades / OOS_months** (the
+  frequency axis; OOS_months = number of test windows × test_months)
+- `wfo_total_return_pct`, `wfo_mean_sharpe`, `max_drawdown_pct`,
+  `profit_concentration_pct`
+- bootstrap `p_loss` if surfaced in `summary`; else note absent
+- `passes_gates` (bool), `failure_reasons` (list)
+
+Write per-run JSON to `research/overlay-threshold-sweep/<v>.json`, combined to
+`combined_results.json`, resolved configs to `research/overlay-threshold-sweep/resolved/`,
+and a report to `docs/reports/overlay-threshold-sweep-2026-06-18.md` (a frontier table:
+one row per threshold, columns = the metrics above).
+
+---
+
+## Decision rule (pre-registered)
+
+Define **forward-validatable frequency** as `trades_per_month ≥ 2` (≥ ~20 trades in a
+~10-month OOS span — enough to clear Phase 0's 20-trade milestone in a quarter, and the
+WFO ≥20-trade floor the program already uses).
+
+- **At least one threshold has `trades_per_month ≥ 2` AND `passes_gates = True`:**
+  → the overlay is rescuable. Report the lowest such threshold (most frequency) and the
+  best-Sharpe such threshold. **Next step = re-validate that config** as a new strategy
+  (its own WFO confirmation at corrected costs + a fresh bootstrap=1000) before any live
+  change. Consolidation direction = **B (re-validate at lower threshold).**
+
+- **Frequency only appears with gate failure** (every `trades_per_month ≥ 2` row fails;
+  the only passing rows are starved): → the overlay's edge depends on a confluence gate
+  that is live-untradeable. The overlay is **not** a viable forward-validation vehicle.
+  Consolidation direction = **A (document, accept) or C (pivot)** — and the consolidation
+  doc says so with this evidence.
+
+- **Whole grid ~0 trades even at `buy_threshold = 0.50`:** the binding constraint is *not*
+  the aggregator. Run the filter-OFF follow-up; if still ~0, escalate — the limiter is
+  upstream (regime filter / data / sizing), needs separate diagnosis.
+
+Report the frontier even when the rule is unambiguous — the trades-per-month vs
+profit_concentration shape is the deliverable.
+
+---
+
+## Acceptance criteria
+
+1. `scripts/run_overlay_threshold_sweep.py` runs all 8 thresholds end-to-end against the
+   DB without manual edits, `--threshold` filter supported (like `--lane`).
+2. Each run's `cost_audit` shows fee 0.0004 / slippage 0.0002 / `scaled_8h`; filter audit
+   shows the held-constant setting. Mismatch = hard fail.
+3. Each resolved config shows all four `buy_threshold*` keys = the run's `v` (assert in the
+   audit, not just on disk).
+4. Report renders the frontier table + applies the decision rule to a one-line verdict.
+5. Candle-coverage assertion up front; if SOL 1h data is short, the report states the
+   actual span used.
+
+## Notes for the builder
+
+- `run_experiment_evaluation(..., manage_pool=False)` inside a single `init_pool/close_pool`
+  — copy the closed-family `main()` pool handling.
+- DB target comes from `_db_config_from_settings(load_settings(base_config))` +
+  `POSTGRES_PASSWORD` env fallback (same as the sibling script).
+- Watch the `CostProfile.to_audit_dict` dead-code trap from #94 (fixed in #95/#96) — if you
+  copy cost-override code, confirm the audit dict is actually populated.
+- This is a backtest against historical data; it does not touch the live agent.
+</content>
+</invoke>

--- a/research/closed-family-cost-rescreen/avax-4h-bollinger-strategy-cell_a.json
+++ b/research/closed-family-cost-rescreen/avax-4h-bollinger-strategy-cell_a.json
@@ -1,0 +1,173 @@
+{
+  "lane_id": "avax-4h-bollinger-strategy",
+  "cell_id": "cell_a",
+  "label": "corrected cost + filter OFF",
+  "summary": {
+    "symbol": "AVAXUSDT",
+    "timeframe": "4h",
+    "start": "2024-02-11",
+    "end": "2026-04-08",
+    "total_trades": 81,
+    "win_rate": 58.0246913580247,
+    "total_return_pct": 46.754032378087324,
+    "max_drawdown_pct": 22.277221569986512,
+    "sharpe_ratio": 0.9255218518607923,
+    "wfo_windows": 3,
+    "wfo_total_trades": 26,
+    "wfo_mean_sharpe": 0.8070804504689949,
+    "wfo_total_return_pct": 11.144621058948756,
+    "bootstrap_p_loss_pct": 16.6,
+    "mc_drawdown_p95_pct": 42.63342643491706,
+    "mc_drawdown_p50_pct": 22.90495239226439,
+    "profit_concentration_pct": 69.9154424913016,
+    "passes_gates": false,
+    "failure_reasons": [
+      "max_drawdown_pct failed (22.28% > 10.00%)",
+      "max_profit_concentration_pct failed (69.92% > 50.00%)"
+    ],
+    "blocked_buy_count": 0,
+    "basis_blocked_buy_count": 0,
+    "dislocation_blocked_buy_count": 0
+  },
+  "gates": {
+    "min_trades": 0,
+    "min_wfo_trades": 20,
+    "min_wfo_sharpe": 0.5,
+    "max_drawdown_pct": 10.0,
+    "max_bootstrap_p_loss_pct": 25.0,
+    "min_oos_return_pct": 0.0,
+    "max_profit_concentration_pct": 50.0,
+    "max_mc_drawdown_p95_pct": 0.0
+  },
+  "windows": [
+    {
+      "window_index": 1,
+      "train_start": "2024-02-11T00:00:00",
+      "train_end": "2024-08-11T00:00:00",
+      "test_start": "2024-08-11T00:00:00",
+      "test_end": "2024-11-11T00:00:00",
+      "total_trades": 8,
+      "win_rate": 75.0,
+      "total_return_pct": 3.8406259373717693,
+      "max_drawdown_pct": 7.470272746601372,
+      "sharpe_ratio": 1.0434146367904473
+    },
+    {
+      "window_index": 2,
+      "train_start": "2024-08-11T00:00:00",
+      "train_end": "2025-02-11T00:00:00",
+      "test_start": "2025-02-11T00:00:00",
+      "test_end": "2025-05-11T00:00:00",
+      "total_trades": 9,
+      "win_rate": 44.44444444444444,
+      "total_return_pct": -1.7366249038081698,
+      "max_drawdown_pct": 11.460835743842988,
+      "sharpe_ratio": -0.12695001624570731
+    },
+    {
+      "window_index": 3,
+      "train_start": "2025-02-11T00:00:00",
+      "train_end": "2025-08-11T00:00:00",
+      "test_start": "2025-08-11T00:00:00",
+      "test_end": "2025-11-11T00:00:00",
+      "total_trades": 9,
+      "win_rate": 55.55555555555556,
+      "total_return_pct": 8.925478188511825,
+      "max_drawdown_pct": 6.289725337642067,
+      "sharpe_ratio": 1.5047767308622448
+    }
+  ],
+  "resolved_backtest_config": {
+    "symbol": "AVAXUSDT",
+    "timeframe": "4h",
+    "start_date": "2024-02-11",
+    "end_date": "2026-04-08",
+    "initial_capital": 10000.0,
+    "fee_rate": 0.0004,
+    "stop_loss_pct": 0.01,
+    "take_profit_pct": 0.03,
+    "sl_atr_multiplier": 2.0,
+    "tp_atr_multiplier": 3.0,
+    "trailing_activate_atr": 2.0,
+    "trailing_offset_atr": 1.0,
+    "slippage_pct": 0.0002,
+    "risk_per_trade": 0.02,
+    "use_atr_sizing": false,
+    "atr_multiplier": 1.0,
+    "apply_global_trend_filter": false,
+    "global_trend_filter_buffer_pct": 0.0,
+    "global_trend_filter_source": "cost_profile_override",
+    "config_global_trend_filter_enabled": null,
+    "session_liquidity_router": {
+      "enabled": false,
+      "allowed_windows": [
+        "americas"
+      ],
+      "block_entries_outside_windows": true
+    },
+    "basis_premium_filter": {
+      "enabled": false,
+      "exchange": "binance_usdm",
+      "tail_metric": "basis_bps",
+      "positive_tail_pct": 0.05,
+      "block_positive_tail_longs": true,
+      "missing_data_policy": "allow",
+      "calibrated_positive_threshold": null
+    },
+    "cross_venue_dislocation": {
+      "enabled": false,
+      "metric": "basis_spread",
+      "mode": "require",
+      "min_spread_bps": 5.0,
+      "side": "both",
+      "missing_data_policy": "allow"
+    },
+    "allow_short": false,
+    "use_executor_exit_model": true,
+    "ignore_signal_sells": false,
+    "strategy_configs": [
+      {
+        "band_distance_threshold": 0.0,
+        "rsi_oversold": 30,
+        "rsi_overbought": 70
+      }
+    ],
+    "aggregator_config": {
+      "buy_threshold": 0.55,
+      "buy_threshold_uptrend": 0.5,
+      "sell_threshold": -0.55,
+      "btc_regime_filter_enabled": true,
+      "btc_reference_symbol": "BTCUSDT",
+      "btc_dump_threshold_pct": -1.0,
+      "btc_dump_require_below_ema200": true,
+      "min_confidence": 0.1
+    },
+    "time_stop_minutes": 720.0,
+    "replay_sentiment_path": null,
+    "replay_sentiment_max_age_seconds": null,
+    "futures_mode": false,
+    "futures_leverage": 5,
+    "futures_funding_rate": 0.0001,
+    "funding_cadence": "scaled_8h",
+    "fixed_notional_usdt": 0.0,
+    "quantity_step_size": 0.0,
+    "min_notional_usdt": 0.0
+  },
+  "cost_audit": {
+    "name": "corrected",
+    "fee_rate": 0.0004,
+    "slippage_pct": 0.0002,
+    "apply_global_trend_filter": false,
+    "funding_cadence": "scaled_8h",
+    "base_futures_funding_rate": 0.0001,
+    "round_trip_cost_pct": 0.12000000000000001,
+    "funding_method": "scale per-bar rate by tf_hours/8 (equivalent to 8h settlement cadence)",
+    "effective_futures_funding_rate": 0.0
+  },
+  "global_trend_filter_audit": {
+    "active": false,
+    "buffer_pct": 0.0,
+    "source": "cost_profile_override",
+    "config_explicit": null
+  }
+}

--- a/research/closed-family-cost-rescreen/avax-4h-bollinger-strategy-cell_b.json
+++ b/research/closed-family-cost-rescreen/avax-4h-bollinger-strategy-cell_b.json
@@ -1,0 +1,176 @@
+{
+  "lane_id": "avax-4h-bollinger-strategy",
+  "cell_id": "cell_b",
+  "label": "corrected cost + filter ON",
+  "summary": {
+    "symbol": "AVAXUSDT",
+    "timeframe": "4h",
+    "start": "2024-02-11",
+    "end": "2026-04-08",
+    "total_trades": 13,
+    "win_rate": 61.53846153846154,
+    "total_return_pct": 6.734541064927743,
+    "max_drawdown_pct": 7.170733930822514,
+    "sharpe_ratio": 0.3958082816462312,
+    "wfo_windows": 3,
+    "wfo_total_trades": 7,
+    "wfo_mean_sharpe": -0.2099624414659996,
+    "wfo_total_return_pct": -3.4469189375277987,
+    "bootstrap_p_loss_pct": 31.0,
+    "mc_drawdown_p95_pct": 16.597665042952226,
+    "mc_drawdown_p50_pct": 7.361053551664051,
+    "profit_concentration_pct": 100.0,
+    "passes_gates": false,
+    "failure_reasons": [
+      "min_wfo_trades failed (7 < 20)",
+      "min_wfo_sharpe failed (-0.21 < 0.50)",
+      "max_bootstrap_p_loss_pct failed (31.00% > 25.00%)",
+      "min_oos_return_pct failed (-3.45% < 0.00%)",
+      "max_profit_concentration_pct failed (100.00% > 50.00%)"
+    ],
+    "blocked_buy_count": 0,
+    "basis_blocked_buy_count": 0,
+    "dislocation_blocked_buy_count": 0
+  },
+  "gates": {
+    "min_trades": 0,
+    "min_wfo_trades": 20,
+    "min_wfo_sharpe": 0.5,
+    "max_drawdown_pct": 10.0,
+    "max_bootstrap_p_loss_pct": 25.0,
+    "min_oos_return_pct": 0.0,
+    "max_profit_concentration_pct": 50.0,
+    "max_mc_drawdown_p95_pct": 0.0
+  },
+  "windows": [
+    {
+      "window_index": 1,
+      "train_start": "2024-02-11T00:00:00",
+      "train_end": "2024-08-11T00:00:00",
+      "test_start": "2024-08-11T00:00:00",
+      "test_end": "2024-11-11T00:00:00",
+      "total_trades": 3,
+      "win_rate": 66.66666666666666,
+      "total_return_pct": 0.7260680595560733,
+      "max_drawdown_pct": 4.261752813883015,
+      "sharpe_ratio": 0.2749583734319949
+    },
+    {
+      "window_index": 2,
+      "train_start": "2024-08-11T00:00:00",
+      "train_end": "2025-02-11T00:00:00",
+      "test_start": "2025-02-11T00:00:00",
+      "test_end": "2025-05-11T00:00:00",
+      "total_trades": 0,
+      "win_rate": 0.0,
+      "total_return_pct": 0.0,
+      "max_drawdown_pct": 0.0,
+      "sharpe_ratio": 0.0
+    },
+    {
+      "window_index": 3,
+      "train_start": "2025-02-11T00:00:00",
+      "train_end": "2025-08-11T00:00:00",
+      "test_start": "2025-08-11T00:00:00",
+      "test_end": "2025-11-11T00:00:00",
+      "total_trades": 4,
+      "win_rate": 25.0,
+      "total_return_pct": -4.14290667497964,
+      "max_drawdown_pct": 5.907452511710836,
+      "sharpe_ratio": -0.9048456978299937
+    }
+  ],
+  "resolved_backtest_config": {
+    "symbol": "AVAXUSDT",
+    "timeframe": "4h",
+    "start_date": "2024-02-11",
+    "end_date": "2026-04-08",
+    "initial_capital": 10000.0,
+    "fee_rate": 0.0004,
+    "stop_loss_pct": 0.01,
+    "take_profit_pct": 0.03,
+    "sl_atr_multiplier": 2.0,
+    "tp_atr_multiplier": 3.0,
+    "trailing_activate_atr": 2.0,
+    "trailing_offset_atr": 1.0,
+    "slippage_pct": 0.0002,
+    "risk_per_trade": 0.02,
+    "use_atr_sizing": false,
+    "atr_multiplier": 1.0,
+    "apply_global_trend_filter": true,
+    "global_trend_filter_buffer_pct": 0.0,
+    "global_trend_filter_source": "cost_profile_override",
+    "config_global_trend_filter_enabled": null,
+    "session_liquidity_router": {
+      "enabled": false,
+      "allowed_windows": [
+        "americas"
+      ],
+      "block_entries_outside_windows": true
+    },
+    "basis_premium_filter": {
+      "enabled": false,
+      "exchange": "binance_usdm",
+      "tail_metric": "basis_bps",
+      "positive_tail_pct": 0.05,
+      "block_positive_tail_longs": true,
+      "missing_data_policy": "allow",
+      "calibrated_positive_threshold": null
+    },
+    "cross_venue_dislocation": {
+      "enabled": false,
+      "metric": "basis_spread",
+      "mode": "require",
+      "min_spread_bps": 5.0,
+      "side": "both",
+      "missing_data_policy": "allow"
+    },
+    "allow_short": false,
+    "use_executor_exit_model": true,
+    "ignore_signal_sells": false,
+    "strategy_configs": [
+      {
+        "band_distance_threshold": 0.0,
+        "rsi_oversold": 30,
+        "rsi_overbought": 70
+      }
+    ],
+    "aggregator_config": {
+      "buy_threshold": 0.55,
+      "buy_threshold_uptrend": 0.5,
+      "sell_threshold": -0.55,
+      "btc_regime_filter_enabled": true,
+      "btc_reference_symbol": "BTCUSDT",
+      "btc_dump_threshold_pct": -1.0,
+      "btc_dump_require_below_ema200": true,
+      "min_confidence": 0.1
+    },
+    "time_stop_minutes": 720.0,
+    "replay_sentiment_path": null,
+    "replay_sentiment_max_age_seconds": null,
+    "futures_mode": false,
+    "futures_leverage": 5,
+    "futures_funding_rate": 0.0001,
+    "funding_cadence": "scaled_8h",
+    "fixed_notional_usdt": 0.0,
+    "quantity_step_size": 0.0,
+    "min_notional_usdt": 0.0
+  },
+  "cost_audit": {
+    "name": "corrected",
+    "fee_rate": 0.0004,
+    "slippage_pct": 0.0002,
+    "apply_global_trend_filter": true,
+    "funding_cadence": "scaled_8h",
+    "base_futures_funding_rate": 0.0001,
+    "round_trip_cost_pct": 0.12000000000000001,
+    "funding_method": "scale per-bar rate by tf_hours/8 (equivalent to 8h settlement cadence)",
+    "effective_futures_funding_rate": 0.0
+  },
+  "global_trend_filter_audit": {
+    "active": true,
+    "buffer_pct": 0.0,
+    "source": "cost_profile_override",
+    "config_explicit": null
+  }
+}

--- a/research/closed-family-cost-rescreen/combined_results.json
+++ b/research/closed-family-cost-rescreen/combined_results.json
@@ -1,0 +1,1102 @@
+[
+  {
+    "lane_id": "sol-4h-rsi-reversal",
+    "cell_id": "cell_a",
+    "label": "corrected cost + filter OFF",
+    "summary": {
+      "symbol": "SOLUSDT",
+      "timeframe": "4h",
+      "start": "2024-01-01",
+      "end": "2026-06-01",
+      "total_trades": 274,
+      "win_rate": 28.467153284671532,
+      "total_return_pct": -11.31478606247736,
+      "max_drawdown_pct": 23.971953365838733,
+      "sharpe_ratio": -0.18010269219020852,
+      "wfo_windows": 4,
+      "wfo_total_trades": 120,
+      "wfo_mean_sharpe": 0.09479586298573628,
+      "wfo_total_return_pct": -4.423129900791444,
+      "bootstrap_p_loss_pct": 65.8,
+      "mc_drawdown_p95_pct": 51.931921058766086,
+      "mc_drawdown_p50_pct": 30.83043380308141,
+      "profit_concentration_pct": 100.0,
+      "passes_gates": false,
+      "failure_reasons": [
+        "min_wfo_sharpe failed (0.09 < 0.50)",
+        "max_drawdown_pct failed (23.97% > 10.00%)",
+        "max_bootstrap_p_loss_pct failed (65.80% > 25.00%)",
+        "min_oos_return_pct failed (-4.42% < 0.00%)",
+        "max_profit_concentration_pct failed (100.00% > 50.00%)"
+      ],
+      "blocked_buy_count": 0,
+      "basis_blocked_buy_count": 0,
+      "dislocation_blocked_buy_count": 0
+    },
+    "gates": {
+      "min_trades": 0,
+      "min_wfo_trades": 20,
+      "min_wfo_sharpe": 0.5,
+      "max_drawdown_pct": 10.0,
+      "max_bootstrap_p_loss_pct": 25.0,
+      "min_oos_return_pct": 0.0,
+      "max_profit_concentration_pct": 50.0,
+      "max_mc_drawdown_p95_pct": 0.0
+    },
+    "windows": [
+      {
+        "window_index": 1,
+        "train_start": "2024-01-01T00:00:00",
+        "train_end": "2024-07-01T00:00:00",
+        "test_start": "2024-07-01T00:00:00",
+        "test_end": "2024-10-01T00:00:00",
+        "total_trades": 31,
+        "win_rate": 32.25806451612903,
+        "total_return_pct": -3.002039270201058,
+        "max_drawdown_pct": 12.457678746973498,
+        "sharpe_ratio": -0.6311825984051977
+      },
+      {
+        "window_index": 2,
+        "train_start": "2024-07-01T00:00:00",
+        "train_end": "2025-01-01T00:00:00",
+        "test_start": "2025-01-01T00:00:00",
+        "test_end": "2025-04-01T00:00:00",
+        "total_trades": 33,
+        "win_rate": 24.242424242424242,
+        "total_return_pct": -7.266852150962786,
+        "max_drawdown_pct": 13.141133175805495,
+        "sharpe_ratio": -1.4695552683899025
+      },
+      {
+        "window_index": 3,
+        "train_start": "2025-01-01T00:00:00",
+        "train_end": "2025-07-01T00:00:00",
+        "test_start": "2025-07-01T00:00:00",
+        "test_end": "2025-10-01T00:00:00",
+        "total_trades": 34,
+        "win_rate": 23.52941176470588,
+        "total_return_pct": -4.72364634153826,
+        "max_drawdown_pct": 9.570149809256343,
+        "sharpe_ratio": -0.8504893161859002
+      },
+      {
+        "window_index": 4,
+        "train_start": "2025-07-01T00:00:00",
+        "train_end": "2026-01-01T00:00:00",
+        "test_start": "2026-01-01T00:00:00",
+        "test_end": "2026-04-01T00:00:00",
+        "total_trades": 22,
+        "win_rate": 45.45454545454545,
+        "total_return_pct": 11.52444495153708,
+        "max_drawdown_pct": 5.78979812757769,
+        "sharpe_ratio": 3.3304106349239455
+      }
+    ],
+    "resolved_backtest_config": {
+      "symbol": "SOLUSDT",
+      "timeframe": "4h",
+      "start_date": "2024-01-01",
+      "end_date": "2026-06-01",
+      "initial_capital": 10000.0,
+      "fee_rate": 0.0004,
+      "stop_loss_pct": 0.01,
+      "take_profit_pct": 0.03,
+      "sl_atr_multiplier": 2.0,
+      "tp_atr_multiplier": 3.0,
+      "trailing_activate_atr": 1.5,
+      "trailing_offset_atr": 0.8,
+      "slippage_pct": 0.0002,
+      "risk_per_trade": 0.02,
+      "use_atr_sizing": false,
+      "atr_multiplier": 1.0,
+      "apply_global_trend_filter": false,
+      "global_trend_filter_buffer_pct": 0.0,
+      "global_trend_filter_source": "cost_profile_override",
+      "config_global_trend_filter_enabled": null,
+      "session_liquidity_router": {
+        "enabled": false,
+        "allowed_windows": [
+          "americas"
+        ],
+        "block_entries_outside_windows": true
+      },
+      "basis_premium_filter": {
+        "enabled": false,
+        "exchange": "binance_usdm",
+        "tail_metric": "basis_bps",
+        "positive_tail_pct": 0.05,
+        "block_positive_tail_longs": true,
+        "missing_data_policy": "allow",
+        "calibrated_positive_threshold": null
+      },
+      "cross_venue_dislocation": {
+        "enabled": false,
+        "metric": "basis_spread",
+        "mode": "require",
+        "min_spread_bps": 5.0,
+        "side": "both",
+        "missing_data_policy": "allow"
+      },
+      "allow_short": false,
+      "use_executor_exit_model": false,
+      "ignore_signal_sells": false,
+      "strategy_configs": [
+        {
+          "rsi_period": 7,
+          "oversold_threshold": 35,
+          "overbought_threshold": 65
+        }
+      ],
+      "aggregator_config": {
+        "buy_threshold": 0.55,
+        "buy_threshold_uptrend": 0.5,
+        "sell_threshold": -0.55,
+        "btc_regime_filter_enabled": true,
+        "btc_reference_symbol": "BTCUSDT",
+        "btc_dump_threshold_pct": -1.0,
+        "btc_dump_require_below_ema200": true,
+        "min_confidence": 0.1
+      },
+      "time_stop_minutes": 0.0,
+      "replay_sentiment_path": null,
+      "replay_sentiment_max_age_seconds": null,
+      "futures_mode": false,
+      "futures_leverage": 5,
+      "futures_funding_rate": 0.0001,
+      "funding_cadence": "scaled_8h",
+      "fixed_notional_usdt": 0.0,
+      "quantity_step_size": 0.0,
+      "min_notional_usdt": 0.0
+    },
+    "cost_audit": {
+      "name": "corrected",
+      "fee_rate": 0.0004,
+      "slippage_pct": 0.0002,
+      "apply_global_trend_filter": false,
+      "funding_cadence": "scaled_8h",
+      "base_futures_funding_rate": 0.0001,
+      "round_trip_cost_pct": 0.12000000000000001,
+      "funding_method": "scale per-bar rate by tf_hours/8 (equivalent to 8h settlement cadence)",
+      "effective_futures_funding_rate": 0.0
+    },
+    "global_trend_filter_audit": {
+      "active": false,
+      "buffer_pct": 0.0,
+      "source": "cost_profile_override",
+      "config_explicit": null
+    }
+  },
+  {
+    "lane_id": "sol-4h-rsi-reversal",
+    "cell_id": "cell_b",
+    "label": "corrected cost + filter ON",
+    "summary": {
+      "symbol": "SOLUSDT",
+      "timeframe": "4h",
+      "start": "2024-01-01",
+      "end": "2026-06-01",
+      "total_trades": 127,
+      "win_rate": 25.196850393700785,
+      "total_return_pct": -19.063566631687152,
+      "max_drawdown_pct": 20.45685845913771,
+      "sharpe_ratio": -0.703012501731618,
+      "wfo_windows": 4,
+      "wfo_total_trades": 51,
+      "wfo_mean_sharpe": 0.40525169992519006,
+      "wfo_total_return_pct": -4.025028325496438,
+      "bootstrap_p_loss_pct": 87.2,
+      "mc_drawdown_p95_pct": 43.073265352407276,
+      "mc_drawdown_p50_pct": 27.280318573312396,
+      "profit_concentration_pct": 45.960633387657005,
+      "passes_gates": false,
+      "failure_reasons": [
+        "min_wfo_sharpe failed (0.41 < 0.50)",
+        "max_drawdown_pct failed (20.46% > 10.00%)",
+        "max_bootstrap_p_loss_pct failed (87.20% > 25.00%)",
+        "min_oos_return_pct failed (-4.03% < 0.00%)"
+      ],
+      "blocked_buy_count": 0,
+      "basis_blocked_buy_count": 0,
+      "dislocation_blocked_buy_count": 0
+    },
+    "gates": {
+      "min_trades": 0,
+      "min_wfo_trades": 20,
+      "min_wfo_sharpe": 0.5,
+      "max_drawdown_pct": 10.0,
+      "max_bootstrap_p_loss_pct": 25.0,
+      "min_oos_return_pct": 0.0,
+      "max_profit_concentration_pct": 50.0,
+      "max_mc_drawdown_p95_pct": 0.0
+    },
+    "windows": [
+      {
+        "window_index": 1,
+        "train_start": "2024-01-01T00:00:00",
+        "train_end": "2024-07-01T00:00:00",
+        "test_start": "2024-07-01T00:00:00",
+        "test_end": "2024-10-01T00:00:00",
+        "total_trades": 12,
+        "win_rate": 41.66666666666667,
+        "total_return_pct": 2.2480564010348463,
+        "max_drawdown_pct": 2.969522053626899,
+        "sharpe_ratio": 0.9065602336969906
+      },
+      {
+        "window_index": 2,
+        "train_start": "2024-07-01T00:00:00",
+        "train_end": "2025-01-01T00:00:00",
+        "test_start": "2025-01-01T00:00:00",
+        "test_end": "2025-04-01T00:00:00",
+        "total_trades": 9,
+        "win_rate": 33.33333333333333,
+        "total_return_pct": 1.9563106266796786,
+        "max_drawdown_pct": 3.318775263353249,
+        "sharpe_ratio": 0.7698270834198112
+      },
+      {
+        "window_index": 3,
+        "train_start": "2025-01-01T00:00:00",
+        "train_end": "2025-07-01T00:00:00",
+        "test_start": "2025-07-01T00:00:00",
+        "test_end": "2025-10-01T00:00:00",
+        "total_trades": 25,
+        "win_rate": 16.0,
+        "total_return_pct": -11.114603497463142,
+        "max_drawdown_pct": 11.739745193495073,
+        "sharpe_ratio": -2.6738257972259265
+      },
+      {
+        "window_index": 4,
+        "train_start": "2025-07-01T00:00:00",
+        "train_end": "2026-01-01T00:00:00",
+        "test_start": "2026-01-01T00:00:00",
+        "test_end": "2026-04-01T00:00:00",
+        "total_trades": 5,
+        "win_rate": 60.0,
+        "total_return_pct": 3.575825989489003,
+        "max_drawdown_pct": 1.3593133577460055,
+        "sharpe_ratio": 2.618445279809885
+      }
+    ],
+    "resolved_backtest_config": {
+      "symbol": "SOLUSDT",
+      "timeframe": "4h",
+      "start_date": "2024-01-01",
+      "end_date": "2026-06-01",
+      "initial_capital": 10000.0,
+      "fee_rate": 0.0004,
+      "stop_loss_pct": 0.01,
+      "take_profit_pct": 0.03,
+      "sl_atr_multiplier": 2.0,
+      "tp_atr_multiplier": 3.0,
+      "trailing_activate_atr": 1.5,
+      "trailing_offset_atr": 0.8,
+      "slippage_pct": 0.0002,
+      "risk_per_trade": 0.02,
+      "use_atr_sizing": false,
+      "atr_multiplier": 1.0,
+      "apply_global_trend_filter": true,
+      "global_trend_filter_buffer_pct": 0.0,
+      "global_trend_filter_source": "cost_profile_override",
+      "config_global_trend_filter_enabled": null,
+      "session_liquidity_router": {
+        "enabled": false,
+        "allowed_windows": [
+          "americas"
+        ],
+        "block_entries_outside_windows": true
+      },
+      "basis_premium_filter": {
+        "enabled": false,
+        "exchange": "binance_usdm",
+        "tail_metric": "basis_bps",
+        "positive_tail_pct": 0.05,
+        "block_positive_tail_longs": true,
+        "missing_data_policy": "allow",
+        "calibrated_positive_threshold": null
+      },
+      "cross_venue_dislocation": {
+        "enabled": false,
+        "metric": "basis_spread",
+        "mode": "require",
+        "min_spread_bps": 5.0,
+        "side": "both",
+        "missing_data_policy": "allow"
+      },
+      "allow_short": false,
+      "use_executor_exit_model": false,
+      "ignore_signal_sells": false,
+      "strategy_configs": [
+        {
+          "rsi_period": 7,
+          "oversold_threshold": 35,
+          "overbought_threshold": 65
+        }
+      ],
+      "aggregator_config": {
+        "buy_threshold": 0.55,
+        "buy_threshold_uptrend": 0.5,
+        "sell_threshold": -0.55,
+        "btc_regime_filter_enabled": true,
+        "btc_reference_symbol": "BTCUSDT",
+        "btc_dump_threshold_pct": -1.0,
+        "btc_dump_require_below_ema200": true,
+        "min_confidence": 0.1
+      },
+      "time_stop_minutes": 0.0,
+      "replay_sentiment_path": null,
+      "replay_sentiment_max_age_seconds": null,
+      "futures_mode": false,
+      "futures_leverage": 5,
+      "futures_funding_rate": 0.0001,
+      "funding_cadence": "scaled_8h",
+      "fixed_notional_usdt": 0.0,
+      "quantity_step_size": 0.0,
+      "min_notional_usdt": 0.0
+    },
+    "cost_audit": {
+      "name": "corrected",
+      "fee_rate": 0.0004,
+      "slippage_pct": 0.0002,
+      "apply_global_trend_filter": true,
+      "funding_cadence": "scaled_8h",
+      "base_futures_funding_rate": 0.0001,
+      "round_trip_cost_pct": 0.12000000000000001,
+      "funding_method": "scale per-bar rate by tf_hours/8 (equivalent to 8h settlement cadence)",
+      "effective_futures_funding_rate": 0.0
+    },
+    "global_trend_filter_audit": {
+      "active": true,
+      "buffer_pct": 0.0,
+      "source": "cost_profile_override",
+      "config_explicit": null
+    }
+  },
+  {
+    "lane_id": "avax-4h-bollinger-strategy",
+    "cell_id": "cell_a",
+    "label": "corrected cost + filter OFF",
+    "summary": {
+      "symbol": "AVAXUSDT",
+      "timeframe": "4h",
+      "start": "2024-02-11",
+      "end": "2026-04-08",
+      "total_trades": 81,
+      "win_rate": 58.0246913580247,
+      "total_return_pct": 46.754032378087324,
+      "max_drawdown_pct": 22.277221569986512,
+      "sharpe_ratio": 0.9255218518607923,
+      "wfo_windows": 3,
+      "wfo_total_trades": 26,
+      "wfo_mean_sharpe": 0.8070804504689949,
+      "wfo_total_return_pct": 11.144621058948756,
+      "bootstrap_p_loss_pct": 16.6,
+      "mc_drawdown_p95_pct": 42.63342643491706,
+      "mc_drawdown_p50_pct": 22.90495239226439,
+      "profit_concentration_pct": 69.9154424913016,
+      "passes_gates": false,
+      "failure_reasons": [
+        "max_drawdown_pct failed (22.28% > 10.00%)",
+        "max_profit_concentration_pct failed (69.92% > 50.00%)"
+      ],
+      "blocked_buy_count": 0,
+      "basis_blocked_buy_count": 0,
+      "dislocation_blocked_buy_count": 0
+    },
+    "gates": {
+      "min_trades": 0,
+      "min_wfo_trades": 20,
+      "min_wfo_sharpe": 0.5,
+      "max_drawdown_pct": 10.0,
+      "max_bootstrap_p_loss_pct": 25.0,
+      "min_oos_return_pct": 0.0,
+      "max_profit_concentration_pct": 50.0,
+      "max_mc_drawdown_p95_pct": 0.0
+    },
+    "windows": [
+      {
+        "window_index": 1,
+        "train_start": "2024-02-11T00:00:00",
+        "train_end": "2024-08-11T00:00:00",
+        "test_start": "2024-08-11T00:00:00",
+        "test_end": "2024-11-11T00:00:00",
+        "total_trades": 8,
+        "win_rate": 75.0,
+        "total_return_pct": 3.8406259373717693,
+        "max_drawdown_pct": 7.470272746601372,
+        "sharpe_ratio": 1.0434146367904473
+      },
+      {
+        "window_index": 2,
+        "train_start": "2024-08-11T00:00:00",
+        "train_end": "2025-02-11T00:00:00",
+        "test_start": "2025-02-11T00:00:00",
+        "test_end": "2025-05-11T00:00:00",
+        "total_trades": 9,
+        "win_rate": 44.44444444444444,
+        "total_return_pct": -1.7366249038081698,
+        "max_drawdown_pct": 11.460835743842988,
+        "sharpe_ratio": -0.12695001624570731
+      },
+      {
+        "window_index": 3,
+        "train_start": "2025-02-11T00:00:00",
+        "train_end": "2025-08-11T00:00:00",
+        "test_start": "2025-08-11T00:00:00",
+        "test_end": "2025-11-11T00:00:00",
+        "total_trades": 9,
+        "win_rate": 55.55555555555556,
+        "total_return_pct": 8.925478188511825,
+        "max_drawdown_pct": 6.289725337642067,
+        "sharpe_ratio": 1.5047767308622448
+      }
+    ],
+    "resolved_backtest_config": {
+      "symbol": "AVAXUSDT",
+      "timeframe": "4h",
+      "start_date": "2024-02-11",
+      "end_date": "2026-04-08",
+      "initial_capital": 10000.0,
+      "fee_rate": 0.0004,
+      "stop_loss_pct": 0.01,
+      "take_profit_pct": 0.03,
+      "sl_atr_multiplier": 2.0,
+      "tp_atr_multiplier": 3.0,
+      "trailing_activate_atr": 2.0,
+      "trailing_offset_atr": 1.0,
+      "slippage_pct": 0.0002,
+      "risk_per_trade": 0.02,
+      "use_atr_sizing": false,
+      "atr_multiplier": 1.0,
+      "apply_global_trend_filter": false,
+      "global_trend_filter_buffer_pct": 0.0,
+      "global_trend_filter_source": "cost_profile_override",
+      "config_global_trend_filter_enabled": null,
+      "session_liquidity_router": {
+        "enabled": false,
+        "allowed_windows": [
+          "americas"
+        ],
+        "block_entries_outside_windows": true
+      },
+      "basis_premium_filter": {
+        "enabled": false,
+        "exchange": "binance_usdm",
+        "tail_metric": "basis_bps",
+        "positive_tail_pct": 0.05,
+        "block_positive_tail_longs": true,
+        "missing_data_policy": "allow",
+        "calibrated_positive_threshold": null
+      },
+      "cross_venue_dislocation": {
+        "enabled": false,
+        "metric": "basis_spread",
+        "mode": "require",
+        "min_spread_bps": 5.0,
+        "side": "both",
+        "missing_data_policy": "allow"
+      },
+      "allow_short": false,
+      "use_executor_exit_model": true,
+      "ignore_signal_sells": false,
+      "strategy_configs": [
+        {
+          "band_distance_threshold": 0.0,
+          "rsi_oversold": 30,
+          "rsi_overbought": 70
+        }
+      ],
+      "aggregator_config": {
+        "buy_threshold": 0.55,
+        "buy_threshold_uptrend": 0.5,
+        "sell_threshold": -0.55,
+        "btc_regime_filter_enabled": true,
+        "btc_reference_symbol": "BTCUSDT",
+        "btc_dump_threshold_pct": -1.0,
+        "btc_dump_require_below_ema200": true,
+        "min_confidence": 0.1
+      },
+      "time_stop_minutes": 720.0,
+      "replay_sentiment_path": null,
+      "replay_sentiment_max_age_seconds": null,
+      "futures_mode": false,
+      "futures_leverage": 5,
+      "futures_funding_rate": 0.0001,
+      "funding_cadence": "scaled_8h",
+      "fixed_notional_usdt": 0.0,
+      "quantity_step_size": 0.0,
+      "min_notional_usdt": 0.0
+    },
+    "cost_audit": {
+      "name": "corrected",
+      "fee_rate": 0.0004,
+      "slippage_pct": 0.0002,
+      "apply_global_trend_filter": false,
+      "funding_cadence": "scaled_8h",
+      "base_futures_funding_rate": 0.0001,
+      "round_trip_cost_pct": 0.12000000000000001,
+      "funding_method": "scale per-bar rate by tf_hours/8 (equivalent to 8h settlement cadence)",
+      "effective_futures_funding_rate": 0.0
+    },
+    "global_trend_filter_audit": {
+      "active": false,
+      "buffer_pct": 0.0,
+      "source": "cost_profile_override",
+      "config_explicit": null
+    }
+  },
+  {
+    "lane_id": "avax-4h-bollinger-strategy",
+    "cell_id": "cell_b",
+    "label": "corrected cost + filter ON",
+    "summary": {
+      "symbol": "AVAXUSDT",
+      "timeframe": "4h",
+      "start": "2024-02-11",
+      "end": "2026-04-08",
+      "total_trades": 13,
+      "win_rate": 61.53846153846154,
+      "total_return_pct": 6.734541064927743,
+      "max_drawdown_pct": 7.170733930822514,
+      "sharpe_ratio": 0.3958082816462312,
+      "wfo_windows": 3,
+      "wfo_total_trades": 7,
+      "wfo_mean_sharpe": -0.2099624414659996,
+      "wfo_total_return_pct": -3.4469189375277987,
+      "bootstrap_p_loss_pct": 31.0,
+      "mc_drawdown_p95_pct": 16.597665042952226,
+      "mc_drawdown_p50_pct": 7.361053551664051,
+      "profit_concentration_pct": 100.0,
+      "passes_gates": false,
+      "failure_reasons": [
+        "min_wfo_trades failed (7 < 20)",
+        "min_wfo_sharpe failed (-0.21 < 0.50)",
+        "max_bootstrap_p_loss_pct failed (31.00% > 25.00%)",
+        "min_oos_return_pct failed (-3.45% < 0.00%)",
+        "max_profit_concentration_pct failed (100.00% > 50.00%)"
+      ],
+      "blocked_buy_count": 0,
+      "basis_blocked_buy_count": 0,
+      "dislocation_blocked_buy_count": 0
+    },
+    "gates": {
+      "min_trades": 0,
+      "min_wfo_trades": 20,
+      "min_wfo_sharpe": 0.5,
+      "max_drawdown_pct": 10.0,
+      "max_bootstrap_p_loss_pct": 25.0,
+      "min_oos_return_pct": 0.0,
+      "max_profit_concentration_pct": 50.0,
+      "max_mc_drawdown_p95_pct": 0.0
+    },
+    "windows": [
+      {
+        "window_index": 1,
+        "train_start": "2024-02-11T00:00:00",
+        "train_end": "2024-08-11T00:00:00",
+        "test_start": "2024-08-11T00:00:00",
+        "test_end": "2024-11-11T00:00:00",
+        "total_trades": 3,
+        "win_rate": 66.66666666666666,
+        "total_return_pct": 0.7260680595560733,
+        "max_drawdown_pct": 4.261752813883015,
+        "sharpe_ratio": 0.2749583734319949
+      },
+      {
+        "window_index": 2,
+        "train_start": "2024-08-11T00:00:00",
+        "train_end": "2025-02-11T00:00:00",
+        "test_start": "2025-02-11T00:00:00",
+        "test_end": "2025-05-11T00:00:00",
+        "total_trades": 0,
+        "win_rate": 0.0,
+        "total_return_pct": 0.0,
+        "max_drawdown_pct": 0.0,
+        "sharpe_ratio": 0.0
+      },
+      {
+        "window_index": 3,
+        "train_start": "2025-02-11T00:00:00",
+        "train_end": "2025-08-11T00:00:00",
+        "test_start": "2025-08-11T00:00:00",
+        "test_end": "2025-11-11T00:00:00",
+        "total_trades": 4,
+        "win_rate": 25.0,
+        "total_return_pct": -4.14290667497964,
+        "max_drawdown_pct": 5.907452511710836,
+        "sharpe_ratio": -0.9048456978299937
+      }
+    ],
+    "resolved_backtest_config": {
+      "symbol": "AVAXUSDT",
+      "timeframe": "4h",
+      "start_date": "2024-02-11",
+      "end_date": "2026-04-08",
+      "initial_capital": 10000.0,
+      "fee_rate": 0.0004,
+      "stop_loss_pct": 0.01,
+      "take_profit_pct": 0.03,
+      "sl_atr_multiplier": 2.0,
+      "tp_atr_multiplier": 3.0,
+      "trailing_activate_atr": 2.0,
+      "trailing_offset_atr": 1.0,
+      "slippage_pct": 0.0002,
+      "risk_per_trade": 0.02,
+      "use_atr_sizing": false,
+      "atr_multiplier": 1.0,
+      "apply_global_trend_filter": true,
+      "global_trend_filter_buffer_pct": 0.0,
+      "global_trend_filter_source": "cost_profile_override",
+      "config_global_trend_filter_enabled": null,
+      "session_liquidity_router": {
+        "enabled": false,
+        "allowed_windows": [
+          "americas"
+        ],
+        "block_entries_outside_windows": true
+      },
+      "basis_premium_filter": {
+        "enabled": false,
+        "exchange": "binance_usdm",
+        "tail_metric": "basis_bps",
+        "positive_tail_pct": 0.05,
+        "block_positive_tail_longs": true,
+        "missing_data_policy": "allow",
+        "calibrated_positive_threshold": null
+      },
+      "cross_venue_dislocation": {
+        "enabled": false,
+        "metric": "basis_spread",
+        "mode": "require",
+        "min_spread_bps": 5.0,
+        "side": "both",
+        "missing_data_policy": "allow"
+      },
+      "allow_short": false,
+      "use_executor_exit_model": true,
+      "ignore_signal_sells": false,
+      "strategy_configs": [
+        {
+          "band_distance_threshold": 0.0,
+          "rsi_oversold": 30,
+          "rsi_overbought": 70
+        }
+      ],
+      "aggregator_config": {
+        "buy_threshold": 0.55,
+        "buy_threshold_uptrend": 0.5,
+        "sell_threshold": -0.55,
+        "btc_regime_filter_enabled": true,
+        "btc_reference_symbol": "BTCUSDT",
+        "btc_dump_threshold_pct": -1.0,
+        "btc_dump_require_below_ema200": true,
+        "min_confidence": 0.1
+      },
+      "time_stop_minutes": 720.0,
+      "replay_sentiment_path": null,
+      "replay_sentiment_max_age_seconds": null,
+      "futures_mode": false,
+      "futures_leverage": 5,
+      "futures_funding_rate": 0.0001,
+      "funding_cadence": "scaled_8h",
+      "fixed_notional_usdt": 0.0,
+      "quantity_step_size": 0.0,
+      "min_notional_usdt": 0.0
+    },
+    "cost_audit": {
+      "name": "corrected",
+      "fee_rate": 0.0004,
+      "slippage_pct": 0.0002,
+      "apply_global_trend_filter": true,
+      "funding_cadence": "scaled_8h",
+      "base_futures_funding_rate": 0.0001,
+      "round_trip_cost_pct": 0.12000000000000001,
+      "funding_method": "scale per-bar rate by tf_hours/8 (equivalent to 8h settlement cadence)",
+      "effective_futures_funding_rate": 0.0
+    },
+    "global_trend_filter_audit": {
+      "active": true,
+      "buffer_pct": 0.0,
+      "source": "cost_profile_override",
+      "config_explicit": null
+    }
+  },
+  {
+    "lane_id": "eth-4h-range-reversion-bounded",
+    "cell_id": "cell_a",
+    "label": "corrected cost + filter OFF",
+    "summary": {
+      "symbol": "ETHUSDT",
+      "timeframe": "4h",
+      "start": "2024-01-01",
+      "end": "2026-06-01",
+      "total_trades": 131,
+      "win_rate": 49.61832061068702,
+      "total_return_pct": -65.88493139899496,
+      "max_drawdown_pct": 71.52601896009385,
+      "sharpe_ratio": -1.4093515849991738,
+      "wfo_windows": 4,
+      "wfo_total_trades": 66,
+      "wfo_mean_sharpe": -1.8386434854105729,
+      "wfo_total_return_pct": -46.51796867913662,
+      "bootstrap_p_loss_pct": 98.0,
+      "mc_drawdown_p95_pct": 85.27730913494725,
+      "mc_drawdown_p50_pct": 70.76285282314392,
+      "profit_concentration_pct": 100.0,
+      "passes_gates": false,
+      "failure_reasons": [
+        "min_wfo_sharpe failed (-1.84 < 0.50)",
+        "max_drawdown_pct failed (71.53% > 10.00%)",
+        "max_bootstrap_p_loss_pct failed (98.00% > 25.00%)",
+        "min_oos_return_pct failed (-46.52% < 0.00%)",
+        "max_profit_concentration_pct failed (100.00% > 50.00%)"
+      ],
+      "blocked_buy_count": 0,
+      "basis_blocked_buy_count": 0,
+      "dislocation_blocked_buy_count": 0
+    },
+    "gates": {
+      "min_trades": 0,
+      "min_wfo_trades": 20,
+      "min_wfo_sharpe": 0.5,
+      "max_drawdown_pct": 10.0,
+      "max_bootstrap_p_loss_pct": 25.0,
+      "min_oos_return_pct": 0.0,
+      "max_profit_concentration_pct": 50.0,
+      "max_mc_drawdown_p95_pct": 0.0
+    },
+    "windows": [
+      {
+        "window_index": 1,
+        "train_start": "2024-01-01T00:00:00",
+        "train_end": "2024-07-01T00:00:00",
+        "test_start": "2024-07-01T00:00:00",
+        "test_end": "2024-10-01T00:00:00",
+        "total_trades": 23,
+        "win_rate": 47.82608695652174,
+        "total_return_pct": -17.69773941784477,
+        "max_drawdown_pct": 25.68525547070852,
+        "sharpe_ratio": -1.8939859233462055
+      },
+      {
+        "window_index": 2,
+        "train_start": "2024-07-01T00:00:00",
+        "train_end": "2025-01-01T00:00:00",
+        "test_start": "2025-01-01T00:00:00",
+        "test_end": "2025-04-01T00:00:00",
+        "total_trades": 18,
+        "win_rate": 44.44444444444444,
+        "total_return_pct": -18.898251761855573,
+        "max_drawdown_pct": 21.406951936342935,
+        "sharpe_ratio": -2.0002690013792788
+      },
+      {
+        "window_index": 3,
+        "train_start": "2025-01-01T00:00:00",
+        "train_end": "2025-07-01T00:00:00",
+        "test_start": "2025-07-01T00:00:00",
+        "test_end": "2025-10-01T00:00:00",
+        "total_trades": 13,
+        "win_rate": 61.53846153846154,
+        "total_return_pct": 0.7684898080006496,
+        "max_drawdown_pct": 8.928810703402657,
+        "sharpe_ratio": 0.25005549921667436
+      },
+      {
+        "window_index": 4,
+        "train_start": "2025-07-01T00:00:00",
+        "train_end": "2026-01-01T00:00:00",
+        "test_start": "2026-01-01T00:00:00",
+        "test_end": "2026-04-01T00:00:00",
+        "total_trades": 12,
+        "win_rate": 41.66666666666667,
+        "total_return_pct": -20.48644627139671,
+        "max_drawdown_pct": 32.60858501241407,
+        "sharpe_ratio": -3.710374516133482
+      }
+    ],
+    "resolved_backtest_config": {
+      "symbol": "ETHUSDT",
+      "timeframe": "4h",
+      "start_date": "2024-01-01",
+      "end_date": "2026-06-01",
+      "initial_capital": 10000.0,
+      "fee_rate": 0.0004,
+      "stop_loss_pct": 0.01,
+      "take_profit_pct": 0.03,
+      "sl_atr_multiplier": 2.1,
+      "tp_atr_multiplier": 3.0,
+      "trailing_activate_atr": 1.6,
+      "trailing_offset_atr": 0.8,
+      "slippage_pct": 0.0002,
+      "risk_per_trade": 0.02,
+      "use_atr_sizing": false,
+      "atr_multiplier": 1.0,
+      "apply_global_trend_filter": false,
+      "global_trend_filter_buffer_pct": 0.0025,
+      "global_trend_filter_source": "cost_profile_override",
+      "config_global_trend_filter_enabled": null,
+      "session_liquidity_router": {
+        "enabled": false,
+        "allowed_windows": [
+          "americas"
+        ],
+        "block_entries_outside_windows": true
+      },
+      "basis_premium_filter": {
+        "enabled": false,
+        "exchange": "binance_usdm",
+        "tail_metric": "basis_bps",
+        "positive_tail_pct": 0.05,
+        "block_positive_tail_longs": true,
+        "missing_data_policy": "allow",
+        "calibrated_positive_threshold": null
+      },
+      "cross_venue_dislocation": {
+        "enabled": false,
+        "metric": "basis_spread",
+        "mode": "require",
+        "min_spread_bps": 5.0,
+        "side": "both",
+        "missing_data_policy": "allow"
+      },
+      "allow_short": false,
+      "use_executor_exit_model": true,
+      "ignore_signal_sells": false,
+      "strategy_configs": [
+        {
+          "band_distance_threshold": 0.0045,
+          "rsi_oversold": 38,
+          "rsi_overbought": 62
+        }
+      ],
+      "aggregator_config": {
+        "buy_threshold": 0.6,
+        "buy_threshold_uptrend": 0.55,
+        "sell_threshold": -0.58,
+        "btc_regime_filter_enabled": true,
+        "btc_reference_symbol": "BTCUSDT",
+        "btc_dump_threshold_pct": -1.0,
+        "btc_dump_require_below_ema200": true,
+        "min_confidence": 0.1
+      },
+      "time_stop_minutes": 4320.0,
+      "replay_sentiment_path": null,
+      "replay_sentiment_max_age_seconds": null,
+      "futures_mode": false,
+      "futures_leverage": 5,
+      "futures_funding_rate": 0.0001,
+      "funding_cadence": "scaled_8h",
+      "fixed_notional_usdt": 0.0,
+      "quantity_step_size": 0.0,
+      "min_notional_usdt": 0.0
+    },
+    "cost_audit": {
+      "name": "corrected",
+      "fee_rate": 0.0004,
+      "slippage_pct": 0.0002,
+      "apply_global_trend_filter": false,
+      "funding_cadence": "scaled_8h",
+      "base_futures_funding_rate": 0.0001,
+      "round_trip_cost_pct": 0.12000000000000001,
+      "funding_method": "scale per-bar rate by tf_hours/8 (equivalent to 8h settlement cadence)",
+      "effective_futures_funding_rate": 0.0
+    },
+    "global_trend_filter_audit": {
+      "active": false,
+      "buffer_pct": 0.0025,
+      "source": "cost_profile_override",
+      "config_explicit": null
+    }
+  },
+  {
+    "lane_id": "eth-4h-range-reversion-bounded",
+    "cell_id": "cell_b",
+    "label": "corrected cost + filter ON",
+    "summary": {
+      "symbol": "ETHUSDT",
+      "timeframe": "4h",
+      "start": "2024-01-01",
+      "end": "2026-06-01",
+      "total_trades": 35,
+      "win_rate": 57.14285714285714,
+      "total_return_pct": -17.371135463806823,
+      "max_drawdown_pct": 28.05831490101427,
+      "sharpe_ratio": -0.5211381138451376,
+      "wfo_windows": 4,
+      "wfo_total_trades": 14,
+      "wfo_mean_sharpe": -0.29227240639889007,
+      "wfo_total_return_pct": 3.6575344219441863,
+      "bootstrap_p_loss_pct": 88.0,
+      "mc_drawdown_p95_pct": 41.51470768838381,
+      "mc_drawdown_p50_pct": 25.038129793647272,
+      "profit_concentration_pct": 100.0,
+      "passes_gates": false,
+      "failure_reasons": [
+        "min_wfo_trades failed (14 < 20)",
+        "min_wfo_sharpe failed (-0.29 < 0.50)",
+        "max_drawdown_pct failed (28.06% > 10.00%)",
+        "max_bootstrap_p_loss_pct failed (88.00% > 25.00%)",
+        "max_profit_concentration_pct failed (100.00% > 50.00%)"
+      ],
+      "blocked_buy_count": 0,
+      "basis_blocked_buy_count": 0,
+      "dislocation_blocked_buy_count": 0
+    },
+    "gates": {
+      "min_trades": 0,
+      "min_wfo_trades": 20,
+      "min_wfo_sharpe": 0.5,
+      "max_drawdown_pct": 10.0,
+      "max_bootstrap_p_loss_pct": 25.0,
+      "min_oos_return_pct": 0.0,
+      "max_profit_concentration_pct": 50.0,
+      "max_mc_drawdown_p95_pct": 0.0
+    },
+    "windows": [
+      {
+        "window_index": 1,
+        "train_start": "2024-01-01T00:00:00",
+        "train_end": "2024-07-01T00:00:00",
+        "test_start": "2024-07-01T00:00:00",
+        "test_end": "2024-10-01T00:00:00",
+        "total_trades": 3,
+        "win_rate": 66.66666666666666,
+        "total_return_pct": -1.4155911623963948,
+        "max_drawdown_pct": 4.148128971679798,
+        "sharpe_ratio": -0.658526527867147
+      },
+      {
+        "window_index": 2,
+        "train_start": "2024-07-01T00:00:00",
+        "train_end": "2025-01-01T00:00:00",
+        "test_start": "2025-01-01T00:00:00",
+        "test_end": "2025-04-01T00:00:00",
+        "total_trades": 0,
+        "win_rate": 0.0,
+        "total_return_pct": 0.0,
+        "max_drawdown_pct": 0.0,
+        "sharpe_ratio": 0.0
+      },
+      {
+        "window_index": 3,
+        "train_start": "2025-01-01T00:00:00",
+        "train_end": "2025-07-01T00:00:00",
+        "test_start": "2025-07-01T00:00:00",
+        "test_end": "2025-10-01T00:00:00",
+        "total_trades": 9,
+        "win_rate": 77.77777777777779,
+        "total_return_pct": 7.1746394921003045,
+        "max_drawdown_pct": 7.268913456093655,
+        "sharpe_ratio": 1.4187662895996729
+      },
+      {
+        "window_index": 4,
+        "train_start": "2025-07-01T00:00:00",
+        "train_end": "2026-01-01T00:00:00",
+        "test_start": "2026-01-01T00:00:00",
+        "test_end": "2026-04-01T00:00:00",
+        "total_trades": 2,
+        "win_rate": 50.0,
+        "total_return_pct": -1.892861967691024,
+        "max_drawdown_pct": 2.6569545285684923,
+        "sharpe_ratio": -1.9293293873280861
+      }
+    ],
+    "resolved_backtest_config": {
+      "symbol": "ETHUSDT",
+      "timeframe": "4h",
+      "start_date": "2024-01-01",
+      "end_date": "2026-06-01",
+      "initial_capital": 10000.0,
+      "fee_rate": 0.0004,
+      "stop_loss_pct": 0.01,
+      "take_profit_pct": 0.03,
+      "sl_atr_multiplier": 2.1,
+      "tp_atr_multiplier": 3.0,
+      "trailing_activate_atr": 1.6,
+      "trailing_offset_atr": 0.8,
+      "slippage_pct": 0.0002,
+      "risk_per_trade": 0.02,
+      "use_atr_sizing": false,
+      "atr_multiplier": 1.0,
+      "apply_global_trend_filter": true,
+      "global_trend_filter_buffer_pct": 0.0025,
+      "global_trend_filter_source": "cost_profile_override",
+      "config_global_trend_filter_enabled": null,
+      "session_liquidity_router": {
+        "enabled": false,
+        "allowed_windows": [
+          "americas"
+        ],
+        "block_entries_outside_windows": true
+      },
+      "basis_premium_filter": {
+        "enabled": false,
+        "exchange": "binance_usdm",
+        "tail_metric": "basis_bps",
+        "positive_tail_pct": 0.05,
+        "block_positive_tail_longs": true,
+        "missing_data_policy": "allow",
+        "calibrated_positive_threshold": null
+      },
+      "cross_venue_dislocation": {
+        "enabled": false,
+        "metric": "basis_spread",
+        "mode": "require",
+        "min_spread_bps": 5.0,
+        "side": "both",
+        "missing_data_policy": "allow"
+      },
+      "allow_short": false,
+      "use_executor_exit_model": true,
+      "ignore_signal_sells": false,
+      "strategy_configs": [
+        {
+          "band_distance_threshold": 0.0045,
+          "rsi_oversold": 38,
+          "rsi_overbought": 62
+        }
+      ],
+      "aggregator_config": {
+        "buy_threshold": 0.6,
+        "buy_threshold_uptrend": 0.55,
+        "sell_threshold": -0.58,
+        "btc_regime_filter_enabled": true,
+        "btc_reference_symbol": "BTCUSDT",
+        "btc_dump_threshold_pct": -1.0,
+        "btc_dump_require_below_ema200": true,
+        "min_confidence": 0.1
+      },
+      "time_stop_minutes": 4320.0,
+      "replay_sentiment_path": null,
+      "replay_sentiment_max_age_seconds": null,
+      "futures_mode": false,
+      "futures_leverage": 5,
+      "futures_funding_rate": 0.0001,
+      "funding_cadence": "scaled_8h",
+      "fixed_notional_usdt": 0.0,
+      "quantity_step_size": 0.0,
+      "min_notional_usdt": 0.0
+    },
+    "cost_audit": {
+      "name": "corrected",
+      "fee_rate": 0.0004,
+      "slippage_pct": 0.0002,
+      "apply_global_trend_filter": true,
+      "funding_cadence": "scaled_8h",
+      "base_futures_funding_rate": 0.0001,
+      "round_trip_cost_pct": 0.12000000000000001,
+      "funding_method": "scale per-bar rate by tf_hours/8 (equivalent to 8h settlement cadence)",
+      "effective_futures_funding_rate": 0.0
+    },
+    "global_trend_filter_audit": {
+      "active": true,
+      "buffer_pct": 0.0025,
+      "source": "cost_profile_override",
+      "config_explicit": null
+    }
+  }
+]

--- a/research/closed-family-cost-rescreen/eth-4h-range-reversion-bounded-cell_a.json
+++ b/research/closed-family-cost-rescreen/eth-4h-range-reversion-bounded-cell_a.json
@@ -1,0 +1,188 @@
+{
+  "lane_id": "eth-4h-range-reversion-bounded",
+  "cell_id": "cell_a",
+  "label": "corrected cost + filter OFF",
+  "summary": {
+    "symbol": "ETHUSDT",
+    "timeframe": "4h",
+    "start": "2024-01-01",
+    "end": "2026-06-01",
+    "total_trades": 131,
+    "win_rate": 49.61832061068702,
+    "total_return_pct": -65.88493139899496,
+    "max_drawdown_pct": 71.52601896009385,
+    "sharpe_ratio": -1.4093515849991738,
+    "wfo_windows": 4,
+    "wfo_total_trades": 66,
+    "wfo_mean_sharpe": -1.8386434854105729,
+    "wfo_total_return_pct": -46.51796867913662,
+    "bootstrap_p_loss_pct": 98.0,
+    "mc_drawdown_p95_pct": 85.27730913494725,
+    "mc_drawdown_p50_pct": 70.76285282314392,
+    "profit_concentration_pct": 100.0,
+    "passes_gates": false,
+    "failure_reasons": [
+      "min_wfo_sharpe failed (-1.84 < 0.50)",
+      "max_drawdown_pct failed (71.53% > 10.00%)",
+      "max_bootstrap_p_loss_pct failed (98.00% > 25.00%)",
+      "min_oos_return_pct failed (-46.52% < 0.00%)",
+      "max_profit_concentration_pct failed (100.00% > 50.00%)"
+    ],
+    "blocked_buy_count": 0,
+    "basis_blocked_buy_count": 0,
+    "dislocation_blocked_buy_count": 0
+  },
+  "gates": {
+    "min_trades": 0,
+    "min_wfo_trades": 20,
+    "min_wfo_sharpe": 0.5,
+    "max_drawdown_pct": 10.0,
+    "max_bootstrap_p_loss_pct": 25.0,
+    "min_oos_return_pct": 0.0,
+    "max_profit_concentration_pct": 50.0,
+    "max_mc_drawdown_p95_pct": 0.0
+  },
+  "windows": [
+    {
+      "window_index": 1,
+      "train_start": "2024-01-01T00:00:00",
+      "train_end": "2024-07-01T00:00:00",
+      "test_start": "2024-07-01T00:00:00",
+      "test_end": "2024-10-01T00:00:00",
+      "total_trades": 23,
+      "win_rate": 47.82608695652174,
+      "total_return_pct": -17.69773941784477,
+      "max_drawdown_pct": 25.68525547070852,
+      "sharpe_ratio": -1.8939859233462055
+    },
+    {
+      "window_index": 2,
+      "train_start": "2024-07-01T00:00:00",
+      "train_end": "2025-01-01T00:00:00",
+      "test_start": "2025-01-01T00:00:00",
+      "test_end": "2025-04-01T00:00:00",
+      "total_trades": 18,
+      "win_rate": 44.44444444444444,
+      "total_return_pct": -18.898251761855573,
+      "max_drawdown_pct": 21.406951936342935,
+      "sharpe_ratio": -2.0002690013792788
+    },
+    {
+      "window_index": 3,
+      "train_start": "2025-01-01T00:00:00",
+      "train_end": "2025-07-01T00:00:00",
+      "test_start": "2025-07-01T00:00:00",
+      "test_end": "2025-10-01T00:00:00",
+      "total_trades": 13,
+      "win_rate": 61.53846153846154,
+      "total_return_pct": 0.7684898080006496,
+      "max_drawdown_pct": 8.928810703402657,
+      "sharpe_ratio": 0.25005549921667436
+    },
+    {
+      "window_index": 4,
+      "train_start": "2025-07-01T00:00:00",
+      "train_end": "2026-01-01T00:00:00",
+      "test_start": "2026-01-01T00:00:00",
+      "test_end": "2026-04-01T00:00:00",
+      "total_trades": 12,
+      "win_rate": 41.66666666666667,
+      "total_return_pct": -20.48644627139671,
+      "max_drawdown_pct": 32.60858501241407,
+      "sharpe_ratio": -3.710374516133482
+    }
+  ],
+  "resolved_backtest_config": {
+    "symbol": "ETHUSDT",
+    "timeframe": "4h",
+    "start_date": "2024-01-01",
+    "end_date": "2026-06-01",
+    "initial_capital": 10000.0,
+    "fee_rate": 0.0004,
+    "stop_loss_pct": 0.01,
+    "take_profit_pct": 0.03,
+    "sl_atr_multiplier": 2.1,
+    "tp_atr_multiplier": 3.0,
+    "trailing_activate_atr": 1.6,
+    "trailing_offset_atr": 0.8,
+    "slippage_pct": 0.0002,
+    "risk_per_trade": 0.02,
+    "use_atr_sizing": false,
+    "atr_multiplier": 1.0,
+    "apply_global_trend_filter": false,
+    "global_trend_filter_buffer_pct": 0.0025,
+    "global_trend_filter_source": "cost_profile_override",
+    "config_global_trend_filter_enabled": null,
+    "session_liquidity_router": {
+      "enabled": false,
+      "allowed_windows": [
+        "americas"
+      ],
+      "block_entries_outside_windows": true
+    },
+    "basis_premium_filter": {
+      "enabled": false,
+      "exchange": "binance_usdm",
+      "tail_metric": "basis_bps",
+      "positive_tail_pct": 0.05,
+      "block_positive_tail_longs": true,
+      "missing_data_policy": "allow",
+      "calibrated_positive_threshold": null
+    },
+    "cross_venue_dislocation": {
+      "enabled": false,
+      "metric": "basis_spread",
+      "mode": "require",
+      "min_spread_bps": 5.0,
+      "side": "both",
+      "missing_data_policy": "allow"
+    },
+    "allow_short": false,
+    "use_executor_exit_model": true,
+    "ignore_signal_sells": false,
+    "strategy_configs": [
+      {
+        "band_distance_threshold": 0.0045,
+        "rsi_oversold": 38,
+        "rsi_overbought": 62
+      }
+    ],
+    "aggregator_config": {
+      "buy_threshold": 0.6,
+      "buy_threshold_uptrend": 0.55,
+      "sell_threshold": -0.58,
+      "btc_regime_filter_enabled": true,
+      "btc_reference_symbol": "BTCUSDT",
+      "btc_dump_threshold_pct": -1.0,
+      "btc_dump_require_below_ema200": true,
+      "min_confidence": 0.1
+    },
+    "time_stop_minutes": 4320.0,
+    "replay_sentiment_path": null,
+    "replay_sentiment_max_age_seconds": null,
+    "futures_mode": false,
+    "futures_leverage": 5,
+    "futures_funding_rate": 0.0001,
+    "funding_cadence": "scaled_8h",
+    "fixed_notional_usdt": 0.0,
+    "quantity_step_size": 0.0,
+    "min_notional_usdt": 0.0
+  },
+  "cost_audit": {
+    "name": "corrected",
+    "fee_rate": 0.0004,
+    "slippage_pct": 0.0002,
+    "apply_global_trend_filter": false,
+    "funding_cadence": "scaled_8h",
+    "base_futures_funding_rate": 0.0001,
+    "round_trip_cost_pct": 0.12000000000000001,
+    "funding_method": "scale per-bar rate by tf_hours/8 (equivalent to 8h settlement cadence)",
+    "effective_futures_funding_rate": 0.0
+  },
+  "global_trend_filter_audit": {
+    "active": false,
+    "buffer_pct": 0.0025,
+    "source": "cost_profile_override",
+    "config_explicit": null
+  }
+}

--- a/research/closed-family-cost-rescreen/eth-4h-range-reversion-bounded-cell_b.json
+++ b/research/closed-family-cost-rescreen/eth-4h-range-reversion-bounded-cell_b.json
@@ -1,0 +1,188 @@
+{
+  "lane_id": "eth-4h-range-reversion-bounded",
+  "cell_id": "cell_b",
+  "label": "corrected cost + filter ON",
+  "summary": {
+    "symbol": "ETHUSDT",
+    "timeframe": "4h",
+    "start": "2024-01-01",
+    "end": "2026-06-01",
+    "total_trades": 35,
+    "win_rate": 57.14285714285714,
+    "total_return_pct": -17.371135463806823,
+    "max_drawdown_pct": 28.05831490101427,
+    "sharpe_ratio": -0.5211381138451376,
+    "wfo_windows": 4,
+    "wfo_total_trades": 14,
+    "wfo_mean_sharpe": -0.29227240639889007,
+    "wfo_total_return_pct": 3.6575344219441863,
+    "bootstrap_p_loss_pct": 88.0,
+    "mc_drawdown_p95_pct": 41.51470768838381,
+    "mc_drawdown_p50_pct": 25.038129793647272,
+    "profit_concentration_pct": 100.0,
+    "passes_gates": false,
+    "failure_reasons": [
+      "min_wfo_trades failed (14 < 20)",
+      "min_wfo_sharpe failed (-0.29 < 0.50)",
+      "max_drawdown_pct failed (28.06% > 10.00%)",
+      "max_bootstrap_p_loss_pct failed (88.00% > 25.00%)",
+      "max_profit_concentration_pct failed (100.00% > 50.00%)"
+    ],
+    "blocked_buy_count": 0,
+    "basis_blocked_buy_count": 0,
+    "dislocation_blocked_buy_count": 0
+  },
+  "gates": {
+    "min_trades": 0,
+    "min_wfo_trades": 20,
+    "min_wfo_sharpe": 0.5,
+    "max_drawdown_pct": 10.0,
+    "max_bootstrap_p_loss_pct": 25.0,
+    "min_oos_return_pct": 0.0,
+    "max_profit_concentration_pct": 50.0,
+    "max_mc_drawdown_p95_pct": 0.0
+  },
+  "windows": [
+    {
+      "window_index": 1,
+      "train_start": "2024-01-01T00:00:00",
+      "train_end": "2024-07-01T00:00:00",
+      "test_start": "2024-07-01T00:00:00",
+      "test_end": "2024-10-01T00:00:00",
+      "total_trades": 3,
+      "win_rate": 66.66666666666666,
+      "total_return_pct": -1.4155911623963948,
+      "max_drawdown_pct": 4.148128971679798,
+      "sharpe_ratio": -0.658526527867147
+    },
+    {
+      "window_index": 2,
+      "train_start": "2024-07-01T00:00:00",
+      "train_end": "2025-01-01T00:00:00",
+      "test_start": "2025-01-01T00:00:00",
+      "test_end": "2025-04-01T00:00:00",
+      "total_trades": 0,
+      "win_rate": 0.0,
+      "total_return_pct": 0.0,
+      "max_drawdown_pct": 0.0,
+      "sharpe_ratio": 0.0
+    },
+    {
+      "window_index": 3,
+      "train_start": "2025-01-01T00:00:00",
+      "train_end": "2025-07-01T00:00:00",
+      "test_start": "2025-07-01T00:00:00",
+      "test_end": "2025-10-01T00:00:00",
+      "total_trades": 9,
+      "win_rate": 77.77777777777779,
+      "total_return_pct": 7.1746394921003045,
+      "max_drawdown_pct": 7.268913456093655,
+      "sharpe_ratio": 1.4187662895996729
+    },
+    {
+      "window_index": 4,
+      "train_start": "2025-07-01T00:00:00",
+      "train_end": "2026-01-01T00:00:00",
+      "test_start": "2026-01-01T00:00:00",
+      "test_end": "2026-04-01T00:00:00",
+      "total_trades": 2,
+      "win_rate": 50.0,
+      "total_return_pct": -1.892861967691024,
+      "max_drawdown_pct": 2.6569545285684923,
+      "sharpe_ratio": -1.9293293873280861
+    }
+  ],
+  "resolved_backtest_config": {
+    "symbol": "ETHUSDT",
+    "timeframe": "4h",
+    "start_date": "2024-01-01",
+    "end_date": "2026-06-01",
+    "initial_capital": 10000.0,
+    "fee_rate": 0.0004,
+    "stop_loss_pct": 0.01,
+    "take_profit_pct": 0.03,
+    "sl_atr_multiplier": 2.1,
+    "tp_atr_multiplier": 3.0,
+    "trailing_activate_atr": 1.6,
+    "trailing_offset_atr": 0.8,
+    "slippage_pct": 0.0002,
+    "risk_per_trade": 0.02,
+    "use_atr_sizing": false,
+    "atr_multiplier": 1.0,
+    "apply_global_trend_filter": true,
+    "global_trend_filter_buffer_pct": 0.0025,
+    "global_trend_filter_source": "cost_profile_override",
+    "config_global_trend_filter_enabled": null,
+    "session_liquidity_router": {
+      "enabled": false,
+      "allowed_windows": [
+        "americas"
+      ],
+      "block_entries_outside_windows": true
+    },
+    "basis_premium_filter": {
+      "enabled": false,
+      "exchange": "binance_usdm",
+      "tail_metric": "basis_bps",
+      "positive_tail_pct": 0.05,
+      "block_positive_tail_longs": true,
+      "missing_data_policy": "allow",
+      "calibrated_positive_threshold": null
+    },
+    "cross_venue_dislocation": {
+      "enabled": false,
+      "metric": "basis_spread",
+      "mode": "require",
+      "min_spread_bps": 5.0,
+      "side": "both",
+      "missing_data_policy": "allow"
+    },
+    "allow_short": false,
+    "use_executor_exit_model": true,
+    "ignore_signal_sells": false,
+    "strategy_configs": [
+      {
+        "band_distance_threshold": 0.0045,
+        "rsi_oversold": 38,
+        "rsi_overbought": 62
+      }
+    ],
+    "aggregator_config": {
+      "buy_threshold": 0.6,
+      "buy_threshold_uptrend": 0.55,
+      "sell_threshold": -0.58,
+      "btc_regime_filter_enabled": true,
+      "btc_reference_symbol": "BTCUSDT",
+      "btc_dump_threshold_pct": -1.0,
+      "btc_dump_require_below_ema200": true,
+      "min_confidence": 0.1
+    },
+    "time_stop_minutes": 4320.0,
+    "replay_sentiment_path": null,
+    "replay_sentiment_max_age_seconds": null,
+    "futures_mode": false,
+    "futures_leverage": 5,
+    "futures_funding_rate": 0.0001,
+    "funding_cadence": "scaled_8h",
+    "fixed_notional_usdt": 0.0,
+    "quantity_step_size": 0.0,
+    "min_notional_usdt": 0.0
+  },
+  "cost_audit": {
+    "name": "corrected",
+    "fee_rate": 0.0004,
+    "slippage_pct": 0.0002,
+    "apply_global_trend_filter": true,
+    "funding_cadence": "scaled_8h",
+    "base_futures_funding_rate": 0.0001,
+    "round_trip_cost_pct": 0.12000000000000001,
+    "funding_method": "scale per-bar rate by tf_hours/8 (equivalent to 8h settlement cadence)",
+    "effective_futures_funding_rate": 0.0
+  },
+  "global_trend_filter_audit": {
+    "active": true,
+    "buffer_pct": 0.0025,
+    "source": "cost_profile_override",
+    "config_explicit": null
+  }
+}

--- a/research/closed-family-cost-rescreen/resolved/avax-4h-bollinger-strategy.yaml
+++ b/research/closed-family-cost-rescreen/resolved/avax-4h-bollinger-strategy.yaml
@@ -1,0 +1,54 @@
+agent_id: autoresearch
+trading:
+  pairs:
+  - AVAXUSDT
+  timeframe: 4h
+ingest:
+  use_websocket: false
+database:
+  host: 127.0.0.1
+  port: 15432
+telegram:
+  enabled: false
+trading_execution:
+  enabled: false
+  sl_atr_multiplier: 2.0
+  tp_atr_multiplier: 3.0
+  trailing_activate_atr: 2.0
+  trailing_offset_atr: 1.0
+  exit_rules:
+    backtest_use_executor_exit_model: true
+    time_stop_minutes: 720
+futures:
+  enabled: false
+strategy:
+  strategies:
+  - name: bollinger_bounce
+    config:
+      band_distance_threshold: 0.0
+      rsi_oversold: 30
+      rsi_overbought: 70
+  aggregator:
+    buy_threshold: 0.55
+    buy_threshold_uptrend: 0.5
+    sell_threshold: -0.55
+    btc_regime_filter_enabled: true
+    btc_reference_symbol: BTCUSDT
+    btc_dump_threshold_pct: -1.0
+    btc_dump_require_below_ema200: true
+    min_confidence: 0.1
+  per_symbol_aggregator_config:
+    SOLUSDT:
+      min_agreement: 1
+      buy_threshold: 0.8
+      sell_threshold: -0.6
+      sell_min_agreement: 2
+    BNBUSDT:
+      min_agreement: 1
+      buy_threshold: 1.1
+      sell_threshold: -0.5
+    AVAXUSDT:
+      min_agreement: 1
+      buy_threshold: 0.55
+      sell_threshold: -0.55
+      sell_min_agreement: 1

--- a/research/closed-family-cost-rescreen/resolved/eth-4h-range-reversion-bounded.yaml
+++ b/research/closed-family-cost-rescreen/resolved/eth-4h-range-reversion-bounded.yaml
@@ -1,0 +1,55 @@
+agent_id: autoresearch
+trading:
+  pairs:
+  - ETHUSDT
+  timeframe: 4h
+ingest:
+  use_websocket: false
+database:
+  host: 127.0.0.1
+  port: 15432
+telegram:
+  enabled: false
+trading_execution:
+  enabled: false
+  sl_atr_multiplier: 2.1
+  tp_atr_multiplier: 3.0
+  trailing_activate_atr: 1.6
+  trailing_offset_atr: 0.8
+  exit_rules:
+    backtest_use_executor_exit_model: true
+    time_stop_minutes: 4320
+futures:
+  enabled: false
+strategy:
+  strategies:
+  - name: bollinger_bounce
+    config:
+      band_distance_threshold: 0.0045
+      rsi_oversold: 38
+      rsi_overbought: 62
+  aggregator:
+    buy_threshold: 0.6
+    buy_threshold_uptrend: 0.55
+    sell_threshold: -0.58
+    btc_regime_filter_enabled: true
+    btc_reference_symbol: BTCUSDT
+    btc_dump_threshold_pct: -1.0
+    btc_dump_require_below_ema200: true
+    min_confidence: 0.1
+  per_symbol_aggregator_config:
+    SOLUSDT:
+      min_agreement: 1
+      buy_threshold: 0.8
+      sell_threshold: -0.6
+      sell_min_agreement: 2
+    BNBUSDT:
+      min_agreement: 1
+      buy_threshold: 1.1
+      sell_threshold: -0.5
+    ETHUSDT:
+      min_agreement: 1
+      buy_threshold: 0.6
+      sell_threshold: -0.58
+      sell_min_agreement: 1
+  global_trend_filter_buffer_pct: 0.0025

--- a/research/closed-family-cost-rescreen/resolved/sol-4h-rsi-reversal.yaml
+++ b/research/closed-family-cost-rescreen/resolved/sol-4h-rsi-reversal.yaml
@@ -1,0 +1,46 @@
+agent_id: autoresearch
+trading:
+  pairs:
+  - SOLUSDT
+  timeframe: 4h
+ingest:
+  use_websocket: false
+database:
+  host: 127.0.0.1
+  port: 15432
+telegram:
+  enabled: false
+trading_execution:
+  enabled: false
+  sl_atr_multiplier: 2.0
+  tp_atr_multiplier: 3.0
+  trailing_activate_atr: 1.5
+  trailing_offset_atr: 0.8
+futures:
+  enabled: false
+strategy:
+  strategies:
+  - name: rsi_reversal
+    config:
+      rsi_period: 7
+      oversold_threshold: 35
+      overbought_threshold: 65
+  aggregator:
+    buy_threshold: 0.55
+    buy_threshold_uptrend: 0.5
+    sell_threshold: -0.55
+    btc_regime_filter_enabled: true
+    btc_reference_symbol: BTCUSDT
+    btc_dump_threshold_pct: -1.0
+    btc_dump_require_below_ema200: true
+    min_confidence: 0.1
+  per_symbol_aggregator_config:
+    SOLUSDT:
+      min_agreement: 1
+      buy_threshold: 0.55
+      sell_threshold: -0.55
+      sell_min_agreement: 1
+    BNBUSDT:
+      min_agreement: 1
+      buy_threshold: 1.1
+      sell_threshold: -0.5

--- a/research/closed-family-cost-rescreen/sol-4h-rsi-reversal-cell_a.json
+++ b/research/closed-family-cost-rescreen/sol-4h-rsi-reversal-cell_a.json
@@ -1,0 +1,188 @@
+{
+  "lane_id": "sol-4h-rsi-reversal",
+  "cell_id": "cell_a",
+  "label": "corrected cost + filter OFF",
+  "summary": {
+    "symbol": "SOLUSDT",
+    "timeframe": "4h",
+    "start": "2024-01-01",
+    "end": "2026-06-01",
+    "total_trades": 274,
+    "win_rate": 28.467153284671532,
+    "total_return_pct": -11.31478606247736,
+    "max_drawdown_pct": 23.971953365838733,
+    "sharpe_ratio": -0.18010269219020852,
+    "wfo_windows": 4,
+    "wfo_total_trades": 120,
+    "wfo_mean_sharpe": 0.09479586298573628,
+    "wfo_total_return_pct": -4.423129900791444,
+    "bootstrap_p_loss_pct": 65.8,
+    "mc_drawdown_p95_pct": 51.931921058766086,
+    "mc_drawdown_p50_pct": 30.83043380308141,
+    "profit_concentration_pct": 100.0,
+    "passes_gates": false,
+    "failure_reasons": [
+      "min_wfo_sharpe failed (0.09 < 0.50)",
+      "max_drawdown_pct failed (23.97% > 10.00%)",
+      "max_bootstrap_p_loss_pct failed (65.80% > 25.00%)",
+      "min_oos_return_pct failed (-4.42% < 0.00%)",
+      "max_profit_concentration_pct failed (100.00% > 50.00%)"
+    ],
+    "blocked_buy_count": 0,
+    "basis_blocked_buy_count": 0,
+    "dislocation_blocked_buy_count": 0
+  },
+  "gates": {
+    "min_trades": 0,
+    "min_wfo_trades": 20,
+    "min_wfo_sharpe": 0.5,
+    "max_drawdown_pct": 10.0,
+    "max_bootstrap_p_loss_pct": 25.0,
+    "min_oos_return_pct": 0.0,
+    "max_profit_concentration_pct": 50.0,
+    "max_mc_drawdown_p95_pct": 0.0
+  },
+  "windows": [
+    {
+      "window_index": 1,
+      "train_start": "2024-01-01T00:00:00",
+      "train_end": "2024-07-01T00:00:00",
+      "test_start": "2024-07-01T00:00:00",
+      "test_end": "2024-10-01T00:00:00",
+      "total_trades": 31,
+      "win_rate": 32.25806451612903,
+      "total_return_pct": -3.002039270201058,
+      "max_drawdown_pct": 12.457678746973498,
+      "sharpe_ratio": -0.6311825984051977
+    },
+    {
+      "window_index": 2,
+      "train_start": "2024-07-01T00:00:00",
+      "train_end": "2025-01-01T00:00:00",
+      "test_start": "2025-01-01T00:00:00",
+      "test_end": "2025-04-01T00:00:00",
+      "total_trades": 33,
+      "win_rate": 24.242424242424242,
+      "total_return_pct": -7.266852150962786,
+      "max_drawdown_pct": 13.141133175805495,
+      "sharpe_ratio": -1.4695552683899025
+    },
+    {
+      "window_index": 3,
+      "train_start": "2025-01-01T00:00:00",
+      "train_end": "2025-07-01T00:00:00",
+      "test_start": "2025-07-01T00:00:00",
+      "test_end": "2025-10-01T00:00:00",
+      "total_trades": 34,
+      "win_rate": 23.52941176470588,
+      "total_return_pct": -4.72364634153826,
+      "max_drawdown_pct": 9.570149809256343,
+      "sharpe_ratio": -0.8504893161859002
+    },
+    {
+      "window_index": 4,
+      "train_start": "2025-07-01T00:00:00",
+      "train_end": "2026-01-01T00:00:00",
+      "test_start": "2026-01-01T00:00:00",
+      "test_end": "2026-04-01T00:00:00",
+      "total_trades": 22,
+      "win_rate": 45.45454545454545,
+      "total_return_pct": 11.52444495153708,
+      "max_drawdown_pct": 5.78979812757769,
+      "sharpe_ratio": 3.3304106349239455
+    }
+  ],
+  "resolved_backtest_config": {
+    "symbol": "SOLUSDT",
+    "timeframe": "4h",
+    "start_date": "2024-01-01",
+    "end_date": "2026-06-01",
+    "initial_capital": 10000.0,
+    "fee_rate": 0.0004,
+    "stop_loss_pct": 0.01,
+    "take_profit_pct": 0.03,
+    "sl_atr_multiplier": 2.0,
+    "tp_atr_multiplier": 3.0,
+    "trailing_activate_atr": 1.5,
+    "trailing_offset_atr": 0.8,
+    "slippage_pct": 0.0002,
+    "risk_per_trade": 0.02,
+    "use_atr_sizing": false,
+    "atr_multiplier": 1.0,
+    "apply_global_trend_filter": false,
+    "global_trend_filter_buffer_pct": 0.0,
+    "global_trend_filter_source": "cost_profile_override",
+    "config_global_trend_filter_enabled": null,
+    "session_liquidity_router": {
+      "enabled": false,
+      "allowed_windows": [
+        "americas"
+      ],
+      "block_entries_outside_windows": true
+    },
+    "basis_premium_filter": {
+      "enabled": false,
+      "exchange": "binance_usdm",
+      "tail_metric": "basis_bps",
+      "positive_tail_pct": 0.05,
+      "block_positive_tail_longs": true,
+      "missing_data_policy": "allow",
+      "calibrated_positive_threshold": null
+    },
+    "cross_venue_dislocation": {
+      "enabled": false,
+      "metric": "basis_spread",
+      "mode": "require",
+      "min_spread_bps": 5.0,
+      "side": "both",
+      "missing_data_policy": "allow"
+    },
+    "allow_short": false,
+    "use_executor_exit_model": false,
+    "ignore_signal_sells": false,
+    "strategy_configs": [
+      {
+        "rsi_period": 7,
+        "oversold_threshold": 35,
+        "overbought_threshold": 65
+      }
+    ],
+    "aggregator_config": {
+      "buy_threshold": 0.55,
+      "buy_threshold_uptrend": 0.5,
+      "sell_threshold": -0.55,
+      "btc_regime_filter_enabled": true,
+      "btc_reference_symbol": "BTCUSDT",
+      "btc_dump_threshold_pct": -1.0,
+      "btc_dump_require_below_ema200": true,
+      "min_confidence": 0.1
+    },
+    "time_stop_minutes": 0.0,
+    "replay_sentiment_path": null,
+    "replay_sentiment_max_age_seconds": null,
+    "futures_mode": false,
+    "futures_leverage": 5,
+    "futures_funding_rate": 0.0001,
+    "funding_cadence": "scaled_8h",
+    "fixed_notional_usdt": 0.0,
+    "quantity_step_size": 0.0,
+    "min_notional_usdt": 0.0
+  },
+  "cost_audit": {
+    "name": "corrected",
+    "fee_rate": 0.0004,
+    "slippage_pct": 0.0002,
+    "apply_global_trend_filter": false,
+    "funding_cadence": "scaled_8h",
+    "base_futures_funding_rate": 0.0001,
+    "round_trip_cost_pct": 0.12000000000000001,
+    "funding_method": "scale per-bar rate by tf_hours/8 (equivalent to 8h settlement cadence)",
+    "effective_futures_funding_rate": 0.0
+  },
+  "global_trend_filter_audit": {
+    "active": false,
+    "buffer_pct": 0.0,
+    "source": "cost_profile_override",
+    "config_explicit": null
+  }
+}

--- a/research/closed-family-cost-rescreen/sol-4h-rsi-reversal-cell_b.json
+++ b/research/closed-family-cost-rescreen/sol-4h-rsi-reversal-cell_b.json
@@ -1,0 +1,187 @@
+{
+  "lane_id": "sol-4h-rsi-reversal",
+  "cell_id": "cell_b",
+  "label": "corrected cost + filter ON",
+  "summary": {
+    "symbol": "SOLUSDT",
+    "timeframe": "4h",
+    "start": "2024-01-01",
+    "end": "2026-06-01",
+    "total_trades": 127,
+    "win_rate": 25.196850393700785,
+    "total_return_pct": -19.063566631687152,
+    "max_drawdown_pct": 20.45685845913771,
+    "sharpe_ratio": -0.703012501731618,
+    "wfo_windows": 4,
+    "wfo_total_trades": 51,
+    "wfo_mean_sharpe": 0.40525169992519006,
+    "wfo_total_return_pct": -4.025028325496438,
+    "bootstrap_p_loss_pct": 87.2,
+    "mc_drawdown_p95_pct": 43.073265352407276,
+    "mc_drawdown_p50_pct": 27.280318573312396,
+    "profit_concentration_pct": 45.960633387657005,
+    "passes_gates": false,
+    "failure_reasons": [
+      "min_wfo_sharpe failed (0.41 < 0.50)",
+      "max_drawdown_pct failed (20.46% > 10.00%)",
+      "max_bootstrap_p_loss_pct failed (87.20% > 25.00%)",
+      "min_oos_return_pct failed (-4.03% < 0.00%)"
+    ],
+    "blocked_buy_count": 0,
+    "basis_blocked_buy_count": 0,
+    "dislocation_blocked_buy_count": 0
+  },
+  "gates": {
+    "min_trades": 0,
+    "min_wfo_trades": 20,
+    "min_wfo_sharpe": 0.5,
+    "max_drawdown_pct": 10.0,
+    "max_bootstrap_p_loss_pct": 25.0,
+    "min_oos_return_pct": 0.0,
+    "max_profit_concentration_pct": 50.0,
+    "max_mc_drawdown_p95_pct": 0.0
+  },
+  "windows": [
+    {
+      "window_index": 1,
+      "train_start": "2024-01-01T00:00:00",
+      "train_end": "2024-07-01T00:00:00",
+      "test_start": "2024-07-01T00:00:00",
+      "test_end": "2024-10-01T00:00:00",
+      "total_trades": 12,
+      "win_rate": 41.66666666666667,
+      "total_return_pct": 2.2480564010348463,
+      "max_drawdown_pct": 2.969522053626899,
+      "sharpe_ratio": 0.9065602336969906
+    },
+    {
+      "window_index": 2,
+      "train_start": "2024-07-01T00:00:00",
+      "train_end": "2025-01-01T00:00:00",
+      "test_start": "2025-01-01T00:00:00",
+      "test_end": "2025-04-01T00:00:00",
+      "total_trades": 9,
+      "win_rate": 33.33333333333333,
+      "total_return_pct": 1.9563106266796786,
+      "max_drawdown_pct": 3.318775263353249,
+      "sharpe_ratio": 0.7698270834198112
+    },
+    {
+      "window_index": 3,
+      "train_start": "2025-01-01T00:00:00",
+      "train_end": "2025-07-01T00:00:00",
+      "test_start": "2025-07-01T00:00:00",
+      "test_end": "2025-10-01T00:00:00",
+      "total_trades": 25,
+      "win_rate": 16.0,
+      "total_return_pct": -11.114603497463142,
+      "max_drawdown_pct": 11.739745193495073,
+      "sharpe_ratio": -2.6738257972259265
+    },
+    {
+      "window_index": 4,
+      "train_start": "2025-07-01T00:00:00",
+      "train_end": "2026-01-01T00:00:00",
+      "test_start": "2026-01-01T00:00:00",
+      "test_end": "2026-04-01T00:00:00",
+      "total_trades": 5,
+      "win_rate": 60.0,
+      "total_return_pct": 3.575825989489003,
+      "max_drawdown_pct": 1.3593133577460055,
+      "sharpe_ratio": 2.618445279809885
+    }
+  ],
+  "resolved_backtest_config": {
+    "symbol": "SOLUSDT",
+    "timeframe": "4h",
+    "start_date": "2024-01-01",
+    "end_date": "2026-06-01",
+    "initial_capital": 10000.0,
+    "fee_rate": 0.0004,
+    "stop_loss_pct": 0.01,
+    "take_profit_pct": 0.03,
+    "sl_atr_multiplier": 2.0,
+    "tp_atr_multiplier": 3.0,
+    "trailing_activate_atr": 1.5,
+    "trailing_offset_atr": 0.8,
+    "slippage_pct": 0.0002,
+    "risk_per_trade": 0.02,
+    "use_atr_sizing": false,
+    "atr_multiplier": 1.0,
+    "apply_global_trend_filter": true,
+    "global_trend_filter_buffer_pct": 0.0,
+    "global_trend_filter_source": "cost_profile_override",
+    "config_global_trend_filter_enabled": null,
+    "session_liquidity_router": {
+      "enabled": false,
+      "allowed_windows": [
+        "americas"
+      ],
+      "block_entries_outside_windows": true
+    },
+    "basis_premium_filter": {
+      "enabled": false,
+      "exchange": "binance_usdm",
+      "tail_metric": "basis_bps",
+      "positive_tail_pct": 0.05,
+      "block_positive_tail_longs": true,
+      "missing_data_policy": "allow",
+      "calibrated_positive_threshold": null
+    },
+    "cross_venue_dislocation": {
+      "enabled": false,
+      "metric": "basis_spread",
+      "mode": "require",
+      "min_spread_bps": 5.0,
+      "side": "both",
+      "missing_data_policy": "allow"
+    },
+    "allow_short": false,
+    "use_executor_exit_model": false,
+    "ignore_signal_sells": false,
+    "strategy_configs": [
+      {
+        "rsi_period": 7,
+        "oversold_threshold": 35,
+        "overbought_threshold": 65
+      }
+    ],
+    "aggregator_config": {
+      "buy_threshold": 0.55,
+      "buy_threshold_uptrend": 0.5,
+      "sell_threshold": -0.55,
+      "btc_regime_filter_enabled": true,
+      "btc_reference_symbol": "BTCUSDT",
+      "btc_dump_threshold_pct": -1.0,
+      "btc_dump_require_below_ema200": true,
+      "min_confidence": 0.1
+    },
+    "time_stop_minutes": 0.0,
+    "replay_sentiment_path": null,
+    "replay_sentiment_max_age_seconds": null,
+    "futures_mode": false,
+    "futures_leverage": 5,
+    "futures_funding_rate": 0.0001,
+    "funding_cadence": "scaled_8h",
+    "fixed_notional_usdt": 0.0,
+    "quantity_step_size": 0.0,
+    "min_notional_usdt": 0.0
+  },
+  "cost_audit": {
+    "name": "corrected",
+    "fee_rate": 0.0004,
+    "slippage_pct": 0.0002,
+    "apply_global_trend_filter": true,
+    "funding_cadence": "scaled_8h",
+    "base_futures_funding_rate": 0.0001,
+    "round_trip_cost_pct": 0.12000000000000001,
+    "funding_method": "scale per-bar rate by tf_hours/8 (equivalent to 8h settlement cadence)",
+    "effective_futures_funding_rate": 0.0
+  },
+  "global_trend_filter_audit": {
+    "active": true,
+    "buffer_pct": 0.0,
+    "source": "cost_profile_override",
+    "config_explicit": null
+  }
+}

--- a/research/cost-realism-rerun/combined_results.json
+++ b/research/cost-realism-rerun/combined_results.json
@@ -1,0 +1,1867 @@
+[
+  {
+    "lane_id": "daily-trend-long-btc",
+    "pass_name": "legacy",
+    "summary": {
+      "symbol": "BTCUSDT",
+      "timeframe": "1d",
+      "start": "2024-01-01",
+      "end": "2026-06-01",
+      "total_trades": 15,
+      "win_rate": 26.666666666666668,
+      "total_return_pct": 51.035894757459296,
+      "max_drawdown_pct": 19.79083150085217,
+      "sharpe_ratio": 1.0272562312373228,
+      "wfo_windows": 4,
+      "wfo_total_trades": 9,
+      "wfo_mean_sharpe": -0.39678702993720494,
+      "wfo_total_return_pct": -7.291572251122458,
+      "bootstrap_p_loss_pct": 19.8,
+      "mc_drawdown_p95_pct": 23.215131790443863,
+      "mc_drawdown_p50_pct": 12.05139501171129,
+      "profit_concentration_pct": 100.0,
+      "passes_gates": false,
+      "failure_reasons": [
+        "min_wfo_trades failed (9 < 20)",
+        "min_wfo_sharpe failed (-0.40 < 0.50)",
+        "min_oos_return_pct failed (-7.29% < 0.00%)",
+        "max_profit_concentration_pct failed (100.00% > 50.00%)"
+      ],
+      "blocked_buy_count": 0,
+      "basis_blocked_buy_count": 0,
+      "dislocation_blocked_buy_count": 0
+    },
+    "gates": {
+      "min_trades": 0,
+      "min_wfo_trades": 20,
+      "min_wfo_sharpe": 0.5,
+      "max_drawdown_pct": 25.0,
+      "max_bootstrap_p_loss_pct": 25.0,
+      "min_oos_return_pct": 0.0,
+      "max_profit_concentration_pct": 50.0,
+      "max_mc_drawdown_p95_pct": 0.0
+    },
+    "windows": [
+      {
+        "window_index": 1,
+        "train_start": "2024-01-01T00:00:00",
+        "train_end": "2024-07-01T00:00:00",
+        "test_start": "2024-07-01T00:00:00",
+        "test_end": "2024-10-01T00:00:00",
+        "total_trades": 2,
+        "win_rate": 50.0,
+        "total_return_pct": -2.0503179567409644,
+        "max_drawdown_pct": 7.671376846887908,
+        "sharpe_ratio": -0.9360311143670701
+      },
+      {
+        "window_index": 2,
+        "train_start": "2024-07-01T00:00:00",
+        "train_end": "2025-01-01T00:00:00",
+        "test_start": "2025-01-01T00:00:00",
+        "test_end": "2025-04-01T00:00:00",
+        "total_trades": 3,
+        "win_rate": 0.0,
+        "total_return_pct": -7.351304954437947,
+        "max_drawdown_pct": 11.93385971153376,
+        "sharpe_ratio": -1.171092324927367
+      },
+      {
+        "window_index": 3,
+        "train_start": "2025-01-01T00:00:00",
+        "train_end": "2025-07-01T00:00:00",
+        "test_start": "2025-07-01T00:00:00",
+        "test_end": "2025-10-01T00:00:00",
+        "total_trades": 4,
+        "win_rate": 50.0,
+        "total_return_pct": 2.1590577611365735,
+        "max_drawdown_pct": 13.101738874810573,
+        "sharpe_ratio": 0.5199753195456174
+      },
+      {
+        "window_index": 4,
+        "train_start": "2025-07-01T00:00:00",
+        "train_end": "2026-01-01T00:00:00",
+        "test_start": "2026-01-01T00:00:00",
+        "test_end": "2026-04-01T00:00:00",
+        "total_trades": 0,
+        "win_rate": 0.0,
+        "total_return_pct": 0.0,
+        "max_drawdown_pct": 0.0,
+        "sharpe_ratio": 0.0
+      }
+    ],
+    "resolved_backtest_config": {
+      "symbol": "BTCUSDT",
+      "timeframe": "1d",
+      "start_date": "2024-01-01",
+      "end_date": "2026-06-01",
+      "initial_capital": 10000.0,
+      "fee_rate": 0.001,
+      "stop_loss_pct": 0.0,
+      "take_profit_pct": 0.0,
+      "sl_atr_multiplier": 2.0,
+      "tp_atr_multiplier": 4.5,
+      "trailing_activate_atr": 1.5,
+      "trailing_offset_atr": 1.0,
+      "slippage_pct": 0.001,
+      "risk_per_trade": 0.02,
+      "use_atr_sizing": false,
+      "atr_multiplier": 1.0,
+      "apply_global_trend_filter": true,
+      "global_trend_filter_buffer_pct": 0.0,
+      "session_liquidity_router": {
+        "enabled": false,
+        "allowed_windows": [
+          "americas"
+        ],
+        "block_entries_outside_windows": true
+      },
+      "basis_premium_filter": {
+        "enabled": false,
+        "exchange": "binance_usdm",
+        "tail_metric": "basis_bps",
+        "positive_tail_pct": 0.05,
+        "block_positive_tail_longs": true,
+        "missing_data_policy": "allow",
+        "calibrated_positive_threshold": null
+      },
+      "cross_venue_dislocation": {
+        "enabled": false,
+        "metric": "basis_spread",
+        "mode": "require",
+        "min_spread_bps": 5.0,
+        "side": "both",
+        "missing_data_policy": "allow"
+      },
+      "allow_short": false,
+      "use_executor_exit_model": false,
+      "ignore_signal_sells": false,
+      "strategy_configs": [
+        {
+          "sma_window": 50
+        }
+      ],
+      "aggregator_config": {
+        "min_agreement": 1,
+        "buy_threshold": 0.5,
+        "sell_threshold": -0.5,
+        "btc_regime_filter_enabled": false
+      },
+      "time_stop_minutes": 0.0,
+      "replay_sentiment_path": null,
+      "replay_sentiment_max_age_seconds": null,
+      "futures_mode": false,
+      "futures_leverage": 5,
+      "futures_funding_rate": 0.0001,
+      "fixed_notional_usdt": 0.0,
+      "quantity_step_size": 0.0,
+      "min_notional_usdt": 0.0
+    },
+    "cost_audit": {
+      "name": "legacy",
+      "fee_rate": 0.001,
+      "slippage_pct": 0.001,
+      "apply_global_trend_filter": true,
+      "funding_cadence": "per_bar",
+      "base_futures_funding_rate": 0.0001,
+      "round_trip_cost_pct": 0.4,
+      "funding_method": "charge base rate every bar (legacy engine behavior)",
+      "effective_futures_funding_rate": 0.0
+    }
+  },
+  {
+    "lane_id": "daily-trend-long-btc",
+    "pass_name": "realistic",
+    "summary": {
+      "symbol": "BTCUSDT",
+      "timeframe": "1d",
+      "start": "2024-01-01",
+      "end": "2026-06-01",
+      "total_trades": 22,
+      "win_rate": 27.27272727272727,
+      "total_return_pct": 49.89695563843443,
+      "max_drawdown_pct": 24.865144722940542,
+      "sharpe_ratio": 0.9454102313375167,
+      "wfo_windows": 4,
+      "wfo_total_trades": 13,
+      "wfo_mean_sharpe": -0.8072324640915508,
+      "wfo_total_return_pct": -15.53409119840381,
+      "bootstrap_p_loss_pct": 17.4,
+      "mc_drawdown_p95_pct": 28.473915277377294,
+      "mc_drawdown_p50_pct": 15.469985208846929,
+      "profit_concentration_pct": 100.0,
+      "passes_gates": false,
+      "failure_reasons": [
+        "min_wfo_trades failed (13 < 20)",
+        "min_wfo_sharpe failed (-0.81 < 0.50)",
+        "min_oos_return_pct failed (-15.53% < 0.00%)",
+        "max_profit_concentration_pct failed (100.00% > 50.00%)"
+      ],
+      "blocked_buy_count": 0,
+      "basis_blocked_buy_count": 0,
+      "dislocation_blocked_buy_count": 0
+    },
+    "gates": {
+      "min_trades": 0,
+      "min_wfo_trades": 20,
+      "min_wfo_sharpe": 0.5,
+      "max_drawdown_pct": 25.0,
+      "max_bootstrap_p_loss_pct": 25.0,
+      "min_oos_return_pct": 0.0,
+      "max_profit_concentration_pct": 50.0,
+      "max_mc_drawdown_p95_pct": 0.0
+    },
+    "windows": [
+      {
+        "window_index": 1,
+        "train_start": "2024-01-01T00:00:00",
+        "train_end": "2024-07-01T00:00:00",
+        "test_start": "2024-07-01T00:00:00",
+        "test_end": "2024-10-01T00:00:00",
+        "total_trades": 2,
+        "win_rate": 50.0,
+        "total_return_pct": -1.6381543116224382,
+        "max_drawdown_pct": 7.671382761773696,
+        "sharpe_ratio": -0.7195415948003873
+      },
+      {
+        "window_index": 2,
+        "train_start": "2024-07-01T00:00:00",
+        "train_end": "2025-01-01T00:00:00",
+        "test_start": "2025-01-01T00:00:00",
+        "test_end": "2025-04-01T00:00:00",
+        "total_trades": 3,
+        "win_rate": 0.0,
+        "total_return_pct": -6.569783964460112,
+        "max_drawdown_pct": 11.352987092495288,
+        "sharpe_ratio": -1.0651157790181918
+      },
+      {
+        "window_index": 3,
+        "train_start": "2025-01-01T00:00:00",
+        "train_end": "2025-07-01T00:00:00",
+        "test_start": "2025-07-01T00:00:00",
+        "test_end": "2025-10-01T00:00:00",
+        "total_trades": 4,
+        "win_rate": 50.0,
+        "total_return_pct": 3.1650474295359525,
+        "max_drawdown_pct": 12.368728776293647,
+        "sharpe_ratio": 0.6687509549995945
+      },
+      {
+        "window_index": 4,
+        "train_start": "2025-07-01T00:00:00",
+        "train_end": "2026-01-01T00:00:00",
+        "test_start": "2026-01-01T00:00:00",
+        "test_end": "2026-04-01T00:00:00",
+        "total_trades": 4,
+        "win_rate": 0.0,
+        "total_return_pct": -10.908790576983101,
+        "max_drawdown_pct": 17.251788758524985,
+        "sharpe_ratio": -2.1130234375472186
+      }
+    ],
+    "resolved_backtest_config": {
+      "symbol": "BTCUSDT",
+      "timeframe": "1d",
+      "start_date": "2024-01-01",
+      "end_date": "2026-06-01",
+      "initial_capital": 10000.0,
+      "fee_rate": 0.0004,
+      "stop_loss_pct": 0.0,
+      "take_profit_pct": 0.0,
+      "sl_atr_multiplier": 2.0,
+      "tp_atr_multiplier": 4.5,
+      "trailing_activate_atr": 1.5,
+      "trailing_offset_atr": 1.0,
+      "slippage_pct": 0.0002,
+      "risk_per_trade": 0.02,
+      "use_atr_sizing": false,
+      "atr_multiplier": 1.0,
+      "apply_global_trend_filter": false,
+      "global_trend_filter_buffer_pct": 0.0,
+      "session_liquidity_router": {
+        "enabled": false,
+        "allowed_windows": [
+          "americas"
+        ],
+        "block_entries_outside_windows": true
+      },
+      "basis_premium_filter": {
+        "enabled": false,
+        "exchange": "binance_usdm",
+        "tail_metric": "basis_bps",
+        "positive_tail_pct": 0.05,
+        "block_positive_tail_longs": true,
+        "missing_data_policy": "allow",
+        "calibrated_positive_threshold": null
+      },
+      "cross_venue_dislocation": {
+        "enabled": false,
+        "metric": "basis_spread",
+        "mode": "require",
+        "min_spread_bps": 5.0,
+        "side": "both",
+        "missing_data_policy": "allow"
+      },
+      "allow_short": false,
+      "use_executor_exit_model": false,
+      "ignore_signal_sells": false,
+      "strategy_configs": [
+        {
+          "sma_window": 50
+        }
+      ],
+      "aggregator_config": {
+        "min_agreement": 1,
+        "buy_threshold": 0.5,
+        "sell_threshold": -0.5,
+        "btc_regime_filter_enabled": false
+      },
+      "time_stop_minutes": 0.0,
+      "replay_sentiment_path": null,
+      "replay_sentiment_max_age_seconds": null,
+      "futures_mode": false,
+      "futures_leverage": 5,
+      "futures_funding_rate": 0.00030000000000000003,
+      "fixed_notional_usdt": 0.0,
+      "quantity_step_size": 0.0,
+      "min_notional_usdt": 0.0
+    },
+    "cost_audit": {
+      "name": "realistic",
+      "fee_rate": 0.0004,
+      "slippage_pct": 0.0002,
+      "apply_global_trend_filter": false,
+      "funding_cadence": "scaled_8h",
+      "base_futures_funding_rate": 0.0001,
+      "round_trip_cost_pct": 0.12000000000000001,
+      "funding_method": "scale per-bar rate by tf_hours/8 (equivalent to 8h settlement cadence)",
+      "effective_futures_funding_rate": 0.0
+    }
+  },
+  {
+    "lane_id": "daily-trend-long-eth",
+    "pass_name": "legacy",
+    "summary": {
+      "symbol": "ETHUSDT",
+      "timeframe": "1d",
+      "start": "2024-01-01",
+      "end": "2026-06-01",
+      "total_trades": 8,
+      "win_rate": 25.0,
+      "total_return_pct": 27.733737094272982,
+      "max_drawdown_pct": 34.2684147170336,
+      "sharpe_ratio": 0.5679495362505739,
+      "wfo_windows": 4,
+      "wfo_total_trades": 4,
+      "wfo_mean_sharpe": -0.3120194075566561,
+      "wfo_total_return_pct": 29.919077656354997,
+      "bootstrap_p_loss_pct": 31.2,
+      "mc_drawdown_p95_pct": 41.455040807640785,
+      "mc_drawdown_p50_pct": 23.106914626191667,
+      "profit_concentration_pct": 100.0,
+      "passes_gates": false,
+      "failure_reasons": [
+        "min_wfo_trades failed (4 < 20)",
+        "min_wfo_sharpe failed (-0.31 < 0.50)",
+        "max_drawdown_pct failed (34.27% > 25.00%)",
+        "max_bootstrap_p_loss_pct failed (31.20% > 25.00%)",
+        "max_profit_concentration_pct failed (100.00% > 50.00%)"
+      ],
+      "blocked_buy_count": 0,
+      "basis_blocked_buy_count": 0,
+      "dislocation_blocked_buy_count": 0
+    },
+    "gates": {
+      "min_trades": 0,
+      "min_wfo_trades": 20,
+      "min_wfo_sharpe": 0.5,
+      "max_drawdown_pct": 25.0,
+      "max_bootstrap_p_loss_pct": 25.0,
+      "min_oos_return_pct": 0.0,
+      "max_profit_concentration_pct": 50.0,
+      "max_mc_drawdown_p95_pct": 0.0
+    },
+    "windows": [
+      {
+        "window_index": 1,
+        "train_start": "2024-01-01T00:00:00",
+        "train_end": "2024-07-01T00:00:00",
+        "test_start": "2024-07-01T00:00:00",
+        "test_end": "2024-10-01T00:00:00",
+        "total_trades": 0,
+        "win_rate": 0.0,
+        "total_return_pct": 0.0,
+        "max_drawdown_pct": 0.0,
+        "sharpe_ratio": 0.0
+      },
+      {
+        "window_index": 2,
+        "train_start": "2024-07-01T00:00:00",
+        "train_end": "2025-01-01T00:00:00",
+        "test_start": "2025-01-01T00:00:00",
+        "test_end": "2025-04-01T00:00:00",
+        "total_trades": 1,
+        "win_rate": 0.0,
+        "total_return_pct": -6.683217526231747,
+        "max_drawdown_pct": 8.48550981936035,
+        "sharpe_ratio": -1.5168048681559083
+      },
+      {
+        "window_index": 3,
+        "train_start": "2025-01-01T00:00:00",
+        "train_end": "2025-07-01T00:00:00",
+        "test_start": "2025-07-01T00:00:00",
+        "test_end": "2025-10-01T00:00:00",
+        "total_trades": 2,
+        "win_rate": 50.0,
+        "total_return_pct": 58.13187811453149,
+        "max_drawdown_pct": 14.185451217111842,
+        "sharpe_ratio": 3.172733248800485
+      },
+      {
+        "window_index": 4,
+        "train_start": "2025-07-01T00:00:00",
+        "train_end": "2026-01-01T00:00:00",
+        "test_start": "2026-01-01T00:00:00",
+        "test_end": "2026-04-01T00:00:00",
+        "total_trades": 1,
+        "win_rate": 0.0,
+        "total_return_pct": -11.957220730993976,
+        "max_drawdown_pct": 12.546242593539883,
+        "sharpe_ratio": -2.904006010871201
+      }
+    ],
+    "resolved_backtest_config": {
+      "symbol": "ETHUSDT",
+      "timeframe": "1d",
+      "start_date": "2024-01-01",
+      "end_date": "2026-06-01",
+      "initial_capital": 10000.0,
+      "fee_rate": 0.001,
+      "stop_loss_pct": 0.0,
+      "take_profit_pct": 0.0,
+      "sl_atr_multiplier": 2.0,
+      "tp_atr_multiplier": 4.5,
+      "trailing_activate_atr": 1.5,
+      "trailing_offset_atr": 1.0,
+      "slippage_pct": 0.001,
+      "risk_per_trade": 0.02,
+      "use_atr_sizing": false,
+      "atr_multiplier": 1.0,
+      "apply_global_trend_filter": true,
+      "global_trend_filter_buffer_pct": 0.0,
+      "session_liquidity_router": {
+        "enabled": false,
+        "allowed_windows": [
+          "americas"
+        ],
+        "block_entries_outside_windows": true
+      },
+      "basis_premium_filter": {
+        "enabled": false,
+        "exchange": "binance_usdm",
+        "tail_metric": "basis_bps",
+        "positive_tail_pct": 0.05,
+        "block_positive_tail_longs": true,
+        "missing_data_policy": "allow",
+        "calibrated_positive_threshold": null
+      },
+      "cross_venue_dislocation": {
+        "enabled": false,
+        "metric": "basis_spread",
+        "mode": "require",
+        "min_spread_bps": 5.0,
+        "side": "both",
+        "missing_data_policy": "allow"
+      },
+      "allow_short": false,
+      "use_executor_exit_model": false,
+      "ignore_signal_sells": false,
+      "strategy_configs": [
+        {
+          "sma_window": 50
+        }
+      ],
+      "aggregator_config": {
+        "min_agreement": 1,
+        "buy_threshold": 0.5,
+        "sell_threshold": -0.5,
+        "btc_regime_filter_enabled": false
+      },
+      "time_stop_minutes": 0.0,
+      "replay_sentiment_path": null,
+      "replay_sentiment_max_age_seconds": null,
+      "futures_mode": false,
+      "futures_leverage": 5,
+      "futures_funding_rate": 0.0001,
+      "fixed_notional_usdt": 0.0,
+      "quantity_step_size": 0.0,
+      "min_notional_usdt": 0.0
+    },
+    "cost_audit": {
+      "name": "legacy",
+      "fee_rate": 0.001,
+      "slippage_pct": 0.001,
+      "apply_global_trend_filter": true,
+      "funding_cadence": "per_bar",
+      "base_futures_funding_rate": 0.0001,
+      "round_trip_cost_pct": 0.4,
+      "funding_method": "charge base rate every bar (legacy engine behavior)",
+      "effective_futures_funding_rate": 0.0
+    }
+  },
+  {
+    "lane_id": "daily-trend-long-eth",
+    "pass_name": "realistic",
+    "summary": {
+      "symbol": "ETHUSDT",
+      "timeframe": "1d",
+      "start": "2024-01-01",
+      "end": "2026-06-01",
+      "total_trades": 14,
+      "win_rate": 35.714285714285715,
+      "total_return_pct": 89.51823636146717,
+      "max_drawdown_pct": 29.286183736942096,
+      "sharpe_ratio": 1.0250669651183513,
+      "wfo_windows": 4,
+      "wfo_total_trades": 7,
+      "wfo_mean_sharpe": -0.41246935845229266,
+      "wfo_total_return_pct": 23.878603052404944,
+      "bootstrap_p_loss_pct": 10.8,
+      "mc_drawdown_p95_pct": 35.18751768764176,
+      "mc_drawdown_p50_pct": 18.969014435641306,
+      "profit_concentration_pct": 100.0,
+      "passes_gates": false,
+      "failure_reasons": [
+        "min_wfo_trades failed (7 < 20)",
+        "min_wfo_sharpe failed (-0.41 < 0.50)",
+        "max_drawdown_pct failed (29.29% > 25.00%)",
+        "max_profit_concentration_pct failed (100.00% > 50.00%)"
+      ],
+      "blocked_buy_count": 0,
+      "basis_blocked_buy_count": 0,
+      "dislocation_blocked_buy_count": 0
+    },
+    "gates": {
+      "min_trades": 0,
+      "min_wfo_trades": 20,
+      "min_wfo_sharpe": 0.5,
+      "max_drawdown_pct": 25.0,
+      "max_bootstrap_p_loss_pct": 25.0,
+      "min_oos_return_pct": 0.0,
+      "max_profit_concentration_pct": 50.0,
+      "max_mc_drawdown_p95_pct": 0.0
+    },
+    "windows": [
+      {
+        "window_index": 1,
+        "train_start": "2024-01-01T00:00:00",
+        "train_end": "2024-07-01T00:00:00",
+        "test_start": "2024-07-01T00:00:00",
+        "test_end": "2024-10-01T00:00:00",
+        "total_trades": 1,
+        "win_rate": 0.0,
+        "total_return_pct": -4.550072919731829,
+        "max_drawdown_pct": 9.208197667660476,
+        "sharpe_ratio": -2.05062897237179
+      },
+      {
+        "window_index": 2,
+        "train_start": "2024-07-01T00:00:00",
+        "train_end": "2025-01-01T00:00:00",
+        "test_start": "2025-01-01T00:00:00",
+        "test_end": "2025-04-01T00:00:00",
+        "total_trades": 1,
+        "win_rate": 0.0,
+        "total_return_pct": -6.421569946096352,
+        "max_drawdown_pct": 8.357224293431615,
+        "sharpe_ratio": -1.4756065134059408
+      },
+      {
+        "window_index": 3,
+        "train_start": "2025-01-01T00:00:00",
+        "train_end": "2025-07-01T00:00:00",
+        "test_start": "2025-07-01T00:00:00",
+        "test_end": "2025-10-01T00:00:00",
+        "total_trades": 2,
+        "win_rate": 50.0,
+        "total_return_pct": 59.01994867985486,
+        "max_drawdown_pct": 14.185457680635821,
+        "sharpe_ratio": 3.2023710985140172
+      },
+      {
+        "window_index": 4,
+        "train_start": "2025-07-01T00:00:00",
+        "train_end": "2026-01-01T00:00:00",
+        "test_start": "2026-01-01T00:00:00",
+        "test_end": "2026-04-01T00:00:00",
+        "total_trades": 3,
+        "win_rate": 33.33333333333333,
+        "total_return_pct": -12.784568356866949,
+        "max_drawdown_pct": 20.027574055410298,
+        "sharpe_ratio": -1.3260130465454572
+      }
+    ],
+    "resolved_backtest_config": {
+      "symbol": "ETHUSDT",
+      "timeframe": "1d",
+      "start_date": "2024-01-01",
+      "end_date": "2026-06-01",
+      "initial_capital": 10000.0,
+      "fee_rate": 0.0004,
+      "stop_loss_pct": 0.0,
+      "take_profit_pct": 0.0,
+      "sl_atr_multiplier": 2.0,
+      "tp_atr_multiplier": 4.5,
+      "trailing_activate_atr": 1.5,
+      "trailing_offset_atr": 1.0,
+      "slippage_pct": 0.0002,
+      "risk_per_trade": 0.02,
+      "use_atr_sizing": false,
+      "atr_multiplier": 1.0,
+      "apply_global_trend_filter": false,
+      "global_trend_filter_buffer_pct": 0.0,
+      "session_liquidity_router": {
+        "enabled": false,
+        "allowed_windows": [
+          "americas"
+        ],
+        "block_entries_outside_windows": true
+      },
+      "basis_premium_filter": {
+        "enabled": false,
+        "exchange": "binance_usdm",
+        "tail_metric": "basis_bps",
+        "positive_tail_pct": 0.05,
+        "block_positive_tail_longs": true,
+        "missing_data_policy": "allow",
+        "calibrated_positive_threshold": null
+      },
+      "cross_venue_dislocation": {
+        "enabled": false,
+        "metric": "basis_spread",
+        "mode": "require",
+        "min_spread_bps": 5.0,
+        "side": "both",
+        "missing_data_policy": "allow"
+      },
+      "allow_short": false,
+      "use_executor_exit_model": false,
+      "ignore_signal_sells": false,
+      "strategy_configs": [
+        {
+          "sma_window": 50
+        }
+      ],
+      "aggregator_config": {
+        "min_agreement": 1,
+        "buy_threshold": 0.5,
+        "sell_threshold": -0.5,
+        "btc_regime_filter_enabled": false
+      },
+      "time_stop_minutes": 0.0,
+      "replay_sentiment_path": null,
+      "replay_sentiment_max_age_seconds": null,
+      "futures_mode": false,
+      "futures_leverage": 5,
+      "futures_funding_rate": 0.00030000000000000003,
+      "fixed_notional_usdt": 0.0,
+      "quantity_step_size": 0.0,
+      "min_notional_usdt": 0.0
+    },
+    "cost_audit": {
+      "name": "realistic",
+      "fee_rate": 0.0004,
+      "slippage_pct": 0.0002,
+      "apply_global_trend_filter": false,
+      "funding_cadence": "scaled_8h",
+      "base_futures_funding_rate": 0.0001,
+      "round_trip_cost_pct": 0.12000000000000001,
+      "funding_method": "scale per-bar rate by tf_hours/8 (equivalent to 8h settlement cadence)",
+      "effective_futures_funding_rate": 0.0
+    }
+  },
+  {
+    "lane_id": "daily-trend-long-sol",
+    "pass_name": "legacy",
+    "summary": {
+      "symbol": "SOLUSDT",
+      "timeframe": "1d",
+      "start": "2024-01-01",
+      "end": "2026-06-01",
+      "total_trades": 12,
+      "win_rate": 16.666666666666664,
+      "total_return_pct": -11.125774845984088,
+      "max_drawdown_pct": 44.067243182625674,
+      "sharpe_ratio": 0.07880526021425881,
+      "wfo_windows": 4,
+      "wfo_total_trades": 7,
+      "wfo_mean_sharpe": 0.0037695168492929074,
+      "wfo_total_return_pct": -3.463786308942518,
+      "bootstrap_p_loss_pct": 64.2,
+      "mc_drawdown_p95_pct": 56.887884195075685,
+      "mc_drawdown_p50_pct": 35.9406413298218,
+      "profit_concentration_pct": 100.0,
+      "passes_gates": false,
+      "failure_reasons": [
+        "min_wfo_trades failed (7 < 20)",
+        "min_wfo_sharpe failed (0.00 < 0.50)",
+        "max_drawdown_pct failed (44.07% > 25.00%)",
+        "max_bootstrap_p_loss_pct failed (64.20% > 25.00%)",
+        "min_oos_return_pct failed (-3.46% < 0.00%)",
+        "max_profit_concentration_pct failed (100.00% > 50.00%)"
+      ],
+      "blocked_buy_count": 0,
+      "basis_blocked_buy_count": 0,
+      "dislocation_blocked_buy_count": 0
+    },
+    "gates": {
+      "min_trades": 0,
+      "min_wfo_trades": 20,
+      "min_wfo_sharpe": 0.5,
+      "max_drawdown_pct": 25.0,
+      "max_bootstrap_p_loss_pct": 25.0,
+      "min_oos_return_pct": 0.0,
+      "max_profit_concentration_pct": 50.0,
+      "max_mc_drawdown_p95_pct": 0.0
+    },
+    "windows": [
+      {
+        "window_index": 1,
+        "train_start": "2024-01-01T00:00:00",
+        "train_end": "2024-07-01T00:00:00",
+        "test_start": "2024-07-01T00:00:00",
+        "test_end": "2024-10-01T00:00:00",
+        "total_trades": 1,
+        "win_rate": 0.0,
+        "total_return_pct": -1.2408450633915344,
+        "max_drawdown_pct": 8.412209792978508,
+        "sharpe_ratio": -0.23517596578293595
+      },
+      {
+        "window_index": 2,
+        "train_start": "2024-07-01T00:00:00",
+        "train_end": "2025-01-01T00:00:00",
+        "test_start": "2025-01-01T00:00:00",
+        "test_end": "2025-04-01T00:00:00",
+        "total_trades": 2,
+        "win_rate": 0.0,
+        "total_return_pct": -8.643605236852729,
+        "max_drawdown_pct": 26.222123996565937,
+        "sharpe_ratio": -0.4862780483783968
+      },
+      {
+        "window_index": 3,
+        "train_start": "2025-01-01T00:00:00",
+        "train_end": "2025-07-01T00:00:00",
+        "test_start": "2025-07-01T00:00:00",
+        "test_end": "2025-10-01T00:00:00",
+        "total_trades": 4,
+        "win_rate": 25.0,
+        "total_return_pct": 6.997577110331549,
+        "max_drawdown_pct": 25.734444639394592,
+        "sharpe_ratio": 0.7365320815585044
+      },
+      {
+        "window_index": 4,
+        "train_start": "2025-07-01T00:00:00",
+        "train_end": "2026-01-01T00:00:00",
+        "test_start": "2026-01-01T00:00:00",
+        "test_end": "2026-04-01T00:00:00",
+        "total_trades": 0,
+        "win_rate": 0.0,
+        "total_return_pct": 0.0,
+        "max_drawdown_pct": 0.0,
+        "sharpe_ratio": 0.0
+      }
+    ],
+    "resolved_backtest_config": {
+      "symbol": "SOLUSDT",
+      "timeframe": "1d",
+      "start_date": "2024-01-01",
+      "end_date": "2026-06-01",
+      "initial_capital": 10000.0,
+      "fee_rate": 0.001,
+      "stop_loss_pct": 0.0,
+      "take_profit_pct": 0.0,
+      "sl_atr_multiplier": 2.0,
+      "tp_atr_multiplier": 4.5,
+      "trailing_activate_atr": 1.5,
+      "trailing_offset_atr": 1.0,
+      "slippage_pct": 0.001,
+      "risk_per_trade": 0.02,
+      "use_atr_sizing": false,
+      "atr_multiplier": 1.0,
+      "apply_global_trend_filter": true,
+      "global_trend_filter_buffer_pct": 0.0,
+      "session_liquidity_router": {
+        "enabled": false,
+        "allowed_windows": [
+          "americas"
+        ],
+        "block_entries_outside_windows": true
+      },
+      "basis_premium_filter": {
+        "enabled": false,
+        "exchange": "binance_usdm",
+        "tail_metric": "basis_bps",
+        "positive_tail_pct": 0.05,
+        "block_positive_tail_longs": true,
+        "missing_data_policy": "allow",
+        "calibrated_positive_threshold": null
+      },
+      "cross_venue_dislocation": {
+        "enabled": false,
+        "metric": "basis_spread",
+        "mode": "require",
+        "min_spread_bps": 5.0,
+        "side": "both",
+        "missing_data_policy": "allow"
+      },
+      "allow_short": false,
+      "use_executor_exit_model": false,
+      "ignore_signal_sells": false,
+      "strategy_configs": [
+        {
+          "sma_window": 50
+        }
+      ],
+      "aggregator_config": {
+        "min_agreement": 1,
+        "buy_threshold": 0.5,
+        "sell_threshold": -0.5,
+        "btc_regime_filter_enabled": false
+      },
+      "time_stop_minutes": 0.0,
+      "replay_sentiment_path": null,
+      "replay_sentiment_max_age_seconds": null,
+      "futures_mode": false,
+      "futures_leverage": 5,
+      "futures_funding_rate": 0.0001,
+      "fixed_notional_usdt": 0.0,
+      "quantity_step_size": 0.0,
+      "min_notional_usdt": 0.0
+    },
+    "cost_audit": {
+      "name": "legacy",
+      "fee_rate": 0.001,
+      "slippage_pct": 0.001,
+      "apply_global_trend_filter": true,
+      "funding_cadence": "per_bar",
+      "base_futures_funding_rate": 0.0001,
+      "round_trip_cost_pct": 0.4,
+      "funding_method": "charge base rate every bar (legacy engine behavior)",
+      "effective_futures_funding_rate": 0.0
+    }
+  },
+  {
+    "lane_id": "daily-trend-long-sol",
+    "pass_name": "realistic",
+    "summary": {
+      "symbol": "SOLUSDT",
+      "timeframe": "1d",
+      "start": "2024-01-01",
+      "end": "2026-06-01",
+      "total_trades": 21,
+      "win_rate": 19.047619047619047,
+      "total_return_pct": -9.5806924358391,
+      "max_drawdown_pct": 56.506638266777564,
+      "sharpe_ratio": 0.1319880964145363,
+      "wfo_windows": 4,
+      "wfo_total_trades": 10,
+      "wfo_mean_sharpe": -0.2761602278720331,
+      "wfo_total_return_pct": -11.21812552478001,
+      "bootstrap_p_loss_pct": 54.0,
+      "mc_drawdown_p95_pct": 61.16307860642461,
+      "mc_drawdown_p50_pct": 39.87215751752065,
+      "profit_concentration_pct": 92.41512447947743,
+      "passes_gates": false,
+      "failure_reasons": [
+        "min_wfo_trades failed (10 < 20)",
+        "min_wfo_sharpe failed (-0.28 < 0.50)",
+        "max_drawdown_pct failed (56.51% > 25.00%)",
+        "max_bootstrap_p_loss_pct failed (54.00% > 25.00%)",
+        "min_oos_return_pct failed (-11.22% < 0.00%)",
+        "max_profit_concentration_pct failed (92.42% > 50.00%)"
+      ],
+      "blocked_buy_count": 0,
+      "basis_blocked_buy_count": 0,
+      "dislocation_blocked_buy_count": 0
+    },
+    "gates": {
+      "min_trades": 0,
+      "min_wfo_trades": 20,
+      "min_wfo_sharpe": 0.5,
+      "max_drawdown_pct": 25.0,
+      "max_bootstrap_p_loss_pct": 25.0,
+      "min_oos_return_pct": 0.0,
+      "max_profit_concentration_pct": 50.0,
+      "max_mc_drawdown_p95_pct": 0.0
+    },
+    "windows": [
+      {
+        "window_index": 1,
+        "train_start": "2024-01-01T00:00:00",
+        "train_end": "2024-07-01T00:00:00",
+        "test_start": "2024-07-01T00:00:00",
+        "test_end": "2024-10-01T00:00:00",
+        "total_trades": 1,
+        "win_rate": 100.0,
+        "total_return_pct": 1.506727044941963,
+        "max_drawdown_pct": 8.41221637991358,
+        "sharpe_ratio": 0.752230764194683
+      },
+      {
+        "window_index": 2,
+        "train_start": "2024-07-01T00:00:00",
+        "train_end": "2025-01-01T00:00:00",
+        "test_start": "2025-01-01T00:00:00",
+        "test_end": "2025-04-01T00:00:00",
+        "total_trades": 2,
+        "win_rate": 0.0,
+        "total_return_pct": -8.130581268037695,
+        "max_drawdown_pct": 25.9115562494238,
+        "sharpe_ratio": -0.4431570690106098
+      },
+      {
+        "window_index": 3,
+        "train_start": "2025-01-01T00:00:00",
+        "train_end": "2025-07-01T00:00:00",
+        "test_start": "2025-07-01T00:00:00",
+        "test_end": "2025-10-01T00:00:00",
+        "total_trades": 4,
+        "win_rate": 50.0,
+        "total_return_pct": 18.358161190404534,
+        "max_drawdown_pct": 23.104172003794822,
+        "sharpe_ratio": 1.3103401790205478
+      },
+      {
+        "window_index": 4,
+        "train_start": "2025-07-01T00:00:00",
+        "train_end": "2026-01-01T00:00:00",
+        "test_start": "2026-01-01T00:00:00",
+        "test_end": "2026-04-01T00:00:00",
+        "total_trades": 3,
+        "win_rate": 0.0,
+        "total_return_pct": -19.562177119806247,
+        "max_drawdown_pct": 27.414920729580945,
+        "sharpe_ratio": -2.7240547856927533
+      }
+    ],
+    "resolved_backtest_config": {
+      "symbol": "SOLUSDT",
+      "timeframe": "1d",
+      "start_date": "2024-01-01",
+      "end_date": "2026-06-01",
+      "initial_capital": 10000.0,
+      "fee_rate": 0.0004,
+      "stop_loss_pct": 0.0,
+      "take_profit_pct": 0.0,
+      "sl_atr_multiplier": 2.0,
+      "tp_atr_multiplier": 4.5,
+      "trailing_activate_atr": 1.5,
+      "trailing_offset_atr": 1.0,
+      "slippage_pct": 0.0002,
+      "risk_per_trade": 0.02,
+      "use_atr_sizing": false,
+      "atr_multiplier": 1.0,
+      "apply_global_trend_filter": false,
+      "global_trend_filter_buffer_pct": 0.0,
+      "session_liquidity_router": {
+        "enabled": false,
+        "allowed_windows": [
+          "americas"
+        ],
+        "block_entries_outside_windows": true
+      },
+      "basis_premium_filter": {
+        "enabled": false,
+        "exchange": "binance_usdm",
+        "tail_metric": "basis_bps",
+        "positive_tail_pct": 0.05,
+        "block_positive_tail_longs": true,
+        "missing_data_policy": "allow",
+        "calibrated_positive_threshold": null
+      },
+      "cross_venue_dislocation": {
+        "enabled": false,
+        "metric": "basis_spread",
+        "mode": "require",
+        "min_spread_bps": 5.0,
+        "side": "both",
+        "missing_data_policy": "allow"
+      },
+      "allow_short": false,
+      "use_executor_exit_model": false,
+      "ignore_signal_sells": false,
+      "strategy_configs": [
+        {
+          "sma_window": 50
+        }
+      ],
+      "aggregator_config": {
+        "min_agreement": 1,
+        "buy_threshold": 0.5,
+        "sell_threshold": -0.5,
+        "btc_regime_filter_enabled": false
+      },
+      "time_stop_minutes": 0.0,
+      "replay_sentiment_path": null,
+      "replay_sentiment_max_age_seconds": null,
+      "futures_mode": false,
+      "futures_leverage": 5,
+      "futures_funding_rate": 0.00030000000000000003,
+      "fixed_notional_usdt": 0.0,
+      "quantity_step_size": 0.0,
+      "min_notional_usdt": 0.0
+    },
+    "cost_audit": {
+      "name": "realistic",
+      "fee_rate": 0.0004,
+      "slippage_pct": 0.0002,
+      "apply_global_trend_filter": false,
+      "funding_cadence": "scaled_8h",
+      "base_futures_funding_rate": 0.0001,
+      "round_trip_cost_pct": 0.12000000000000001,
+      "funding_method": "scale per-bar rate by tf_hours/8 (equivalent to 8h settlement cadence)",
+      "effective_futures_funding_rate": 0.0
+    }
+  },
+  {
+    "lane_id": "eth-4h-range-reversion-bounded",
+    "pass_name": "legacy",
+    "summary": {
+      "symbol": "ETHUSDT",
+      "timeframe": "4h",
+      "start": "2024-01-01",
+      "end": "2026-06-01",
+      "total_trades": 36,
+      "win_rate": 55.55555555555556,
+      "total_return_pct": -18.709124075640748,
+      "max_drawdown_pct": 28.689738711640523,
+      "sharpe_ratio": -0.5476003266445331,
+      "wfo_windows": 4,
+      "wfo_total_trades": 15,
+      "wfo_mean_sharpe": -0.7105625849116295,
+      "wfo_total_return_pct": 1.2708727742481996,
+      "bootstrap_p_loss_pct": 86.0,
+      "mc_drawdown_p95_pct": 41.632846124151015,
+      "mc_drawdown_p50_pct": 24.666766860951522,
+      "profit_concentration_pct": 100.0,
+      "passes_gates": false,
+      "failure_reasons": [
+        "min_wfo_trades failed (15 < 20)",
+        "min_wfo_sharpe failed (-0.71 < 0.50)",
+        "max_drawdown_pct failed (28.69% > 10.00%)",
+        "max_bootstrap_p_loss_pct failed (86.00% > 25.00%)",
+        "max_profit_concentration_pct failed (100.00% > 50.00%)"
+      ],
+      "blocked_buy_count": 0,
+      "basis_blocked_buy_count": 0,
+      "dislocation_blocked_buy_count": 0
+    },
+    "gates": {
+      "min_trades": 0,
+      "min_wfo_trades": 20,
+      "min_wfo_sharpe": 0.5,
+      "max_drawdown_pct": 10.0,
+      "max_bootstrap_p_loss_pct": 25.0,
+      "min_oos_return_pct": 0.0,
+      "max_profit_concentration_pct": 50.0,
+      "max_mc_drawdown_p95_pct": 0.0
+    },
+    "windows": [
+      {
+        "window_index": 1,
+        "train_start": "2024-01-01T00:00:00",
+        "train_end": "2024-07-01T00:00:00",
+        "test_start": "2024-07-01T00:00:00",
+        "test_end": "2024-10-01T00:00:00",
+        "total_trades": 4,
+        "win_rate": 50.0,
+        "total_return_pct": -4.007343035066351,
+        "max_drawdown_pct": 5.014782567429429,
+        "sharpe_ratio": -1.8843486529615057
+      },
+      {
+        "window_index": 2,
+        "train_start": "2024-07-01T00:00:00",
+        "train_end": "2025-01-01T00:00:00",
+        "test_start": "2025-01-01T00:00:00",
+        "test_end": "2025-04-01T00:00:00",
+        "total_trades": 0,
+        "win_rate": 0.0,
+        "total_return_pct": 0.0,
+        "max_drawdown_pct": 0.0,
+        "sharpe_ratio": 0.0
+      },
+      {
+        "window_index": 3,
+        "train_start": "2025-01-01T00:00:00",
+        "train_end": "2025-07-01T00:00:00",
+        "test_start": "2025-07-01T00:00:00",
+        "test_end": "2025-10-01T00:00:00",
+        "total_trades": 9,
+        "win_rate": 77.77777777777779,
+        "total_return_pct": 8.049617507270087,
+        "max_drawdown_pct": 8.141018330762464,
+        "sharpe_ratio": 1.4308966946704138
+      },
+      {
+        "window_index": 4,
+        "train_start": "2025-07-01T00:00:00",
+        "train_end": "2026-01-01T00:00:00",
+        "test_start": "2026-01-01T00:00:00",
+        "test_end": "2026-04-01T00:00:00",
+        "total_trades": 2,
+        "win_rate": 50.0,
+        "total_return_pct": -2.3610036882672283,
+        "max_drawdown_pct": 2.7137917627883876,
+        "sharpe_ratio": -2.388798381355426
+      }
+    ],
+    "resolved_backtest_config": {
+      "symbol": "ETHUSDT",
+      "timeframe": "4h",
+      "start_date": "2024-01-01",
+      "end_date": "2026-06-01",
+      "initial_capital": 10000.0,
+      "fee_rate": 0.001,
+      "stop_loss_pct": 0.01,
+      "take_profit_pct": 0.03,
+      "sl_atr_multiplier": 2.1,
+      "tp_atr_multiplier": 3.0,
+      "trailing_activate_atr": 1.6,
+      "trailing_offset_atr": 0.8,
+      "slippage_pct": 0.001,
+      "risk_per_trade": 0.02,
+      "use_atr_sizing": false,
+      "atr_multiplier": 1.0,
+      "apply_global_trend_filter": true,
+      "global_trend_filter_buffer_pct": 0.0025,
+      "session_liquidity_router": {
+        "enabled": false,
+        "allowed_windows": [
+          "americas"
+        ],
+        "block_entries_outside_windows": true
+      },
+      "basis_premium_filter": {
+        "enabled": false,
+        "exchange": "binance_usdm",
+        "tail_metric": "basis_bps",
+        "positive_tail_pct": 0.05,
+        "block_positive_tail_longs": true,
+        "missing_data_policy": "allow",
+        "calibrated_positive_threshold": null
+      },
+      "cross_venue_dislocation": {
+        "enabled": false,
+        "metric": "basis_spread",
+        "mode": "require",
+        "min_spread_bps": 5.0,
+        "side": "both",
+        "missing_data_policy": "allow"
+      },
+      "allow_short": false,
+      "use_executor_exit_model": true,
+      "ignore_signal_sells": false,
+      "strategy_configs": [
+        {
+          "band_distance_threshold": 0.0045,
+          "rsi_oversold": 38,
+          "rsi_overbought": 62
+        }
+      ],
+      "aggregator_config": {
+        "buy_threshold": 0.6,
+        "buy_threshold_uptrend": 0.55,
+        "sell_threshold": -0.58,
+        "btc_regime_filter_enabled": true,
+        "btc_reference_symbol": "BTCUSDT",
+        "btc_dump_threshold_pct": -1.0,
+        "btc_dump_require_below_ema200": true,
+        "min_confidence": 0.1
+      },
+      "time_stop_minutes": 4320.0,
+      "replay_sentiment_path": null,
+      "replay_sentiment_max_age_seconds": null,
+      "futures_mode": false,
+      "futures_leverage": 5,
+      "futures_funding_rate": 0.0001,
+      "fixed_notional_usdt": 0.0,
+      "quantity_step_size": 0.0,
+      "min_notional_usdt": 0.0
+    },
+    "cost_audit": {
+      "name": "legacy",
+      "fee_rate": 0.001,
+      "slippage_pct": 0.001,
+      "apply_global_trend_filter": true,
+      "funding_cadence": "per_bar",
+      "base_futures_funding_rate": 0.0001,
+      "round_trip_cost_pct": 0.4,
+      "funding_method": "charge base rate every bar (legacy engine behavior)",
+      "effective_futures_funding_rate": 0.0
+    }
+  },
+  {
+    "lane_id": "eth-4h-range-reversion-bounded",
+    "pass_name": "realistic",
+    "summary": {
+      "symbol": "ETHUSDT",
+      "timeframe": "4h",
+      "start": "2024-01-01",
+      "end": "2026-06-01",
+      "total_trades": 131,
+      "win_rate": 49.61832061068702,
+      "total_return_pct": -65.88493139899496,
+      "max_drawdown_pct": 71.52601896009385,
+      "sharpe_ratio": -1.4093515849991738,
+      "wfo_windows": 4,
+      "wfo_total_trades": 66,
+      "wfo_mean_sharpe": -1.8386434854105729,
+      "wfo_total_return_pct": -46.51796867913662,
+      "bootstrap_p_loss_pct": 98.0,
+      "mc_drawdown_p95_pct": 85.27730913494725,
+      "mc_drawdown_p50_pct": 70.76285282314392,
+      "profit_concentration_pct": 100.0,
+      "passes_gates": false,
+      "failure_reasons": [
+        "min_wfo_sharpe failed (-1.84 < 0.50)",
+        "max_drawdown_pct failed (71.53% > 10.00%)",
+        "max_bootstrap_p_loss_pct failed (98.00% > 25.00%)",
+        "min_oos_return_pct failed (-46.52% < 0.00%)",
+        "max_profit_concentration_pct failed (100.00% > 50.00%)"
+      ],
+      "blocked_buy_count": 0,
+      "basis_blocked_buy_count": 0,
+      "dislocation_blocked_buy_count": 0
+    },
+    "gates": {
+      "min_trades": 0,
+      "min_wfo_trades": 20,
+      "min_wfo_sharpe": 0.5,
+      "max_drawdown_pct": 10.0,
+      "max_bootstrap_p_loss_pct": 25.0,
+      "min_oos_return_pct": 0.0,
+      "max_profit_concentration_pct": 50.0,
+      "max_mc_drawdown_p95_pct": 0.0
+    },
+    "windows": [
+      {
+        "window_index": 1,
+        "train_start": "2024-01-01T00:00:00",
+        "train_end": "2024-07-01T00:00:00",
+        "test_start": "2024-07-01T00:00:00",
+        "test_end": "2024-10-01T00:00:00",
+        "total_trades": 23,
+        "win_rate": 47.82608695652174,
+        "total_return_pct": -17.69773941784477,
+        "max_drawdown_pct": 25.68525547070852,
+        "sharpe_ratio": -1.8939859233462055
+      },
+      {
+        "window_index": 2,
+        "train_start": "2024-07-01T00:00:00",
+        "train_end": "2025-01-01T00:00:00",
+        "test_start": "2025-01-01T00:00:00",
+        "test_end": "2025-04-01T00:00:00",
+        "total_trades": 18,
+        "win_rate": 44.44444444444444,
+        "total_return_pct": -18.898251761855573,
+        "max_drawdown_pct": 21.406951936342935,
+        "sharpe_ratio": -2.0002690013792788
+      },
+      {
+        "window_index": 3,
+        "train_start": "2025-01-01T00:00:00",
+        "train_end": "2025-07-01T00:00:00",
+        "test_start": "2025-07-01T00:00:00",
+        "test_end": "2025-10-01T00:00:00",
+        "total_trades": 13,
+        "win_rate": 61.53846153846154,
+        "total_return_pct": 0.7684898080006496,
+        "max_drawdown_pct": 8.928810703402657,
+        "sharpe_ratio": 0.25005549921667436
+      },
+      {
+        "window_index": 4,
+        "train_start": "2025-07-01T00:00:00",
+        "train_end": "2026-01-01T00:00:00",
+        "test_start": "2026-01-01T00:00:00",
+        "test_end": "2026-04-01T00:00:00",
+        "total_trades": 12,
+        "win_rate": 41.66666666666667,
+        "total_return_pct": -20.48644627139671,
+        "max_drawdown_pct": 32.60858501241407,
+        "sharpe_ratio": -3.710374516133482
+      }
+    ],
+    "resolved_backtest_config": {
+      "symbol": "ETHUSDT",
+      "timeframe": "4h",
+      "start_date": "2024-01-01",
+      "end_date": "2026-06-01",
+      "initial_capital": 10000.0,
+      "fee_rate": 0.0004,
+      "stop_loss_pct": 0.01,
+      "take_profit_pct": 0.03,
+      "sl_atr_multiplier": 2.1,
+      "tp_atr_multiplier": 3.0,
+      "trailing_activate_atr": 1.6,
+      "trailing_offset_atr": 0.8,
+      "slippage_pct": 0.0002,
+      "risk_per_trade": 0.02,
+      "use_atr_sizing": false,
+      "atr_multiplier": 1.0,
+      "apply_global_trend_filter": false,
+      "global_trend_filter_buffer_pct": 0.0025,
+      "session_liquidity_router": {
+        "enabled": false,
+        "allowed_windows": [
+          "americas"
+        ],
+        "block_entries_outside_windows": true
+      },
+      "basis_premium_filter": {
+        "enabled": false,
+        "exchange": "binance_usdm",
+        "tail_metric": "basis_bps",
+        "positive_tail_pct": 0.05,
+        "block_positive_tail_longs": true,
+        "missing_data_policy": "allow",
+        "calibrated_positive_threshold": null
+      },
+      "cross_venue_dislocation": {
+        "enabled": false,
+        "metric": "basis_spread",
+        "mode": "require",
+        "min_spread_bps": 5.0,
+        "side": "both",
+        "missing_data_policy": "allow"
+      },
+      "allow_short": false,
+      "use_executor_exit_model": true,
+      "ignore_signal_sells": false,
+      "strategy_configs": [
+        {
+          "band_distance_threshold": 0.0045,
+          "rsi_oversold": 38,
+          "rsi_overbought": 62
+        }
+      ],
+      "aggregator_config": {
+        "buy_threshold": 0.6,
+        "buy_threshold_uptrend": 0.55,
+        "sell_threshold": -0.58,
+        "btc_regime_filter_enabled": true,
+        "btc_reference_symbol": "BTCUSDT",
+        "btc_dump_threshold_pct": -1.0,
+        "btc_dump_require_below_ema200": true,
+        "min_confidence": 0.1
+      },
+      "time_stop_minutes": 4320.0,
+      "replay_sentiment_path": null,
+      "replay_sentiment_max_age_seconds": null,
+      "futures_mode": false,
+      "futures_leverage": 5,
+      "futures_funding_rate": 5e-05,
+      "fixed_notional_usdt": 0.0,
+      "quantity_step_size": 0.0,
+      "min_notional_usdt": 0.0
+    },
+    "cost_audit": {
+      "name": "realistic",
+      "fee_rate": 0.0004,
+      "slippage_pct": 0.0002,
+      "apply_global_trend_filter": false,
+      "funding_cadence": "scaled_8h",
+      "base_futures_funding_rate": 0.0001,
+      "round_trip_cost_pct": 0.12000000000000001,
+      "funding_method": "scale per-bar rate by tf_hours/8 (equivalent to 8h settlement cadence)",
+      "effective_futures_funding_rate": 0.0
+    }
+  },
+  {
+    "lane_id": "sol-1h-dislocation-event",
+    "pass_name": "legacy",
+    "summary": {
+      "symbol": "SOLUSDT",
+      "timeframe": "1h",
+      "start": "2024-01-01",
+      "end": "2026-06-01",
+      "total_trades": 144,
+      "win_rate": 50.69444444444444,
+      "total_return_pct": -17.35588177638125,
+      "max_drawdown_pct": 45.794001920016356,
+      "sharpe_ratio": -0.06275145601635096,
+      "wfo_windows": 9,
+      "wfo_total_trades": 91,
+      "wfo_mean_sharpe": -0.7264273357505712,
+      "wfo_total_return_pct": -23.75893679024481,
+      "bootstrap_p_loss_pct": 64.0,
+      "mc_drawdown_p95_pct": 72.40496174597345,
+      "mc_drawdown_p50_pct": 44.261113266737574,
+      "profit_concentration_pct": 100.0,
+      "passes_gates": false,
+      "failure_reasons": [
+        "min_wfo_sharpe failed (-0.73 < 0.50)",
+        "max_drawdown_pct failed (45.79% > 10.00%)",
+        "max_bootstrap_p_loss_pct failed (64.00% > 25.00%)",
+        "min_oos_return_pct failed (-23.76% < 0.00%)",
+        "max_profit_concentration_pct failed (100.00% > 50.00%)"
+      ],
+      "blocked_buy_count": 0,
+      "basis_blocked_buy_count": 0,
+      "dislocation_blocked_buy_count": 0
+    },
+    "gates": {
+      "min_trades": 0,
+      "min_wfo_trades": 20,
+      "min_wfo_sharpe": 0.5,
+      "max_drawdown_pct": 10.0,
+      "max_bootstrap_p_loss_pct": 25.0,
+      "min_oos_return_pct": 0.0,
+      "max_profit_concentration_pct": 50.0,
+      "max_mc_drawdown_p95_pct": 0.0
+    },
+    "windows": [
+      {
+        "window_index": 1,
+        "train_start": "2024-01-01T00:00:00",
+        "train_end": "2024-04-01T00:00:00",
+        "test_start": "2024-04-01T00:00:00",
+        "test_end": "2024-06-01T00:00:00",
+        "total_trades": 5,
+        "win_rate": 40.0,
+        "total_return_pct": -9.004539683493949,
+        "max_drawdown_pct": 14.43903443263829,
+        "sharpe_ratio": -2.113328485272658
+      },
+      {
+        "window_index": 2,
+        "train_start": "2024-04-01T00:00:00",
+        "train_end": "2024-07-01T00:00:00",
+        "test_start": "2024-07-01T00:00:00",
+        "test_end": "2024-09-01T00:00:00",
+        "total_trades": 7,
+        "win_rate": 42.857142857142854,
+        "total_return_pct": -2.273593284771341,
+        "max_drawdown_pct": 12.386097576379473,
+        "sharpe_ratio": -0.3958594598981342
+      },
+      {
+        "window_index": 3,
+        "train_start": "2024-07-01T00:00:00",
+        "train_end": "2024-10-01T00:00:00",
+        "test_start": "2024-10-01T00:00:00",
+        "test_end": "2024-12-01T00:00:00",
+        "total_trades": 16,
+        "win_rate": 50.0,
+        "total_return_pct": -3.9581890014269807,
+        "max_drawdown_pct": 13.82173985332119,
+        "sharpe_ratio": -0.3703192255236676
+      },
+      {
+        "window_index": 4,
+        "train_start": "2024-10-01T00:00:00",
+        "train_end": "2025-01-01T00:00:00",
+        "test_start": "2025-01-01T00:00:00",
+        "test_end": "2025-03-01T00:00:00",
+        "total_trades": 10,
+        "win_rate": 50.0,
+        "total_return_pct": -2.946516838466887,
+        "max_drawdown_pct": 25.065798565228153,
+        "sharpe_ratio": -0.03281989444170621
+      },
+      {
+        "window_index": 5,
+        "train_start": "2025-01-01T00:00:00",
+        "train_end": "2025-04-01T00:00:00",
+        "test_start": "2025-04-01T00:00:00",
+        "test_end": "2025-06-01T00:00:00",
+        "total_trades": 16,
+        "win_rate": 56.25,
+        "total_return_pct": 17.65480076185733,
+        "max_drawdown_pct": 6.638783272398823,
+        "sharpe_ratio": 2.8033323303876614
+      },
+      {
+        "window_index": 6,
+        "train_start": "2025-04-01T00:00:00",
+        "train_end": "2025-07-01T00:00:00",
+        "test_start": "2025-07-01T00:00:00",
+        "test_end": "2025-09-01T00:00:00",
+        "total_trades": 20,
+        "win_rate": 50.0,
+        "total_return_pct": -4.71568514448747,
+        "max_drawdown_pct": 16.83002501262126,
+        "sharpe_ratio": -0.46978994174657207
+      },
+      {
+        "window_index": 7,
+        "train_start": "2025-07-01T00:00:00",
+        "train_end": "2025-10-01T00:00:00",
+        "test_start": "2025-10-01T00:00:00",
+        "test_end": "2025-12-01T00:00:00",
+        "total_trades": 5,
+        "win_rate": 60.0,
+        "total_return_pct": -7.444549367855234,
+        "max_drawdown_pct": 13.122076562906967,
+        "sharpe_ratio": -3.2118801738231246
+      },
+      {
+        "window_index": 8,
+        "train_start": "2025-10-01T00:00:00",
+        "train_end": "2026-01-01T00:00:00",
+        "test_start": "2026-01-01T00:00:00",
+        "test_end": "2026-03-01T00:00:00",
+        "total_trades": 12,
+        "win_rate": 50.0,
+        "total_return_pct": -11.355304564726175,
+        "max_drawdown_pct": 14.44732466860628,
+        "sharpe_ratio": -2.7471811714369387
+      },
+      {
+        "window_index": 9,
+        "train_start": "2026-01-01T00:00:00",
+        "train_end": "2026-04-01T00:00:00",
+        "test_start": "2026-04-01T00:00:00",
+        "test_end": "2026-06-01T00:00:00",
+        "total_trades": 0,
+        "win_rate": 0.0,
+        "total_return_pct": 0.0,
+        "max_drawdown_pct": 0.0,
+        "sharpe_ratio": 0.0
+      }
+    ],
+    "resolved_backtest_config": {
+      "symbol": "SOLUSDT",
+      "timeframe": "1h",
+      "start_date": "2024-01-01",
+      "end_date": "2026-06-01",
+      "initial_capital": 10000.0,
+      "fee_rate": 0.001,
+      "stop_loss_pct": 0.01,
+      "take_profit_pct": 0.03,
+      "sl_atr_multiplier": 4.0,
+      "tp_atr_multiplier": 8.0,
+      "trailing_activate_atr": 10.0,
+      "trailing_offset_atr": 0.5,
+      "slippage_pct": 0.001,
+      "risk_per_trade": 0.02,
+      "use_atr_sizing": false,
+      "atr_multiplier": 1.0,
+      "apply_global_trend_filter": true,
+      "global_trend_filter_buffer_pct": 0.0,
+      "session_liquidity_router": {
+        "enabled": false,
+        "allowed_windows": [
+          "americas"
+        ],
+        "block_entries_outside_windows": true
+      },
+      "basis_premium_filter": {
+        "enabled": false,
+        "exchange": "binance_usdm",
+        "tail_metric": "basis_bps",
+        "positive_tail_pct": 0.05,
+        "block_positive_tail_longs": true,
+        "missing_data_policy": "allow",
+        "calibrated_positive_threshold": null
+      },
+      "cross_venue_dislocation": {
+        "enabled": false,
+        "metric": "basis_spread",
+        "mode": "require",
+        "min_spread_bps": 5.0,
+        "side": "both",
+        "missing_data_policy": "allow"
+      },
+      "allow_short": false,
+      "use_executor_exit_model": true,
+      "ignore_signal_sells": false,
+      "strategy_configs": [
+        {
+          "threshold_mode": "rolling",
+          "metric": "basis_spread",
+          "tail_pct": 5,
+          "rolling_days": 90,
+          "cooldown_bars": 24
+        }
+      ],
+      "aggregator_config": {
+        "buy_threshold": 0.55,
+        "buy_threshold_uptrend": 0.5,
+        "sell_threshold": -0.6,
+        "btc_regime_filter_enabled": true,
+        "btc_reference_symbol": "BTCUSDT",
+        "btc_dump_threshold_pct": -1.0,
+        "btc_dump_require_below_ema200": true,
+        "min_confidence": 0.1
+      },
+      "time_stop_minutes": 1440.0,
+      "replay_sentiment_path": null,
+      "replay_sentiment_max_age_seconds": null,
+      "futures_mode": false,
+      "futures_leverage": 5,
+      "futures_funding_rate": 0.0001,
+      "fixed_notional_usdt": 0.0,
+      "quantity_step_size": 0.0,
+      "min_notional_usdt": 0.0
+    },
+    "cost_audit": {
+      "name": "legacy",
+      "fee_rate": 0.001,
+      "slippage_pct": 0.001,
+      "apply_global_trend_filter": true,
+      "funding_cadence": "per_bar",
+      "base_futures_funding_rate": 0.0001,
+      "round_trip_cost_pct": 0.4,
+      "funding_method": "charge base rate every bar (legacy engine behavior)",
+      "effective_futures_funding_rate": 0.0
+    }
+  },
+  {
+    "lane_id": "sol-1h-dislocation-event",
+    "pass_name": "realistic",
+    "summary": {
+      "symbol": "SOLUSDT",
+      "timeframe": "1h",
+      "start": "2024-01-01",
+      "end": "2026-06-01",
+      "total_trades": 326,
+      "win_rate": 51.533742331288344,
+      "total_return_pct": 114.26801873805456,
+      "max_drawdown_pct": 43.0368240486554,
+      "sharpe_ratio": 0.9268665167564124,
+      "wfo_windows": 9,
+      "wfo_total_trades": 205,
+      "wfo_mean_sharpe": 0.1498709190143359,
+      "wfo_total_return_pct": 4.637911796351024,
+      "bootstrap_p_loss_pct": 15.0,
+      "mc_drawdown_p95_pct": 67.00499460693436,
+      "mc_drawdown_p50_pct": 48.15578798654927,
+      "profit_concentration_pct": 79.14477987746834,
+      "passes_gates": false,
+      "failure_reasons": [
+        "min_wfo_sharpe failed (0.15 < 0.50)",
+        "max_drawdown_pct failed (43.04% > 10.00%)",
+        "max_profit_concentration_pct failed (79.14% > 50.00%)"
+      ],
+      "blocked_buy_count": 0,
+      "basis_blocked_buy_count": 0,
+      "dislocation_blocked_buy_count": 0
+    },
+    "gates": {
+      "min_trades": 0,
+      "min_wfo_trades": 20,
+      "min_wfo_sharpe": 0.5,
+      "max_drawdown_pct": 10.0,
+      "max_bootstrap_p_loss_pct": 25.0,
+      "min_oos_return_pct": 0.0,
+      "max_profit_concentration_pct": 50.0,
+      "max_mc_drawdown_p95_pct": 0.0
+    },
+    "windows": [
+      {
+        "window_index": 1,
+        "train_start": "2024-01-01T00:00:00",
+        "train_end": "2024-04-01T00:00:00",
+        "test_start": "2024-04-01T00:00:00",
+        "test_end": "2024-06-01T00:00:00",
+        "total_trades": 20,
+        "win_rate": 55.00000000000001,
+        "total_return_pct": -2.5525017540318005,
+        "max_drawdown_pct": 28.313349192570925,
+        "sharpe_ratio": 0.06378993354662606
+      },
+      {
+        "window_index": 2,
+        "train_start": "2024-04-01T00:00:00",
+        "train_end": "2024-07-01T00:00:00",
+        "test_start": "2024-07-01T00:00:00",
+        "test_end": "2024-09-01T00:00:00",
+        "total_trades": 26,
+        "win_rate": 57.692307692307686,
+        "total_return_pct": -4.67913853715274,
+        "max_drawdown_pct": 25.529606234229785,
+        "sharpe_ratio": -0.2149204903171648
+      },
+      {
+        "window_index": 3,
+        "train_start": "2024-07-01T00:00:00",
+        "train_end": "2024-10-01T00:00:00",
+        "test_start": "2024-10-01T00:00:00",
+        "test_end": "2024-12-01T00:00:00",
+        "total_trades": 23,
+        "win_rate": 47.82608695652174,
+        "total_return_pct": -6.654455725526113,
+        "max_drawdown_pct": 15.762595801135104,
+        "sharpe_ratio": -0.6428732024455694
+      },
+      {
+        "window_index": 4,
+        "train_start": "2024-10-01T00:00:00",
+        "train_end": "2025-01-01T00:00:00",
+        "test_start": "2025-01-01T00:00:00",
+        "test_end": "2025-03-01T00:00:00",
+        "total_trades": 28,
+        "win_rate": 50.0,
+        "total_return_pct": 16.635371411480794,
+        "max_drawdown_pct": 36.59240379880231,
+        "sharpe_ratio": 1.606183020988613
+      },
+      {
+        "window_index": 5,
+        "train_start": "2025-01-01T00:00:00",
+        "train_end": "2025-04-01T00:00:00",
+        "test_start": "2025-04-01T00:00:00",
+        "test_end": "2025-06-01T00:00:00",
+        "total_trades": 28,
+        "win_rate": 57.14285714285714,
+        "total_return_pct": 65.20557174686262,
+        "max_drawdown_pct": 12.914515348914414,
+        "sharpe_ratio": 5.5304386430325705
+      },
+      {
+        "window_index": 6,
+        "train_start": "2025-04-01T00:00:00",
+        "train_end": "2025-07-01T00:00:00",
+        "test_start": "2025-07-01T00:00:00",
+        "test_end": "2025-09-01T00:00:00",
+        "total_trades": 26,
+        "win_rate": 46.15384615384615,
+        "total_return_pct": 0.5467668685385252,
+        "max_drawdown_pct": 16.35446600140212,
+        "sharpe_ratio": 0.3069938399476153
+      },
+      {
+        "window_index": 7,
+        "train_start": "2025-07-01T00:00:00",
+        "train_end": "2025-10-01T00:00:00",
+        "test_start": "2025-10-01T00:00:00",
+        "test_end": "2025-12-01T00:00:00",
+        "total_trades": 24,
+        "win_rate": 45.83333333333333,
+        "total_return_pct": -19.748776560578953,
+        "max_drawdown_pct": 30.494757551387625,
+        "sharpe_ratio": -2.195813221262054
+      },
+      {
+        "window_index": 8,
+        "train_start": "2025-10-01T00:00:00",
+        "train_end": "2026-01-01T00:00:00",
+        "test_start": "2026-01-01T00:00:00",
+        "test_end": "2026-03-01T00:00:00",
+        "total_trades": 30,
+        "win_rate": 40.0,
+        "total_return_pct": -22.382065777018898,
+        "max_drawdown_pct": 28.467398822917627,
+        "sharpe_ratio": -3.1049602523616135
+      },
+      {
+        "window_index": 9,
+        "train_start": "2026-01-01T00:00:00",
+        "train_end": "2026-04-01T00:00:00",
+        "test_start": "2026-04-01T00:00:00",
+        "test_end": "2026-06-01T00:00:00",
+        "total_trades": 0,
+        "win_rate": 0.0,
+        "total_return_pct": 0.0,
+        "max_drawdown_pct": 0.0,
+        "sharpe_ratio": 0.0
+      }
+    ],
+    "resolved_backtest_config": {
+      "symbol": "SOLUSDT",
+      "timeframe": "1h",
+      "start_date": "2024-01-01",
+      "end_date": "2026-06-01",
+      "initial_capital": 10000.0,
+      "fee_rate": 0.0004,
+      "stop_loss_pct": 0.01,
+      "take_profit_pct": 0.03,
+      "sl_atr_multiplier": 4.0,
+      "tp_atr_multiplier": 8.0,
+      "trailing_activate_atr": 10.0,
+      "trailing_offset_atr": 0.5,
+      "slippage_pct": 0.0002,
+      "risk_per_trade": 0.02,
+      "use_atr_sizing": false,
+      "atr_multiplier": 1.0,
+      "apply_global_trend_filter": false,
+      "global_trend_filter_buffer_pct": 0.0,
+      "session_liquidity_router": {
+        "enabled": false,
+        "allowed_windows": [
+          "americas"
+        ],
+        "block_entries_outside_windows": true
+      },
+      "basis_premium_filter": {
+        "enabled": false,
+        "exchange": "binance_usdm",
+        "tail_metric": "basis_bps",
+        "positive_tail_pct": 0.05,
+        "block_positive_tail_longs": true,
+        "missing_data_policy": "allow",
+        "calibrated_positive_threshold": null
+      },
+      "cross_venue_dislocation": {
+        "enabled": false,
+        "metric": "basis_spread",
+        "mode": "require",
+        "min_spread_bps": 5.0,
+        "side": "both",
+        "missing_data_policy": "allow"
+      },
+      "allow_short": false,
+      "use_executor_exit_model": true,
+      "ignore_signal_sells": false,
+      "strategy_configs": [
+        {
+          "threshold_mode": "rolling",
+          "metric": "basis_spread",
+          "tail_pct": 5,
+          "rolling_days": 90,
+          "cooldown_bars": 24
+        }
+      ],
+      "aggregator_config": {
+        "buy_threshold": 0.55,
+        "buy_threshold_uptrend": 0.5,
+        "sell_threshold": -0.6,
+        "btc_regime_filter_enabled": true,
+        "btc_reference_symbol": "BTCUSDT",
+        "btc_dump_threshold_pct": -1.0,
+        "btc_dump_require_below_ema200": true,
+        "min_confidence": 0.1
+      },
+      "time_stop_minutes": 1440.0,
+      "replay_sentiment_path": null,
+      "replay_sentiment_max_age_seconds": null,
+      "futures_mode": false,
+      "futures_leverage": 5,
+      "futures_funding_rate": 1.25e-05,
+      "fixed_notional_usdt": 0.0,
+      "quantity_step_size": 0.0,
+      "min_notional_usdt": 0.0
+    },
+    "cost_audit": {
+      "name": "realistic",
+      "fee_rate": 0.0004,
+      "slippage_pct": 0.0002,
+      "apply_global_trend_filter": false,
+      "funding_cadence": "scaled_8h",
+      "base_futures_funding_rate": 0.0001,
+      "round_trip_cost_pct": 0.12000000000000001,
+      "funding_method": "scale per-bar rate by tf_hours/8 (equivalent to 8h settlement cadence)",
+      "effective_futures_funding_rate": 0.0
+    }
+  }
+]

--- a/research/cost-realism-rerun/daily-trend-long-btc-legacy.json
+++ b/research/cost-realism-rerun/daily-trend-long-btc-legacy.json
@@ -1,0 +1,171 @@
+{
+  "lane_id": "daily-trend-long-btc",
+  "pass_name": "legacy",
+  "summary": {
+    "symbol": "BTCUSDT",
+    "timeframe": "1d",
+    "start": "2024-01-01",
+    "end": "2026-06-01",
+    "total_trades": 15,
+    "win_rate": 26.666666666666668,
+    "total_return_pct": 51.035894757459296,
+    "max_drawdown_pct": 19.79083150085217,
+    "sharpe_ratio": 1.0272562312373228,
+    "wfo_windows": 4,
+    "wfo_total_trades": 9,
+    "wfo_mean_sharpe": -0.39678702993720494,
+    "wfo_total_return_pct": -7.291572251122458,
+    "bootstrap_p_loss_pct": 19.8,
+    "mc_drawdown_p95_pct": 23.215131790443863,
+    "mc_drawdown_p50_pct": 12.05139501171129,
+    "profit_concentration_pct": 100.0,
+    "passes_gates": false,
+    "failure_reasons": [
+      "min_wfo_trades failed (9 < 20)",
+      "min_wfo_sharpe failed (-0.40 < 0.50)",
+      "min_oos_return_pct failed (-7.29% < 0.00%)",
+      "max_profit_concentration_pct failed (100.00% > 50.00%)"
+    ],
+    "blocked_buy_count": 0,
+    "basis_blocked_buy_count": 0,
+    "dislocation_blocked_buy_count": 0
+  },
+  "gates": {
+    "min_trades": 0,
+    "min_wfo_trades": 20,
+    "min_wfo_sharpe": 0.5,
+    "max_drawdown_pct": 25.0,
+    "max_bootstrap_p_loss_pct": 25.0,
+    "min_oos_return_pct": 0.0,
+    "max_profit_concentration_pct": 50.0,
+    "max_mc_drawdown_p95_pct": 0.0
+  },
+  "windows": [
+    {
+      "window_index": 1,
+      "train_start": "2024-01-01T00:00:00",
+      "train_end": "2024-07-01T00:00:00",
+      "test_start": "2024-07-01T00:00:00",
+      "test_end": "2024-10-01T00:00:00",
+      "total_trades": 2,
+      "win_rate": 50.0,
+      "total_return_pct": -2.0503179567409644,
+      "max_drawdown_pct": 7.671376846887908,
+      "sharpe_ratio": -0.9360311143670701
+    },
+    {
+      "window_index": 2,
+      "train_start": "2024-07-01T00:00:00",
+      "train_end": "2025-01-01T00:00:00",
+      "test_start": "2025-01-01T00:00:00",
+      "test_end": "2025-04-01T00:00:00",
+      "total_trades": 3,
+      "win_rate": 0.0,
+      "total_return_pct": -7.351304954437947,
+      "max_drawdown_pct": 11.93385971153376,
+      "sharpe_ratio": -1.171092324927367
+    },
+    {
+      "window_index": 3,
+      "train_start": "2025-01-01T00:00:00",
+      "train_end": "2025-07-01T00:00:00",
+      "test_start": "2025-07-01T00:00:00",
+      "test_end": "2025-10-01T00:00:00",
+      "total_trades": 4,
+      "win_rate": 50.0,
+      "total_return_pct": 2.1590577611365735,
+      "max_drawdown_pct": 13.101738874810573,
+      "sharpe_ratio": 0.5199753195456174
+    },
+    {
+      "window_index": 4,
+      "train_start": "2025-07-01T00:00:00",
+      "train_end": "2026-01-01T00:00:00",
+      "test_start": "2026-01-01T00:00:00",
+      "test_end": "2026-04-01T00:00:00",
+      "total_trades": 0,
+      "win_rate": 0.0,
+      "total_return_pct": 0.0,
+      "max_drawdown_pct": 0.0,
+      "sharpe_ratio": 0.0
+    }
+  ],
+  "resolved_backtest_config": {
+    "symbol": "BTCUSDT",
+    "timeframe": "1d",
+    "start_date": "2024-01-01",
+    "end_date": "2026-06-01",
+    "initial_capital": 10000.0,
+    "fee_rate": 0.001,
+    "stop_loss_pct": 0.0,
+    "take_profit_pct": 0.0,
+    "sl_atr_multiplier": 2.0,
+    "tp_atr_multiplier": 4.5,
+    "trailing_activate_atr": 1.5,
+    "trailing_offset_atr": 1.0,
+    "slippage_pct": 0.001,
+    "risk_per_trade": 0.02,
+    "use_atr_sizing": false,
+    "atr_multiplier": 1.0,
+    "apply_global_trend_filter": true,
+    "global_trend_filter_buffer_pct": 0.0,
+    "session_liquidity_router": {
+      "enabled": false,
+      "allowed_windows": [
+        "americas"
+      ],
+      "block_entries_outside_windows": true
+    },
+    "basis_premium_filter": {
+      "enabled": false,
+      "exchange": "binance_usdm",
+      "tail_metric": "basis_bps",
+      "positive_tail_pct": 0.05,
+      "block_positive_tail_longs": true,
+      "missing_data_policy": "allow",
+      "calibrated_positive_threshold": null
+    },
+    "cross_venue_dislocation": {
+      "enabled": false,
+      "metric": "basis_spread",
+      "mode": "require",
+      "min_spread_bps": 5.0,
+      "side": "both",
+      "missing_data_policy": "allow"
+    },
+    "allow_short": false,
+    "use_executor_exit_model": false,
+    "ignore_signal_sells": false,
+    "strategy_configs": [
+      {
+        "sma_window": 50
+      }
+    ],
+    "aggregator_config": {
+      "min_agreement": 1,
+      "buy_threshold": 0.5,
+      "sell_threshold": -0.5,
+      "btc_regime_filter_enabled": false
+    },
+    "time_stop_minutes": 0.0,
+    "replay_sentiment_path": null,
+    "replay_sentiment_max_age_seconds": null,
+    "futures_mode": false,
+    "futures_leverage": 5,
+    "futures_funding_rate": 0.0001,
+    "fixed_notional_usdt": 0.0,
+    "quantity_step_size": 0.0,
+    "min_notional_usdt": 0.0
+  },
+  "cost_audit": {
+    "name": "legacy",
+    "fee_rate": 0.001,
+    "slippage_pct": 0.001,
+    "apply_global_trend_filter": true,
+    "funding_cadence": "per_bar",
+    "base_futures_funding_rate": 0.0001,
+    "round_trip_cost_pct": 0.4,
+    "funding_method": "charge base rate every bar (legacy engine behavior)",
+    "effective_futures_funding_rate": 0.0
+  }
+}

--- a/research/cost-realism-rerun/daily-trend-long-btc-realistic.json
+++ b/research/cost-realism-rerun/daily-trend-long-btc-realistic.json
@@ -1,0 +1,171 @@
+{
+  "lane_id": "daily-trend-long-btc",
+  "pass_name": "realistic",
+  "summary": {
+    "symbol": "BTCUSDT",
+    "timeframe": "1d",
+    "start": "2024-01-01",
+    "end": "2026-06-01",
+    "total_trades": 22,
+    "win_rate": 27.27272727272727,
+    "total_return_pct": 49.89695563843443,
+    "max_drawdown_pct": 24.865144722940542,
+    "sharpe_ratio": 0.9454102313375167,
+    "wfo_windows": 4,
+    "wfo_total_trades": 13,
+    "wfo_mean_sharpe": -0.8072324640915508,
+    "wfo_total_return_pct": -15.53409119840381,
+    "bootstrap_p_loss_pct": 17.4,
+    "mc_drawdown_p95_pct": 28.473915277377294,
+    "mc_drawdown_p50_pct": 15.469985208846929,
+    "profit_concentration_pct": 100.0,
+    "passes_gates": false,
+    "failure_reasons": [
+      "min_wfo_trades failed (13 < 20)",
+      "min_wfo_sharpe failed (-0.81 < 0.50)",
+      "min_oos_return_pct failed (-15.53% < 0.00%)",
+      "max_profit_concentration_pct failed (100.00% > 50.00%)"
+    ],
+    "blocked_buy_count": 0,
+    "basis_blocked_buy_count": 0,
+    "dislocation_blocked_buy_count": 0
+  },
+  "gates": {
+    "min_trades": 0,
+    "min_wfo_trades": 20,
+    "min_wfo_sharpe": 0.5,
+    "max_drawdown_pct": 25.0,
+    "max_bootstrap_p_loss_pct": 25.0,
+    "min_oos_return_pct": 0.0,
+    "max_profit_concentration_pct": 50.0,
+    "max_mc_drawdown_p95_pct": 0.0
+  },
+  "windows": [
+    {
+      "window_index": 1,
+      "train_start": "2024-01-01T00:00:00",
+      "train_end": "2024-07-01T00:00:00",
+      "test_start": "2024-07-01T00:00:00",
+      "test_end": "2024-10-01T00:00:00",
+      "total_trades": 2,
+      "win_rate": 50.0,
+      "total_return_pct": -1.6381543116224382,
+      "max_drawdown_pct": 7.671382761773696,
+      "sharpe_ratio": -0.7195415948003873
+    },
+    {
+      "window_index": 2,
+      "train_start": "2024-07-01T00:00:00",
+      "train_end": "2025-01-01T00:00:00",
+      "test_start": "2025-01-01T00:00:00",
+      "test_end": "2025-04-01T00:00:00",
+      "total_trades": 3,
+      "win_rate": 0.0,
+      "total_return_pct": -6.569783964460112,
+      "max_drawdown_pct": 11.352987092495288,
+      "sharpe_ratio": -1.0651157790181918
+    },
+    {
+      "window_index": 3,
+      "train_start": "2025-01-01T00:00:00",
+      "train_end": "2025-07-01T00:00:00",
+      "test_start": "2025-07-01T00:00:00",
+      "test_end": "2025-10-01T00:00:00",
+      "total_trades": 4,
+      "win_rate": 50.0,
+      "total_return_pct": 3.1650474295359525,
+      "max_drawdown_pct": 12.368728776293647,
+      "sharpe_ratio": 0.6687509549995945
+    },
+    {
+      "window_index": 4,
+      "train_start": "2025-07-01T00:00:00",
+      "train_end": "2026-01-01T00:00:00",
+      "test_start": "2026-01-01T00:00:00",
+      "test_end": "2026-04-01T00:00:00",
+      "total_trades": 4,
+      "win_rate": 0.0,
+      "total_return_pct": -10.908790576983101,
+      "max_drawdown_pct": 17.251788758524985,
+      "sharpe_ratio": -2.1130234375472186
+    }
+  ],
+  "resolved_backtest_config": {
+    "symbol": "BTCUSDT",
+    "timeframe": "1d",
+    "start_date": "2024-01-01",
+    "end_date": "2026-06-01",
+    "initial_capital": 10000.0,
+    "fee_rate": 0.0004,
+    "stop_loss_pct": 0.0,
+    "take_profit_pct": 0.0,
+    "sl_atr_multiplier": 2.0,
+    "tp_atr_multiplier": 4.5,
+    "trailing_activate_atr": 1.5,
+    "trailing_offset_atr": 1.0,
+    "slippage_pct": 0.0002,
+    "risk_per_trade": 0.02,
+    "use_atr_sizing": false,
+    "atr_multiplier": 1.0,
+    "apply_global_trend_filter": false,
+    "global_trend_filter_buffer_pct": 0.0,
+    "session_liquidity_router": {
+      "enabled": false,
+      "allowed_windows": [
+        "americas"
+      ],
+      "block_entries_outside_windows": true
+    },
+    "basis_premium_filter": {
+      "enabled": false,
+      "exchange": "binance_usdm",
+      "tail_metric": "basis_bps",
+      "positive_tail_pct": 0.05,
+      "block_positive_tail_longs": true,
+      "missing_data_policy": "allow",
+      "calibrated_positive_threshold": null
+    },
+    "cross_venue_dislocation": {
+      "enabled": false,
+      "metric": "basis_spread",
+      "mode": "require",
+      "min_spread_bps": 5.0,
+      "side": "both",
+      "missing_data_policy": "allow"
+    },
+    "allow_short": false,
+    "use_executor_exit_model": false,
+    "ignore_signal_sells": false,
+    "strategy_configs": [
+      {
+        "sma_window": 50
+      }
+    ],
+    "aggregator_config": {
+      "min_agreement": 1,
+      "buy_threshold": 0.5,
+      "sell_threshold": -0.5,
+      "btc_regime_filter_enabled": false
+    },
+    "time_stop_minutes": 0.0,
+    "replay_sentiment_path": null,
+    "replay_sentiment_max_age_seconds": null,
+    "futures_mode": false,
+    "futures_leverage": 5,
+    "futures_funding_rate": 0.00030000000000000003,
+    "fixed_notional_usdt": 0.0,
+    "quantity_step_size": 0.0,
+    "min_notional_usdt": 0.0
+  },
+  "cost_audit": {
+    "name": "realistic",
+    "fee_rate": 0.0004,
+    "slippage_pct": 0.0002,
+    "apply_global_trend_filter": false,
+    "funding_cadence": "scaled_8h",
+    "base_futures_funding_rate": 0.0001,
+    "round_trip_cost_pct": 0.12000000000000001,
+    "funding_method": "scale per-bar rate by tf_hours/8 (equivalent to 8h settlement cadence)",
+    "effective_futures_funding_rate": 0.0
+  }
+}

--- a/research/cost-realism-rerun/daily-trend-long-eth-legacy.json
+++ b/research/cost-realism-rerun/daily-trend-long-eth-legacy.json
@@ -1,0 +1,172 @@
+{
+  "lane_id": "daily-trend-long-eth",
+  "pass_name": "legacy",
+  "summary": {
+    "symbol": "ETHUSDT",
+    "timeframe": "1d",
+    "start": "2024-01-01",
+    "end": "2026-06-01",
+    "total_trades": 8,
+    "win_rate": 25.0,
+    "total_return_pct": 27.733737094272982,
+    "max_drawdown_pct": 34.2684147170336,
+    "sharpe_ratio": 0.5679495362505739,
+    "wfo_windows": 4,
+    "wfo_total_trades": 4,
+    "wfo_mean_sharpe": -0.3120194075566561,
+    "wfo_total_return_pct": 29.919077656354997,
+    "bootstrap_p_loss_pct": 31.2,
+    "mc_drawdown_p95_pct": 41.455040807640785,
+    "mc_drawdown_p50_pct": 23.106914626191667,
+    "profit_concentration_pct": 100.0,
+    "passes_gates": false,
+    "failure_reasons": [
+      "min_wfo_trades failed (4 < 20)",
+      "min_wfo_sharpe failed (-0.31 < 0.50)",
+      "max_drawdown_pct failed (34.27% > 25.00%)",
+      "max_bootstrap_p_loss_pct failed (31.20% > 25.00%)",
+      "max_profit_concentration_pct failed (100.00% > 50.00%)"
+    ],
+    "blocked_buy_count": 0,
+    "basis_blocked_buy_count": 0,
+    "dislocation_blocked_buy_count": 0
+  },
+  "gates": {
+    "min_trades": 0,
+    "min_wfo_trades": 20,
+    "min_wfo_sharpe": 0.5,
+    "max_drawdown_pct": 25.0,
+    "max_bootstrap_p_loss_pct": 25.0,
+    "min_oos_return_pct": 0.0,
+    "max_profit_concentration_pct": 50.0,
+    "max_mc_drawdown_p95_pct": 0.0
+  },
+  "windows": [
+    {
+      "window_index": 1,
+      "train_start": "2024-01-01T00:00:00",
+      "train_end": "2024-07-01T00:00:00",
+      "test_start": "2024-07-01T00:00:00",
+      "test_end": "2024-10-01T00:00:00",
+      "total_trades": 0,
+      "win_rate": 0.0,
+      "total_return_pct": 0.0,
+      "max_drawdown_pct": 0.0,
+      "sharpe_ratio": 0.0
+    },
+    {
+      "window_index": 2,
+      "train_start": "2024-07-01T00:00:00",
+      "train_end": "2025-01-01T00:00:00",
+      "test_start": "2025-01-01T00:00:00",
+      "test_end": "2025-04-01T00:00:00",
+      "total_trades": 1,
+      "win_rate": 0.0,
+      "total_return_pct": -6.683217526231747,
+      "max_drawdown_pct": 8.48550981936035,
+      "sharpe_ratio": -1.5168048681559083
+    },
+    {
+      "window_index": 3,
+      "train_start": "2025-01-01T00:00:00",
+      "train_end": "2025-07-01T00:00:00",
+      "test_start": "2025-07-01T00:00:00",
+      "test_end": "2025-10-01T00:00:00",
+      "total_trades": 2,
+      "win_rate": 50.0,
+      "total_return_pct": 58.13187811453149,
+      "max_drawdown_pct": 14.185451217111842,
+      "sharpe_ratio": 3.172733248800485
+    },
+    {
+      "window_index": 4,
+      "train_start": "2025-07-01T00:00:00",
+      "train_end": "2026-01-01T00:00:00",
+      "test_start": "2026-01-01T00:00:00",
+      "test_end": "2026-04-01T00:00:00",
+      "total_trades": 1,
+      "win_rate": 0.0,
+      "total_return_pct": -11.957220730993976,
+      "max_drawdown_pct": 12.546242593539883,
+      "sharpe_ratio": -2.904006010871201
+    }
+  ],
+  "resolved_backtest_config": {
+    "symbol": "ETHUSDT",
+    "timeframe": "1d",
+    "start_date": "2024-01-01",
+    "end_date": "2026-06-01",
+    "initial_capital": 10000.0,
+    "fee_rate": 0.001,
+    "stop_loss_pct": 0.0,
+    "take_profit_pct": 0.0,
+    "sl_atr_multiplier": 2.0,
+    "tp_atr_multiplier": 4.5,
+    "trailing_activate_atr": 1.5,
+    "trailing_offset_atr": 1.0,
+    "slippage_pct": 0.001,
+    "risk_per_trade": 0.02,
+    "use_atr_sizing": false,
+    "atr_multiplier": 1.0,
+    "apply_global_trend_filter": true,
+    "global_trend_filter_buffer_pct": 0.0,
+    "session_liquidity_router": {
+      "enabled": false,
+      "allowed_windows": [
+        "americas"
+      ],
+      "block_entries_outside_windows": true
+    },
+    "basis_premium_filter": {
+      "enabled": false,
+      "exchange": "binance_usdm",
+      "tail_metric": "basis_bps",
+      "positive_tail_pct": 0.05,
+      "block_positive_tail_longs": true,
+      "missing_data_policy": "allow",
+      "calibrated_positive_threshold": null
+    },
+    "cross_venue_dislocation": {
+      "enabled": false,
+      "metric": "basis_spread",
+      "mode": "require",
+      "min_spread_bps": 5.0,
+      "side": "both",
+      "missing_data_policy": "allow"
+    },
+    "allow_short": false,
+    "use_executor_exit_model": false,
+    "ignore_signal_sells": false,
+    "strategy_configs": [
+      {
+        "sma_window": 50
+      }
+    ],
+    "aggregator_config": {
+      "min_agreement": 1,
+      "buy_threshold": 0.5,
+      "sell_threshold": -0.5,
+      "btc_regime_filter_enabled": false
+    },
+    "time_stop_minutes": 0.0,
+    "replay_sentiment_path": null,
+    "replay_sentiment_max_age_seconds": null,
+    "futures_mode": false,
+    "futures_leverage": 5,
+    "futures_funding_rate": 0.0001,
+    "fixed_notional_usdt": 0.0,
+    "quantity_step_size": 0.0,
+    "min_notional_usdt": 0.0
+  },
+  "cost_audit": {
+    "name": "legacy",
+    "fee_rate": 0.001,
+    "slippage_pct": 0.001,
+    "apply_global_trend_filter": true,
+    "funding_cadence": "per_bar",
+    "base_futures_funding_rate": 0.0001,
+    "round_trip_cost_pct": 0.4,
+    "funding_method": "charge base rate every bar (legacy engine behavior)",
+    "effective_futures_funding_rate": 0.0
+  }
+}

--- a/research/cost-realism-rerun/daily-trend-long-eth-realistic.json
+++ b/research/cost-realism-rerun/daily-trend-long-eth-realistic.json
@@ -1,0 +1,171 @@
+{
+  "lane_id": "daily-trend-long-eth",
+  "pass_name": "realistic",
+  "summary": {
+    "symbol": "ETHUSDT",
+    "timeframe": "1d",
+    "start": "2024-01-01",
+    "end": "2026-06-01",
+    "total_trades": 14,
+    "win_rate": 35.714285714285715,
+    "total_return_pct": 89.51823636146717,
+    "max_drawdown_pct": 29.286183736942096,
+    "sharpe_ratio": 1.0250669651183513,
+    "wfo_windows": 4,
+    "wfo_total_trades": 7,
+    "wfo_mean_sharpe": -0.41246935845229266,
+    "wfo_total_return_pct": 23.878603052404944,
+    "bootstrap_p_loss_pct": 10.8,
+    "mc_drawdown_p95_pct": 35.18751768764176,
+    "mc_drawdown_p50_pct": 18.969014435641306,
+    "profit_concentration_pct": 100.0,
+    "passes_gates": false,
+    "failure_reasons": [
+      "min_wfo_trades failed (7 < 20)",
+      "min_wfo_sharpe failed (-0.41 < 0.50)",
+      "max_drawdown_pct failed (29.29% > 25.00%)",
+      "max_profit_concentration_pct failed (100.00% > 50.00%)"
+    ],
+    "blocked_buy_count": 0,
+    "basis_blocked_buy_count": 0,
+    "dislocation_blocked_buy_count": 0
+  },
+  "gates": {
+    "min_trades": 0,
+    "min_wfo_trades": 20,
+    "min_wfo_sharpe": 0.5,
+    "max_drawdown_pct": 25.0,
+    "max_bootstrap_p_loss_pct": 25.0,
+    "min_oos_return_pct": 0.0,
+    "max_profit_concentration_pct": 50.0,
+    "max_mc_drawdown_p95_pct": 0.0
+  },
+  "windows": [
+    {
+      "window_index": 1,
+      "train_start": "2024-01-01T00:00:00",
+      "train_end": "2024-07-01T00:00:00",
+      "test_start": "2024-07-01T00:00:00",
+      "test_end": "2024-10-01T00:00:00",
+      "total_trades": 1,
+      "win_rate": 0.0,
+      "total_return_pct": -4.550072919731829,
+      "max_drawdown_pct": 9.208197667660476,
+      "sharpe_ratio": -2.05062897237179
+    },
+    {
+      "window_index": 2,
+      "train_start": "2024-07-01T00:00:00",
+      "train_end": "2025-01-01T00:00:00",
+      "test_start": "2025-01-01T00:00:00",
+      "test_end": "2025-04-01T00:00:00",
+      "total_trades": 1,
+      "win_rate": 0.0,
+      "total_return_pct": -6.421569946096352,
+      "max_drawdown_pct": 8.357224293431615,
+      "sharpe_ratio": -1.4756065134059408
+    },
+    {
+      "window_index": 3,
+      "train_start": "2025-01-01T00:00:00",
+      "train_end": "2025-07-01T00:00:00",
+      "test_start": "2025-07-01T00:00:00",
+      "test_end": "2025-10-01T00:00:00",
+      "total_trades": 2,
+      "win_rate": 50.0,
+      "total_return_pct": 59.01994867985486,
+      "max_drawdown_pct": 14.185457680635821,
+      "sharpe_ratio": 3.2023710985140172
+    },
+    {
+      "window_index": 4,
+      "train_start": "2025-07-01T00:00:00",
+      "train_end": "2026-01-01T00:00:00",
+      "test_start": "2026-01-01T00:00:00",
+      "test_end": "2026-04-01T00:00:00",
+      "total_trades": 3,
+      "win_rate": 33.33333333333333,
+      "total_return_pct": -12.784568356866949,
+      "max_drawdown_pct": 20.027574055410298,
+      "sharpe_ratio": -1.3260130465454572
+    }
+  ],
+  "resolved_backtest_config": {
+    "symbol": "ETHUSDT",
+    "timeframe": "1d",
+    "start_date": "2024-01-01",
+    "end_date": "2026-06-01",
+    "initial_capital": 10000.0,
+    "fee_rate": 0.0004,
+    "stop_loss_pct": 0.0,
+    "take_profit_pct": 0.0,
+    "sl_atr_multiplier": 2.0,
+    "tp_atr_multiplier": 4.5,
+    "trailing_activate_atr": 1.5,
+    "trailing_offset_atr": 1.0,
+    "slippage_pct": 0.0002,
+    "risk_per_trade": 0.02,
+    "use_atr_sizing": false,
+    "atr_multiplier": 1.0,
+    "apply_global_trend_filter": false,
+    "global_trend_filter_buffer_pct": 0.0,
+    "session_liquidity_router": {
+      "enabled": false,
+      "allowed_windows": [
+        "americas"
+      ],
+      "block_entries_outside_windows": true
+    },
+    "basis_premium_filter": {
+      "enabled": false,
+      "exchange": "binance_usdm",
+      "tail_metric": "basis_bps",
+      "positive_tail_pct": 0.05,
+      "block_positive_tail_longs": true,
+      "missing_data_policy": "allow",
+      "calibrated_positive_threshold": null
+    },
+    "cross_venue_dislocation": {
+      "enabled": false,
+      "metric": "basis_spread",
+      "mode": "require",
+      "min_spread_bps": 5.0,
+      "side": "both",
+      "missing_data_policy": "allow"
+    },
+    "allow_short": false,
+    "use_executor_exit_model": false,
+    "ignore_signal_sells": false,
+    "strategy_configs": [
+      {
+        "sma_window": 50
+      }
+    ],
+    "aggregator_config": {
+      "min_agreement": 1,
+      "buy_threshold": 0.5,
+      "sell_threshold": -0.5,
+      "btc_regime_filter_enabled": false
+    },
+    "time_stop_minutes": 0.0,
+    "replay_sentiment_path": null,
+    "replay_sentiment_max_age_seconds": null,
+    "futures_mode": false,
+    "futures_leverage": 5,
+    "futures_funding_rate": 0.00030000000000000003,
+    "fixed_notional_usdt": 0.0,
+    "quantity_step_size": 0.0,
+    "min_notional_usdt": 0.0
+  },
+  "cost_audit": {
+    "name": "realistic",
+    "fee_rate": 0.0004,
+    "slippage_pct": 0.0002,
+    "apply_global_trend_filter": false,
+    "funding_cadence": "scaled_8h",
+    "base_futures_funding_rate": 0.0001,
+    "round_trip_cost_pct": 0.12000000000000001,
+    "funding_method": "scale per-bar rate by tf_hours/8 (equivalent to 8h settlement cadence)",
+    "effective_futures_funding_rate": 0.0
+  }
+}

--- a/research/cost-realism-rerun/daily-trend-long-sol-legacy.json
+++ b/research/cost-realism-rerun/daily-trend-long-sol-legacy.json
@@ -1,0 +1,173 @@
+{
+  "lane_id": "daily-trend-long-sol",
+  "pass_name": "legacy",
+  "summary": {
+    "symbol": "SOLUSDT",
+    "timeframe": "1d",
+    "start": "2024-01-01",
+    "end": "2026-06-01",
+    "total_trades": 12,
+    "win_rate": 16.666666666666664,
+    "total_return_pct": -11.125774845984088,
+    "max_drawdown_pct": 44.067243182625674,
+    "sharpe_ratio": 0.07880526021425881,
+    "wfo_windows": 4,
+    "wfo_total_trades": 7,
+    "wfo_mean_sharpe": 0.0037695168492929074,
+    "wfo_total_return_pct": -3.463786308942518,
+    "bootstrap_p_loss_pct": 64.2,
+    "mc_drawdown_p95_pct": 56.887884195075685,
+    "mc_drawdown_p50_pct": 35.9406413298218,
+    "profit_concentration_pct": 100.0,
+    "passes_gates": false,
+    "failure_reasons": [
+      "min_wfo_trades failed (7 < 20)",
+      "min_wfo_sharpe failed (0.00 < 0.50)",
+      "max_drawdown_pct failed (44.07% > 25.00%)",
+      "max_bootstrap_p_loss_pct failed (64.20% > 25.00%)",
+      "min_oos_return_pct failed (-3.46% < 0.00%)",
+      "max_profit_concentration_pct failed (100.00% > 50.00%)"
+    ],
+    "blocked_buy_count": 0,
+    "basis_blocked_buy_count": 0,
+    "dislocation_blocked_buy_count": 0
+  },
+  "gates": {
+    "min_trades": 0,
+    "min_wfo_trades": 20,
+    "min_wfo_sharpe": 0.5,
+    "max_drawdown_pct": 25.0,
+    "max_bootstrap_p_loss_pct": 25.0,
+    "min_oos_return_pct": 0.0,
+    "max_profit_concentration_pct": 50.0,
+    "max_mc_drawdown_p95_pct": 0.0
+  },
+  "windows": [
+    {
+      "window_index": 1,
+      "train_start": "2024-01-01T00:00:00",
+      "train_end": "2024-07-01T00:00:00",
+      "test_start": "2024-07-01T00:00:00",
+      "test_end": "2024-10-01T00:00:00",
+      "total_trades": 1,
+      "win_rate": 0.0,
+      "total_return_pct": -1.2408450633915344,
+      "max_drawdown_pct": 8.412209792978508,
+      "sharpe_ratio": -0.23517596578293595
+    },
+    {
+      "window_index": 2,
+      "train_start": "2024-07-01T00:00:00",
+      "train_end": "2025-01-01T00:00:00",
+      "test_start": "2025-01-01T00:00:00",
+      "test_end": "2025-04-01T00:00:00",
+      "total_trades": 2,
+      "win_rate": 0.0,
+      "total_return_pct": -8.643605236852729,
+      "max_drawdown_pct": 26.222123996565937,
+      "sharpe_ratio": -0.4862780483783968
+    },
+    {
+      "window_index": 3,
+      "train_start": "2025-01-01T00:00:00",
+      "train_end": "2025-07-01T00:00:00",
+      "test_start": "2025-07-01T00:00:00",
+      "test_end": "2025-10-01T00:00:00",
+      "total_trades": 4,
+      "win_rate": 25.0,
+      "total_return_pct": 6.997577110331549,
+      "max_drawdown_pct": 25.734444639394592,
+      "sharpe_ratio": 0.7365320815585044
+    },
+    {
+      "window_index": 4,
+      "train_start": "2025-07-01T00:00:00",
+      "train_end": "2026-01-01T00:00:00",
+      "test_start": "2026-01-01T00:00:00",
+      "test_end": "2026-04-01T00:00:00",
+      "total_trades": 0,
+      "win_rate": 0.0,
+      "total_return_pct": 0.0,
+      "max_drawdown_pct": 0.0,
+      "sharpe_ratio": 0.0
+    }
+  ],
+  "resolved_backtest_config": {
+    "symbol": "SOLUSDT",
+    "timeframe": "1d",
+    "start_date": "2024-01-01",
+    "end_date": "2026-06-01",
+    "initial_capital": 10000.0,
+    "fee_rate": 0.001,
+    "stop_loss_pct": 0.0,
+    "take_profit_pct": 0.0,
+    "sl_atr_multiplier": 2.0,
+    "tp_atr_multiplier": 4.5,
+    "trailing_activate_atr": 1.5,
+    "trailing_offset_atr": 1.0,
+    "slippage_pct": 0.001,
+    "risk_per_trade": 0.02,
+    "use_atr_sizing": false,
+    "atr_multiplier": 1.0,
+    "apply_global_trend_filter": true,
+    "global_trend_filter_buffer_pct": 0.0,
+    "session_liquidity_router": {
+      "enabled": false,
+      "allowed_windows": [
+        "americas"
+      ],
+      "block_entries_outside_windows": true
+    },
+    "basis_premium_filter": {
+      "enabled": false,
+      "exchange": "binance_usdm",
+      "tail_metric": "basis_bps",
+      "positive_tail_pct": 0.05,
+      "block_positive_tail_longs": true,
+      "missing_data_policy": "allow",
+      "calibrated_positive_threshold": null
+    },
+    "cross_venue_dislocation": {
+      "enabled": false,
+      "metric": "basis_spread",
+      "mode": "require",
+      "min_spread_bps": 5.0,
+      "side": "both",
+      "missing_data_policy": "allow"
+    },
+    "allow_short": false,
+    "use_executor_exit_model": false,
+    "ignore_signal_sells": false,
+    "strategy_configs": [
+      {
+        "sma_window": 50
+      }
+    ],
+    "aggregator_config": {
+      "min_agreement": 1,
+      "buy_threshold": 0.5,
+      "sell_threshold": -0.5,
+      "btc_regime_filter_enabled": false
+    },
+    "time_stop_minutes": 0.0,
+    "replay_sentiment_path": null,
+    "replay_sentiment_max_age_seconds": null,
+    "futures_mode": false,
+    "futures_leverage": 5,
+    "futures_funding_rate": 0.0001,
+    "fixed_notional_usdt": 0.0,
+    "quantity_step_size": 0.0,
+    "min_notional_usdt": 0.0
+  },
+  "cost_audit": {
+    "name": "legacy",
+    "fee_rate": 0.001,
+    "slippage_pct": 0.001,
+    "apply_global_trend_filter": true,
+    "funding_cadence": "per_bar",
+    "base_futures_funding_rate": 0.0001,
+    "round_trip_cost_pct": 0.4,
+    "funding_method": "charge base rate every bar (legacy engine behavior)",
+    "effective_futures_funding_rate": 0.0
+  }
+}

--- a/research/cost-realism-rerun/daily-trend-long-sol-realistic.json
+++ b/research/cost-realism-rerun/daily-trend-long-sol-realistic.json
@@ -1,0 +1,173 @@
+{
+  "lane_id": "daily-trend-long-sol",
+  "pass_name": "realistic",
+  "summary": {
+    "symbol": "SOLUSDT",
+    "timeframe": "1d",
+    "start": "2024-01-01",
+    "end": "2026-06-01",
+    "total_trades": 21,
+    "win_rate": 19.047619047619047,
+    "total_return_pct": -9.5806924358391,
+    "max_drawdown_pct": 56.506638266777564,
+    "sharpe_ratio": 0.1319880964145363,
+    "wfo_windows": 4,
+    "wfo_total_trades": 10,
+    "wfo_mean_sharpe": -0.2761602278720331,
+    "wfo_total_return_pct": -11.21812552478001,
+    "bootstrap_p_loss_pct": 54.0,
+    "mc_drawdown_p95_pct": 61.16307860642461,
+    "mc_drawdown_p50_pct": 39.87215751752065,
+    "profit_concentration_pct": 92.41512447947743,
+    "passes_gates": false,
+    "failure_reasons": [
+      "min_wfo_trades failed (10 < 20)",
+      "min_wfo_sharpe failed (-0.28 < 0.50)",
+      "max_drawdown_pct failed (56.51% > 25.00%)",
+      "max_bootstrap_p_loss_pct failed (54.00% > 25.00%)",
+      "min_oos_return_pct failed (-11.22% < 0.00%)",
+      "max_profit_concentration_pct failed (92.42% > 50.00%)"
+    ],
+    "blocked_buy_count": 0,
+    "basis_blocked_buy_count": 0,
+    "dislocation_blocked_buy_count": 0
+  },
+  "gates": {
+    "min_trades": 0,
+    "min_wfo_trades": 20,
+    "min_wfo_sharpe": 0.5,
+    "max_drawdown_pct": 25.0,
+    "max_bootstrap_p_loss_pct": 25.0,
+    "min_oos_return_pct": 0.0,
+    "max_profit_concentration_pct": 50.0,
+    "max_mc_drawdown_p95_pct": 0.0
+  },
+  "windows": [
+    {
+      "window_index": 1,
+      "train_start": "2024-01-01T00:00:00",
+      "train_end": "2024-07-01T00:00:00",
+      "test_start": "2024-07-01T00:00:00",
+      "test_end": "2024-10-01T00:00:00",
+      "total_trades": 1,
+      "win_rate": 100.0,
+      "total_return_pct": 1.506727044941963,
+      "max_drawdown_pct": 8.41221637991358,
+      "sharpe_ratio": 0.752230764194683
+    },
+    {
+      "window_index": 2,
+      "train_start": "2024-07-01T00:00:00",
+      "train_end": "2025-01-01T00:00:00",
+      "test_start": "2025-01-01T00:00:00",
+      "test_end": "2025-04-01T00:00:00",
+      "total_trades": 2,
+      "win_rate": 0.0,
+      "total_return_pct": -8.130581268037695,
+      "max_drawdown_pct": 25.9115562494238,
+      "sharpe_ratio": -0.4431570690106098
+    },
+    {
+      "window_index": 3,
+      "train_start": "2025-01-01T00:00:00",
+      "train_end": "2025-07-01T00:00:00",
+      "test_start": "2025-07-01T00:00:00",
+      "test_end": "2025-10-01T00:00:00",
+      "total_trades": 4,
+      "win_rate": 50.0,
+      "total_return_pct": 18.358161190404534,
+      "max_drawdown_pct": 23.104172003794822,
+      "sharpe_ratio": 1.3103401790205478
+    },
+    {
+      "window_index": 4,
+      "train_start": "2025-07-01T00:00:00",
+      "train_end": "2026-01-01T00:00:00",
+      "test_start": "2026-01-01T00:00:00",
+      "test_end": "2026-04-01T00:00:00",
+      "total_trades": 3,
+      "win_rate": 0.0,
+      "total_return_pct": -19.562177119806247,
+      "max_drawdown_pct": 27.414920729580945,
+      "sharpe_ratio": -2.7240547856927533
+    }
+  ],
+  "resolved_backtest_config": {
+    "symbol": "SOLUSDT",
+    "timeframe": "1d",
+    "start_date": "2024-01-01",
+    "end_date": "2026-06-01",
+    "initial_capital": 10000.0,
+    "fee_rate": 0.0004,
+    "stop_loss_pct": 0.0,
+    "take_profit_pct": 0.0,
+    "sl_atr_multiplier": 2.0,
+    "tp_atr_multiplier": 4.5,
+    "trailing_activate_atr": 1.5,
+    "trailing_offset_atr": 1.0,
+    "slippage_pct": 0.0002,
+    "risk_per_trade": 0.02,
+    "use_atr_sizing": false,
+    "atr_multiplier": 1.0,
+    "apply_global_trend_filter": false,
+    "global_trend_filter_buffer_pct": 0.0,
+    "session_liquidity_router": {
+      "enabled": false,
+      "allowed_windows": [
+        "americas"
+      ],
+      "block_entries_outside_windows": true
+    },
+    "basis_premium_filter": {
+      "enabled": false,
+      "exchange": "binance_usdm",
+      "tail_metric": "basis_bps",
+      "positive_tail_pct": 0.05,
+      "block_positive_tail_longs": true,
+      "missing_data_policy": "allow",
+      "calibrated_positive_threshold": null
+    },
+    "cross_venue_dislocation": {
+      "enabled": false,
+      "metric": "basis_spread",
+      "mode": "require",
+      "min_spread_bps": 5.0,
+      "side": "both",
+      "missing_data_policy": "allow"
+    },
+    "allow_short": false,
+    "use_executor_exit_model": false,
+    "ignore_signal_sells": false,
+    "strategy_configs": [
+      {
+        "sma_window": 50
+      }
+    ],
+    "aggregator_config": {
+      "min_agreement": 1,
+      "buy_threshold": 0.5,
+      "sell_threshold": -0.5,
+      "btc_regime_filter_enabled": false
+    },
+    "time_stop_minutes": 0.0,
+    "replay_sentiment_path": null,
+    "replay_sentiment_max_age_seconds": null,
+    "futures_mode": false,
+    "futures_leverage": 5,
+    "futures_funding_rate": 0.00030000000000000003,
+    "fixed_notional_usdt": 0.0,
+    "quantity_step_size": 0.0,
+    "min_notional_usdt": 0.0
+  },
+  "cost_audit": {
+    "name": "realistic",
+    "fee_rate": 0.0004,
+    "slippage_pct": 0.0002,
+    "apply_global_trend_filter": false,
+    "funding_cadence": "scaled_8h",
+    "base_futures_funding_rate": 0.0001,
+    "round_trip_cost_pct": 0.12000000000000001,
+    "funding_method": "scale per-bar rate by tf_hours/8 (equivalent to 8h settlement cadence)",
+    "effective_futures_funding_rate": 0.0
+  }
+}

--- a/research/cost-realism-rerun/eth-4h-range-reversion-bounded-legacy.json
+++ b/research/cost-realism-rerun/eth-4h-range-reversion-bounded-legacy.json
@@ -1,0 +1,178 @@
+{
+  "lane_id": "eth-4h-range-reversion-bounded",
+  "pass_name": "legacy",
+  "summary": {
+    "symbol": "ETHUSDT",
+    "timeframe": "4h",
+    "start": "2024-01-01",
+    "end": "2026-06-01",
+    "total_trades": 36,
+    "win_rate": 55.55555555555556,
+    "total_return_pct": -18.709124075640748,
+    "max_drawdown_pct": 28.689738711640523,
+    "sharpe_ratio": -0.5476003266445331,
+    "wfo_windows": 4,
+    "wfo_total_trades": 15,
+    "wfo_mean_sharpe": -0.7105625849116295,
+    "wfo_total_return_pct": 1.2708727742481996,
+    "bootstrap_p_loss_pct": 86.0,
+    "mc_drawdown_p95_pct": 41.632846124151015,
+    "mc_drawdown_p50_pct": 24.666766860951522,
+    "profit_concentration_pct": 100.0,
+    "passes_gates": false,
+    "failure_reasons": [
+      "min_wfo_trades failed (15 < 20)",
+      "min_wfo_sharpe failed (-0.71 < 0.50)",
+      "max_drawdown_pct failed (28.69% > 10.00%)",
+      "max_bootstrap_p_loss_pct failed (86.00% > 25.00%)",
+      "max_profit_concentration_pct failed (100.00% > 50.00%)"
+    ],
+    "blocked_buy_count": 0,
+    "basis_blocked_buy_count": 0,
+    "dislocation_blocked_buy_count": 0
+  },
+  "gates": {
+    "min_trades": 0,
+    "min_wfo_trades": 20,
+    "min_wfo_sharpe": 0.5,
+    "max_drawdown_pct": 10.0,
+    "max_bootstrap_p_loss_pct": 25.0,
+    "min_oos_return_pct": 0.0,
+    "max_profit_concentration_pct": 50.0,
+    "max_mc_drawdown_p95_pct": 0.0
+  },
+  "windows": [
+    {
+      "window_index": 1,
+      "train_start": "2024-01-01T00:00:00",
+      "train_end": "2024-07-01T00:00:00",
+      "test_start": "2024-07-01T00:00:00",
+      "test_end": "2024-10-01T00:00:00",
+      "total_trades": 4,
+      "win_rate": 50.0,
+      "total_return_pct": -4.007343035066351,
+      "max_drawdown_pct": 5.014782567429429,
+      "sharpe_ratio": -1.8843486529615057
+    },
+    {
+      "window_index": 2,
+      "train_start": "2024-07-01T00:00:00",
+      "train_end": "2025-01-01T00:00:00",
+      "test_start": "2025-01-01T00:00:00",
+      "test_end": "2025-04-01T00:00:00",
+      "total_trades": 0,
+      "win_rate": 0.0,
+      "total_return_pct": 0.0,
+      "max_drawdown_pct": 0.0,
+      "sharpe_ratio": 0.0
+    },
+    {
+      "window_index": 3,
+      "train_start": "2025-01-01T00:00:00",
+      "train_end": "2025-07-01T00:00:00",
+      "test_start": "2025-07-01T00:00:00",
+      "test_end": "2025-10-01T00:00:00",
+      "total_trades": 9,
+      "win_rate": 77.77777777777779,
+      "total_return_pct": 8.049617507270087,
+      "max_drawdown_pct": 8.141018330762464,
+      "sharpe_ratio": 1.4308966946704138
+    },
+    {
+      "window_index": 4,
+      "train_start": "2025-07-01T00:00:00",
+      "train_end": "2026-01-01T00:00:00",
+      "test_start": "2026-01-01T00:00:00",
+      "test_end": "2026-04-01T00:00:00",
+      "total_trades": 2,
+      "win_rate": 50.0,
+      "total_return_pct": -2.3610036882672283,
+      "max_drawdown_pct": 2.7137917627883876,
+      "sharpe_ratio": -2.388798381355426
+    }
+  ],
+  "resolved_backtest_config": {
+    "symbol": "ETHUSDT",
+    "timeframe": "4h",
+    "start_date": "2024-01-01",
+    "end_date": "2026-06-01",
+    "initial_capital": 10000.0,
+    "fee_rate": 0.001,
+    "stop_loss_pct": 0.01,
+    "take_profit_pct": 0.03,
+    "sl_atr_multiplier": 2.1,
+    "tp_atr_multiplier": 3.0,
+    "trailing_activate_atr": 1.6,
+    "trailing_offset_atr": 0.8,
+    "slippage_pct": 0.001,
+    "risk_per_trade": 0.02,
+    "use_atr_sizing": false,
+    "atr_multiplier": 1.0,
+    "apply_global_trend_filter": true,
+    "global_trend_filter_buffer_pct": 0.0025,
+    "session_liquidity_router": {
+      "enabled": false,
+      "allowed_windows": [
+        "americas"
+      ],
+      "block_entries_outside_windows": true
+    },
+    "basis_premium_filter": {
+      "enabled": false,
+      "exchange": "binance_usdm",
+      "tail_metric": "basis_bps",
+      "positive_tail_pct": 0.05,
+      "block_positive_tail_longs": true,
+      "missing_data_policy": "allow",
+      "calibrated_positive_threshold": null
+    },
+    "cross_venue_dislocation": {
+      "enabled": false,
+      "metric": "basis_spread",
+      "mode": "require",
+      "min_spread_bps": 5.0,
+      "side": "both",
+      "missing_data_policy": "allow"
+    },
+    "allow_short": false,
+    "use_executor_exit_model": true,
+    "ignore_signal_sells": false,
+    "strategy_configs": [
+      {
+        "band_distance_threshold": 0.0045,
+        "rsi_oversold": 38,
+        "rsi_overbought": 62
+      }
+    ],
+    "aggregator_config": {
+      "buy_threshold": 0.6,
+      "buy_threshold_uptrend": 0.55,
+      "sell_threshold": -0.58,
+      "btc_regime_filter_enabled": true,
+      "btc_reference_symbol": "BTCUSDT",
+      "btc_dump_threshold_pct": -1.0,
+      "btc_dump_require_below_ema200": true,
+      "min_confidence": 0.1
+    },
+    "time_stop_minutes": 4320.0,
+    "replay_sentiment_path": null,
+    "replay_sentiment_max_age_seconds": null,
+    "futures_mode": false,
+    "futures_leverage": 5,
+    "futures_funding_rate": 0.0001,
+    "fixed_notional_usdt": 0.0,
+    "quantity_step_size": 0.0,
+    "min_notional_usdt": 0.0
+  },
+  "cost_audit": {
+    "name": "legacy",
+    "fee_rate": 0.001,
+    "slippage_pct": 0.001,
+    "apply_global_trend_filter": true,
+    "funding_cadence": "per_bar",
+    "base_futures_funding_rate": 0.0001,
+    "round_trip_cost_pct": 0.4,
+    "funding_method": "charge base rate every bar (legacy engine behavior)",
+    "effective_futures_funding_rate": 0.0
+  }
+}

--- a/research/cost-realism-rerun/eth-4h-range-reversion-bounded-realistic.json
+++ b/research/cost-realism-rerun/eth-4h-range-reversion-bounded-realistic.json
@@ -1,0 +1,178 @@
+{
+  "lane_id": "eth-4h-range-reversion-bounded",
+  "pass_name": "realistic",
+  "summary": {
+    "symbol": "ETHUSDT",
+    "timeframe": "4h",
+    "start": "2024-01-01",
+    "end": "2026-06-01",
+    "total_trades": 131,
+    "win_rate": 49.61832061068702,
+    "total_return_pct": -65.88493139899496,
+    "max_drawdown_pct": 71.52601896009385,
+    "sharpe_ratio": -1.4093515849991738,
+    "wfo_windows": 4,
+    "wfo_total_trades": 66,
+    "wfo_mean_sharpe": -1.8386434854105729,
+    "wfo_total_return_pct": -46.51796867913662,
+    "bootstrap_p_loss_pct": 98.0,
+    "mc_drawdown_p95_pct": 85.27730913494725,
+    "mc_drawdown_p50_pct": 70.76285282314392,
+    "profit_concentration_pct": 100.0,
+    "passes_gates": false,
+    "failure_reasons": [
+      "min_wfo_sharpe failed (-1.84 < 0.50)",
+      "max_drawdown_pct failed (71.53% > 10.00%)",
+      "max_bootstrap_p_loss_pct failed (98.00% > 25.00%)",
+      "min_oos_return_pct failed (-46.52% < 0.00%)",
+      "max_profit_concentration_pct failed (100.00% > 50.00%)"
+    ],
+    "blocked_buy_count": 0,
+    "basis_blocked_buy_count": 0,
+    "dislocation_blocked_buy_count": 0
+  },
+  "gates": {
+    "min_trades": 0,
+    "min_wfo_trades": 20,
+    "min_wfo_sharpe": 0.5,
+    "max_drawdown_pct": 10.0,
+    "max_bootstrap_p_loss_pct": 25.0,
+    "min_oos_return_pct": 0.0,
+    "max_profit_concentration_pct": 50.0,
+    "max_mc_drawdown_p95_pct": 0.0
+  },
+  "windows": [
+    {
+      "window_index": 1,
+      "train_start": "2024-01-01T00:00:00",
+      "train_end": "2024-07-01T00:00:00",
+      "test_start": "2024-07-01T00:00:00",
+      "test_end": "2024-10-01T00:00:00",
+      "total_trades": 23,
+      "win_rate": 47.82608695652174,
+      "total_return_pct": -17.69773941784477,
+      "max_drawdown_pct": 25.68525547070852,
+      "sharpe_ratio": -1.8939859233462055
+    },
+    {
+      "window_index": 2,
+      "train_start": "2024-07-01T00:00:00",
+      "train_end": "2025-01-01T00:00:00",
+      "test_start": "2025-01-01T00:00:00",
+      "test_end": "2025-04-01T00:00:00",
+      "total_trades": 18,
+      "win_rate": 44.44444444444444,
+      "total_return_pct": -18.898251761855573,
+      "max_drawdown_pct": 21.406951936342935,
+      "sharpe_ratio": -2.0002690013792788
+    },
+    {
+      "window_index": 3,
+      "train_start": "2025-01-01T00:00:00",
+      "train_end": "2025-07-01T00:00:00",
+      "test_start": "2025-07-01T00:00:00",
+      "test_end": "2025-10-01T00:00:00",
+      "total_trades": 13,
+      "win_rate": 61.53846153846154,
+      "total_return_pct": 0.7684898080006496,
+      "max_drawdown_pct": 8.928810703402657,
+      "sharpe_ratio": 0.25005549921667436
+    },
+    {
+      "window_index": 4,
+      "train_start": "2025-07-01T00:00:00",
+      "train_end": "2026-01-01T00:00:00",
+      "test_start": "2026-01-01T00:00:00",
+      "test_end": "2026-04-01T00:00:00",
+      "total_trades": 12,
+      "win_rate": 41.66666666666667,
+      "total_return_pct": -20.48644627139671,
+      "max_drawdown_pct": 32.60858501241407,
+      "sharpe_ratio": -3.710374516133482
+    }
+  ],
+  "resolved_backtest_config": {
+    "symbol": "ETHUSDT",
+    "timeframe": "4h",
+    "start_date": "2024-01-01",
+    "end_date": "2026-06-01",
+    "initial_capital": 10000.0,
+    "fee_rate": 0.0004,
+    "stop_loss_pct": 0.01,
+    "take_profit_pct": 0.03,
+    "sl_atr_multiplier": 2.1,
+    "tp_atr_multiplier": 3.0,
+    "trailing_activate_atr": 1.6,
+    "trailing_offset_atr": 0.8,
+    "slippage_pct": 0.0002,
+    "risk_per_trade": 0.02,
+    "use_atr_sizing": false,
+    "atr_multiplier": 1.0,
+    "apply_global_trend_filter": false,
+    "global_trend_filter_buffer_pct": 0.0025,
+    "session_liquidity_router": {
+      "enabled": false,
+      "allowed_windows": [
+        "americas"
+      ],
+      "block_entries_outside_windows": true
+    },
+    "basis_premium_filter": {
+      "enabled": false,
+      "exchange": "binance_usdm",
+      "tail_metric": "basis_bps",
+      "positive_tail_pct": 0.05,
+      "block_positive_tail_longs": true,
+      "missing_data_policy": "allow",
+      "calibrated_positive_threshold": null
+    },
+    "cross_venue_dislocation": {
+      "enabled": false,
+      "metric": "basis_spread",
+      "mode": "require",
+      "min_spread_bps": 5.0,
+      "side": "both",
+      "missing_data_policy": "allow"
+    },
+    "allow_short": false,
+    "use_executor_exit_model": true,
+    "ignore_signal_sells": false,
+    "strategy_configs": [
+      {
+        "band_distance_threshold": 0.0045,
+        "rsi_oversold": 38,
+        "rsi_overbought": 62
+      }
+    ],
+    "aggregator_config": {
+      "buy_threshold": 0.6,
+      "buy_threshold_uptrend": 0.55,
+      "sell_threshold": -0.58,
+      "btc_regime_filter_enabled": true,
+      "btc_reference_symbol": "BTCUSDT",
+      "btc_dump_threshold_pct": -1.0,
+      "btc_dump_require_below_ema200": true,
+      "min_confidence": 0.1
+    },
+    "time_stop_minutes": 4320.0,
+    "replay_sentiment_path": null,
+    "replay_sentiment_max_age_seconds": null,
+    "futures_mode": false,
+    "futures_leverage": 5,
+    "futures_funding_rate": 5e-05,
+    "fixed_notional_usdt": 0.0,
+    "quantity_step_size": 0.0,
+    "min_notional_usdt": 0.0
+  },
+  "cost_audit": {
+    "name": "realistic",
+    "fee_rate": 0.0004,
+    "slippage_pct": 0.0002,
+    "apply_global_trend_filter": false,
+    "funding_cadence": "scaled_8h",
+    "base_futures_funding_rate": 0.0001,
+    "round_trip_cost_pct": 0.12000000000000001,
+    "funding_method": "scale per-bar rate by tf_hours/8 (equivalent to 8h settlement cadence)",
+    "effective_futures_funding_rate": 0.0
+  }
+}

--- a/research/cost-realism-rerun/resolved/daily-trend-long-btc.yaml
+++ b/research/cost-realism-rerun/resolved/daily-trend-long-btc.yaml
@@ -1,0 +1,38 @@
+agent_id: daily-trend-long-gate2
+display_name: daily-trend-long-gate2
+mode: paper
+trading:
+  pairs:
+  - BTCUSDT
+  - ETHUSDT
+  - SOLUSDT
+  timeframe: 1d
+database:
+  host: 127.0.0.1
+  port: 15432
+ingest:
+  use_websocket: false
+telegram:
+  enabled: false
+trading_execution:
+  enabled: false
+  test_mode: true
+  use_atr_sizing: false
+  stop_loss_pct: 0.0
+  take_profit_pct: 0.0
+  exit_rules:
+    backtest_use_executor_exit_model: false
+    backtest_ignore_signal_sells: false
+futures:
+  enabled: false
+strategy:
+  global_trend_filter_enabled: false
+  strategies:
+  - name: daily_trend_long
+    config:
+      sma_window: 50
+  aggregator:
+    min_agreement: 1
+    buy_threshold: 0.5
+    sell_threshold: -0.5
+    btc_regime_filter_enabled: false

--- a/research/cost-realism-rerun/resolved/daily-trend-long-eth.yaml
+++ b/research/cost-realism-rerun/resolved/daily-trend-long-eth.yaml
@@ -1,0 +1,38 @@
+agent_id: daily-trend-long-gate2
+display_name: daily-trend-long-gate2
+mode: paper
+trading:
+  pairs:
+  - BTCUSDT
+  - ETHUSDT
+  - SOLUSDT
+  timeframe: 1d
+database:
+  host: 127.0.0.1
+  port: 15432
+ingest:
+  use_websocket: false
+telegram:
+  enabled: false
+trading_execution:
+  enabled: false
+  test_mode: true
+  use_atr_sizing: false
+  stop_loss_pct: 0.0
+  take_profit_pct: 0.0
+  exit_rules:
+    backtest_use_executor_exit_model: false
+    backtest_ignore_signal_sells: false
+futures:
+  enabled: false
+strategy:
+  global_trend_filter_enabled: false
+  strategies:
+  - name: daily_trend_long
+    config:
+      sma_window: 50
+  aggregator:
+    min_agreement: 1
+    buy_threshold: 0.5
+    sell_threshold: -0.5
+    btc_regime_filter_enabled: false

--- a/research/cost-realism-rerun/resolved/daily-trend-long-sol.yaml
+++ b/research/cost-realism-rerun/resolved/daily-trend-long-sol.yaml
@@ -1,0 +1,38 @@
+agent_id: daily-trend-long-gate2
+display_name: daily-trend-long-gate2
+mode: paper
+trading:
+  pairs:
+  - BTCUSDT
+  - ETHUSDT
+  - SOLUSDT
+  timeframe: 1d
+database:
+  host: 127.0.0.1
+  port: 15432
+ingest:
+  use_websocket: false
+telegram:
+  enabled: false
+trading_execution:
+  enabled: false
+  test_mode: true
+  use_atr_sizing: false
+  stop_loss_pct: 0.0
+  take_profit_pct: 0.0
+  exit_rules:
+    backtest_use_executor_exit_model: false
+    backtest_ignore_signal_sells: false
+futures:
+  enabled: false
+strategy:
+  global_trend_filter_enabled: false
+  strategies:
+  - name: daily_trend_long
+    config:
+      sma_window: 50
+  aggregator:
+    min_agreement: 1
+    buy_threshold: 0.5
+    sell_threshold: -0.5
+    btc_regime_filter_enabled: false

--- a/research/cost-realism-rerun/resolved/eth-4h-range-reversion-bounded.yaml
+++ b/research/cost-realism-rerun/resolved/eth-4h-range-reversion-bounded.yaml
@@ -1,0 +1,55 @@
+agent_id: autoresearch
+trading:
+  pairs:
+  - ETHUSDT
+  timeframe: 4h
+ingest:
+  use_websocket: false
+database:
+  host: 127.0.0.1
+  port: 15432
+telegram:
+  enabled: false
+trading_execution:
+  enabled: false
+  sl_atr_multiplier: 2.1
+  tp_atr_multiplier: 3.0
+  trailing_activate_atr: 1.6
+  trailing_offset_atr: 0.8
+  exit_rules:
+    backtest_use_executor_exit_model: true
+    time_stop_minutes: 4320
+futures:
+  enabled: false
+strategy:
+  strategies:
+  - name: bollinger_bounce
+    config:
+      band_distance_threshold: 0.0045
+      rsi_oversold: 38
+      rsi_overbought: 62
+  aggregator:
+    buy_threshold: 0.6
+    buy_threshold_uptrend: 0.55
+    sell_threshold: -0.58
+    btc_regime_filter_enabled: true
+    btc_reference_symbol: BTCUSDT
+    btc_dump_threshold_pct: -1.0
+    btc_dump_require_below_ema200: true
+    min_confidence: 0.1
+  per_symbol_aggregator_config:
+    SOLUSDT:
+      min_agreement: 1
+      buy_threshold: 0.8
+      sell_threshold: -0.6
+      sell_min_agreement: 2
+    BNBUSDT:
+      min_agreement: 1
+      buy_threshold: 1.1
+      sell_threshold: -0.5
+    ETHUSDT:
+      min_agreement: 1
+      buy_threshold: 0.6
+      sell_threshold: -0.58
+      sell_min_agreement: 1
+  global_trend_filter_buffer_pct: 0.0025

--- a/research/cost-realism-rerun/resolved/sol-1h-dislocation-event.yaml
+++ b/research/cost-realism-rerun/resolved/sol-1h-dislocation-event.yaml
@@ -1,0 +1,51 @@
+agent_id: autoresearch
+trading:
+  pairs:
+  - SOLUSDT
+  timeframe: 1h
+ingest:
+  use_websocket: false
+database:
+  host: 127.0.0.1
+  port: 15432
+telegram:
+  enabled: false
+trading_execution:
+  enabled: false
+  sl_atr_multiplier: 4.0
+  tp_atr_multiplier: 8.0
+  trailing_activate_atr: 10.0
+  trailing_offset_atr: 0.5
+  exit_rules:
+    backtest_use_executor_exit_model: true
+    time_stop_minutes: 1440
+futures:
+  enabled: false
+strategy:
+  strategies:
+  - name: dislocation_event
+    config:
+      threshold_mode: rolling
+      metric: basis_spread
+      tail_pct: 5
+      rolling_days: 90
+      cooldown_bars: 24
+  aggregator:
+    buy_threshold: 0.55
+    buy_threshold_uptrend: 0.5
+    sell_threshold: -0.6
+    btc_regime_filter_enabled: true
+    btc_reference_symbol: BTCUSDT
+    btc_dump_threshold_pct: -1.0
+    btc_dump_require_below_ema200: true
+    min_confidence: 0.1
+  per_symbol_aggregator_config:
+    SOLUSDT:
+      min_agreement: 1
+      buy_threshold: 0.55
+      sell_threshold: -0.6
+      sell_min_agreement: 1
+    BNBUSDT:
+      min_agreement: 1
+      buy_threshold: 1.1
+      sell_threshold: -0.5

--- a/research/cost-realism-rerun/sol-1h-dislocation-event-legacy.json
+++ b/research/cost-realism-rerun/sol-1h-dislocation-event-legacy.json
@@ -1,0 +1,240 @@
+{
+  "lane_id": "sol-1h-dislocation-event",
+  "pass_name": "legacy",
+  "summary": {
+    "symbol": "SOLUSDT",
+    "timeframe": "1h",
+    "start": "2024-01-01",
+    "end": "2026-06-01",
+    "total_trades": 144,
+    "win_rate": 50.69444444444444,
+    "total_return_pct": -17.35588177638125,
+    "max_drawdown_pct": 45.794001920016356,
+    "sharpe_ratio": -0.06275145601635096,
+    "wfo_windows": 9,
+    "wfo_total_trades": 91,
+    "wfo_mean_sharpe": -0.7264273357505712,
+    "wfo_total_return_pct": -23.75893679024481,
+    "bootstrap_p_loss_pct": 64.0,
+    "mc_drawdown_p95_pct": 72.40496174597345,
+    "mc_drawdown_p50_pct": 44.261113266737574,
+    "profit_concentration_pct": 100.0,
+    "passes_gates": false,
+    "failure_reasons": [
+      "min_wfo_sharpe failed (-0.73 < 0.50)",
+      "max_drawdown_pct failed (45.79% > 10.00%)",
+      "max_bootstrap_p_loss_pct failed (64.00% > 25.00%)",
+      "min_oos_return_pct failed (-23.76% < 0.00%)",
+      "max_profit_concentration_pct failed (100.00% > 50.00%)"
+    ],
+    "blocked_buy_count": 0,
+    "basis_blocked_buy_count": 0,
+    "dislocation_blocked_buy_count": 0
+  },
+  "gates": {
+    "min_trades": 0,
+    "min_wfo_trades": 20,
+    "min_wfo_sharpe": 0.5,
+    "max_drawdown_pct": 10.0,
+    "max_bootstrap_p_loss_pct": 25.0,
+    "min_oos_return_pct": 0.0,
+    "max_profit_concentration_pct": 50.0,
+    "max_mc_drawdown_p95_pct": 0.0
+  },
+  "windows": [
+    {
+      "window_index": 1,
+      "train_start": "2024-01-01T00:00:00",
+      "train_end": "2024-04-01T00:00:00",
+      "test_start": "2024-04-01T00:00:00",
+      "test_end": "2024-06-01T00:00:00",
+      "total_trades": 5,
+      "win_rate": 40.0,
+      "total_return_pct": -9.004539683493949,
+      "max_drawdown_pct": 14.43903443263829,
+      "sharpe_ratio": -2.113328485272658
+    },
+    {
+      "window_index": 2,
+      "train_start": "2024-04-01T00:00:00",
+      "train_end": "2024-07-01T00:00:00",
+      "test_start": "2024-07-01T00:00:00",
+      "test_end": "2024-09-01T00:00:00",
+      "total_trades": 7,
+      "win_rate": 42.857142857142854,
+      "total_return_pct": -2.273593284771341,
+      "max_drawdown_pct": 12.386097576379473,
+      "sharpe_ratio": -0.3958594598981342
+    },
+    {
+      "window_index": 3,
+      "train_start": "2024-07-01T00:00:00",
+      "train_end": "2024-10-01T00:00:00",
+      "test_start": "2024-10-01T00:00:00",
+      "test_end": "2024-12-01T00:00:00",
+      "total_trades": 16,
+      "win_rate": 50.0,
+      "total_return_pct": -3.9581890014269807,
+      "max_drawdown_pct": 13.82173985332119,
+      "sharpe_ratio": -0.3703192255236676
+    },
+    {
+      "window_index": 4,
+      "train_start": "2024-10-01T00:00:00",
+      "train_end": "2025-01-01T00:00:00",
+      "test_start": "2025-01-01T00:00:00",
+      "test_end": "2025-03-01T00:00:00",
+      "total_trades": 10,
+      "win_rate": 50.0,
+      "total_return_pct": -2.946516838466887,
+      "max_drawdown_pct": 25.065798565228153,
+      "sharpe_ratio": -0.03281989444170621
+    },
+    {
+      "window_index": 5,
+      "train_start": "2025-01-01T00:00:00",
+      "train_end": "2025-04-01T00:00:00",
+      "test_start": "2025-04-01T00:00:00",
+      "test_end": "2025-06-01T00:00:00",
+      "total_trades": 16,
+      "win_rate": 56.25,
+      "total_return_pct": 17.65480076185733,
+      "max_drawdown_pct": 6.638783272398823,
+      "sharpe_ratio": 2.8033323303876614
+    },
+    {
+      "window_index": 6,
+      "train_start": "2025-04-01T00:00:00",
+      "train_end": "2025-07-01T00:00:00",
+      "test_start": "2025-07-01T00:00:00",
+      "test_end": "2025-09-01T00:00:00",
+      "total_trades": 20,
+      "win_rate": 50.0,
+      "total_return_pct": -4.71568514448747,
+      "max_drawdown_pct": 16.83002501262126,
+      "sharpe_ratio": -0.46978994174657207
+    },
+    {
+      "window_index": 7,
+      "train_start": "2025-07-01T00:00:00",
+      "train_end": "2025-10-01T00:00:00",
+      "test_start": "2025-10-01T00:00:00",
+      "test_end": "2025-12-01T00:00:00",
+      "total_trades": 5,
+      "win_rate": 60.0,
+      "total_return_pct": -7.444549367855234,
+      "max_drawdown_pct": 13.122076562906967,
+      "sharpe_ratio": -3.2118801738231246
+    },
+    {
+      "window_index": 8,
+      "train_start": "2025-10-01T00:00:00",
+      "train_end": "2026-01-01T00:00:00",
+      "test_start": "2026-01-01T00:00:00",
+      "test_end": "2026-03-01T00:00:00",
+      "total_trades": 12,
+      "win_rate": 50.0,
+      "total_return_pct": -11.355304564726175,
+      "max_drawdown_pct": 14.44732466860628,
+      "sharpe_ratio": -2.7471811714369387
+    },
+    {
+      "window_index": 9,
+      "train_start": "2026-01-01T00:00:00",
+      "train_end": "2026-04-01T00:00:00",
+      "test_start": "2026-04-01T00:00:00",
+      "test_end": "2026-06-01T00:00:00",
+      "total_trades": 0,
+      "win_rate": 0.0,
+      "total_return_pct": 0.0,
+      "max_drawdown_pct": 0.0,
+      "sharpe_ratio": 0.0
+    }
+  ],
+  "resolved_backtest_config": {
+    "symbol": "SOLUSDT",
+    "timeframe": "1h",
+    "start_date": "2024-01-01",
+    "end_date": "2026-06-01",
+    "initial_capital": 10000.0,
+    "fee_rate": 0.001,
+    "stop_loss_pct": 0.01,
+    "take_profit_pct": 0.03,
+    "sl_atr_multiplier": 4.0,
+    "tp_atr_multiplier": 8.0,
+    "trailing_activate_atr": 10.0,
+    "trailing_offset_atr": 0.5,
+    "slippage_pct": 0.001,
+    "risk_per_trade": 0.02,
+    "use_atr_sizing": false,
+    "atr_multiplier": 1.0,
+    "apply_global_trend_filter": true,
+    "global_trend_filter_buffer_pct": 0.0,
+    "session_liquidity_router": {
+      "enabled": false,
+      "allowed_windows": [
+        "americas"
+      ],
+      "block_entries_outside_windows": true
+    },
+    "basis_premium_filter": {
+      "enabled": false,
+      "exchange": "binance_usdm",
+      "tail_metric": "basis_bps",
+      "positive_tail_pct": 0.05,
+      "block_positive_tail_longs": true,
+      "missing_data_policy": "allow",
+      "calibrated_positive_threshold": null
+    },
+    "cross_venue_dislocation": {
+      "enabled": false,
+      "metric": "basis_spread",
+      "mode": "require",
+      "min_spread_bps": 5.0,
+      "side": "both",
+      "missing_data_policy": "allow"
+    },
+    "allow_short": false,
+    "use_executor_exit_model": true,
+    "ignore_signal_sells": false,
+    "strategy_configs": [
+      {
+        "threshold_mode": "rolling",
+        "metric": "basis_spread",
+        "tail_pct": 5,
+        "rolling_days": 90,
+        "cooldown_bars": 24
+      }
+    ],
+    "aggregator_config": {
+      "buy_threshold": 0.55,
+      "buy_threshold_uptrend": 0.5,
+      "sell_threshold": -0.6,
+      "btc_regime_filter_enabled": true,
+      "btc_reference_symbol": "BTCUSDT",
+      "btc_dump_threshold_pct": -1.0,
+      "btc_dump_require_below_ema200": true,
+      "min_confidence": 0.1
+    },
+    "time_stop_minutes": 1440.0,
+    "replay_sentiment_path": null,
+    "replay_sentiment_max_age_seconds": null,
+    "futures_mode": false,
+    "futures_leverage": 5,
+    "futures_funding_rate": 0.0001,
+    "fixed_notional_usdt": 0.0,
+    "quantity_step_size": 0.0,
+    "min_notional_usdt": 0.0
+  },
+  "cost_audit": {
+    "name": "legacy",
+    "fee_rate": 0.001,
+    "slippage_pct": 0.001,
+    "apply_global_trend_filter": true,
+    "funding_cadence": "per_bar",
+    "base_futures_funding_rate": 0.0001,
+    "round_trip_cost_pct": 0.4,
+    "funding_method": "charge base rate every bar (legacy engine behavior)",
+    "effective_futures_funding_rate": 0.0
+  }
+}

--- a/research/cost-realism-rerun/sol-1h-dislocation-event-realistic.json
+++ b/research/cost-realism-rerun/sol-1h-dislocation-event-realistic.json
@@ -1,0 +1,238 @@
+{
+  "lane_id": "sol-1h-dislocation-event",
+  "pass_name": "realistic",
+  "summary": {
+    "symbol": "SOLUSDT",
+    "timeframe": "1h",
+    "start": "2024-01-01",
+    "end": "2026-06-01",
+    "total_trades": 326,
+    "win_rate": 51.533742331288344,
+    "total_return_pct": 114.26801873805456,
+    "max_drawdown_pct": 43.0368240486554,
+    "sharpe_ratio": 0.9268665167564124,
+    "wfo_windows": 9,
+    "wfo_total_trades": 205,
+    "wfo_mean_sharpe": 0.1498709190143359,
+    "wfo_total_return_pct": 4.637911796351024,
+    "bootstrap_p_loss_pct": 15.0,
+    "mc_drawdown_p95_pct": 67.00499460693436,
+    "mc_drawdown_p50_pct": 48.15578798654927,
+    "profit_concentration_pct": 79.14477987746834,
+    "passes_gates": false,
+    "failure_reasons": [
+      "min_wfo_sharpe failed (0.15 < 0.50)",
+      "max_drawdown_pct failed (43.04% > 10.00%)",
+      "max_profit_concentration_pct failed (79.14% > 50.00%)"
+    ],
+    "blocked_buy_count": 0,
+    "basis_blocked_buy_count": 0,
+    "dislocation_blocked_buy_count": 0
+  },
+  "gates": {
+    "min_trades": 0,
+    "min_wfo_trades": 20,
+    "min_wfo_sharpe": 0.5,
+    "max_drawdown_pct": 10.0,
+    "max_bootstrap_p_loss_pct": 25.0,
+    "min_oos_return_pct": 0.0,
+    "max_profit_concentration_pct": 50.0,
+    "max_mc_drawdown_p95_pct": 0.0
+  },
+  "windows": [
+    {
+      "window_index": 1,
+      "train_start": "2024-01-01T00:00:00",
+      "train_end": "2024-04-01T00:00:00",
+      "test_start": "2024-04-01T00:00:00",
+      "test_end": "2024-06-01T00:00:00",
+      "total_trades": 20,
+      "win_rate": 55.00000000000001,
+      "total_return_pct": -2.5525017540318005,
+      "max_drawdown_pct": 28.313349192570925,
+      "sharpe_ratio": 0.06378993354662606
+    },
+    {
+      "window_index": 2,
+      "train_start": "2024-04-01T00:00:00",
+      "train_end": "2024-07-01T00:00:00",
+      "test_start": "2024-07-01T00:00:00",
+      "test_end": "2024-09-01T00:00:00",
+      "total_trades": 26,
+      "win_rate": 57.692307692307686,
+      "total_return_pct": -4.67913853715274,
+      "max_drawdown_pct": 25.529606234229785,
+      "sharpe_ratio": -0.2149204903171648
+    },
+    {
+      "window_index": 3,
+      "train_start": "2024-07-01T00:00:00",
+      "train_end": "2024-10-01T00:00:00",
+      "test_start": "2024-10-01T00:00:00",
+      "test_end": "2024-12-01T00:00:00",
+      "total_trades": 23,
+      "win_rate": 47.82608695652174,
+      "total_return_pct": -6.654455725526113,
+      "max_drawdown_pct": 15.762595801135104,
+      "sharpe_ratio": -0.6428732024455694
+    },
+    {
+      "window_index": 4,
+      "train_start": "2024-10-01T00:00:00",
+      "train_end": "2025-01-01T00:00:00",
+      "test_start": "2025-01-01T00:00:00",
+      "test_end": "2025-03-01T00:00:00",
+      "total_trades": 28,
+      "win_rate": 50.0,
+      "total_return_pct": 16.635371411480794,
+      "max_drawdown_pct": 36.59240379880231,
+      "sharpe_ratio": 1.606183020988613
+    },
+    {
+      "window_index": 5,
+      "train_start": "2025-01-01T00:00:00",
+      "train_end": "2025-04-01T00:00:00",
+      "test_start": "2025-04-01T00:00:00",
+      "test_end": "2025-06-01T00:00:00",
+      "total_trades": 28,
+      "win_rate": 57.14285714285714,
+      "total_return_pct": 65.20557174686262,
+      "max_drawdown_pct": 12.914515348914414,
+      "sharpe_ratio": 5.5304386430325705
+    },
+    {
+      "window_index": 6,
+      "train_start": "2025-04-01T00:00:00",
+      "train_end": "2025-07-01T00:00:00",
+      "test_start": "2025-07-01T00:00:00",
+      "test_end": "2025-09-01T00:00:00",
+      "total_trades": 26,
+      "win_rate": 46.15384615384615,
+      "total_return_pct": 0.5467668685385252,
+      "max_drawdown_pct": 16.35446600140212,
+      "sharpe_ratio": 0.3069938399476153
+    },
+    {
+      "window_index": 7,
+      "train_start": "2025-07-01T00:00:00",
+      "train_end": "2025-10-01T00:00:00",
+      "test_start": "2025-10-01T00:00:00",
+      "test_end": "2025-12-01T00:00:00",
+      "total_trades": 24,
+      "win_rate": 45.83333333333333,
+      "total_return_pct": -19.748776560578953,
+      "max_drawdown_pct": 30.494757551387625,
+      "sharpe_ratio": -2.195813221262054
+    },
+    {
+      "window_index": 8,
+      "train_start": "2025-10-01T00:00:00",
+      "train_end": "2026-01-01T00:00:00",
+      "test_start": "2026-01-01T00:00:00",
+      "test_end": "2026-03-01T00:00:00",
+      "total_trades": 30,
+      "win_rate": 40.0,
+      "total_return_pct": -22.382065777018898,
+      "max_drawdown_pct": 28.467398822917627,
+      "sharpe_ratio": -3.1049602523616135
+    },
+    {
+      "window_index": 9,
+      "train_start": "2026-01-01T00:00:00",
+      "train_end": "2026-04-01T00:00:00",
+      "test_start": "2026-04-01T00:00:00",
+      "test_end": "2026-06-01T00:00:00",
+      "total_trades": 0,
+      "win_rate": 0.0,
+      "total_return_pct": 0.0,
+      "max_drawdown_pct": 0.0,
+      "sharpe_ratio": 0.0
+    }
+  ],
+  "resolved_backtest_config": {
+    "symbol": "SOLUSDT",
+    "timeframe": "1h",
+    "start_date": "2024-01-01",
+    "end_date": "2026-06-01",
+    "initial_capital": 10000.0,
+    "fee_rate": 0.0004,
+    "stop_loss_pct": 0.01,
+    "take_profit_pct": 0.03,
+    "sl_atr_multiplier": 4.0,
+    "tp_atr_multiplier": 8.0,
+    "trailing_activate_atr": 10.0,
+    "trailing_offset_atr": 0.5,
+    "slippage_pct": 0.0002,
+    "risk_per_trade": 0.02,
+    "use_atr_sizing": false,
+    "atr_multiplier": 1.0,
+    "apply_global_trend_filter": false,
+    "global_trend_filter_buffer_pct": 0.0,
+    "session_liquidity_router": {
+      "enabled": false,
+      "allowed_windows": [
+        "americas"
+      ],
+      "block_entries_outside_windows": true
+    },
+    "basis_premium_filter": {
+      "enabled": false,
+      "exchange": "binance_usdm",
+      "tail_metric": "basis_bps",
+      "positive_tail_pct": 0.05,
+      "block_positive_tail_longs": true,
+      "missing_data_policy": "allow",
+      "calibrated_positive_threshold": null
+    },
+    "cross_venue_dislocation": {
+      "enabled": false,
+      "metric": "basis_spread",
+      "mode": "require",
+      "min_spread_bps": 5.0,
+      "side": "both",
+      "missing_data_policy": "allow"
+    },
+    "allow_short": false,
+    "use_executor_exit_model": true,
+    "ignore_signal_sells": false,
+    "strategy_configs": [
+      {
+        "threshold_mode": "rolling",
+        "metric": "basis_spread",
+        "tail_pct": 5,
+        "rolling_days": 90,
+        "cooldown_bars": 24
+      }
+    ],
+    "aggregator_config": {
+      "buy_threshold": 0.55,
+      "buy_threshold_uptrend": 0.5,
+      "sell_threshold": -0.6,
+      "btc_regime_filter_enabled": true,
+      "btc_reference_symbol": "BTCUSDT",
+      "btc_dump_threshold_pct": -1.0,
+      "btc_dump_require_below_ema200": true,
+      "min_confidence": 0.1
+    },
+    "time_stop_minutes": 1440.0,
+    "replay_sentiment_path": null,
+    "replay_sentiment_max_age_seconds": null,
+    "futures_mode": false,
+    "futures_leverage": 5,
+    "futures_funding_rate": 1.25e-05,
+    "fixed_notional_usdt": 0.0,
+    "quantity_step_size": 0.0,
+    "min_notional_usdt": 0.0
+  },
+  "cost_audit": {
+    "name": "realistic",
+    "fee_rate": 0.0004,
+    "slippage_pct": 0.0002,
+    "apply_global_trend_filter": false,
+    "funding_cadence": "scaled_8h",
+    "base_futures_funding_rate": 0.0001,
+    "round_trip_cost_pct": 0.12000000000000001,
+    "funding_method": "scale per-bar rate by tf_hours/8 (equivalent to 8h settlement cadence)",
+    "effective_futures_funding_rate": 0.0
+  }
+}

--- a/research/overlay-threshold-sweep/0.50.json
+++ b/research/overlay-threshold-sweep/0.50.json
@@ -1,0 +1,225 @@
+{
+  "buy_threshold": 0.5,
+  "summary": {
+    "symbol": "SOLUSDT",
+    "timeframe": "1h",
+    "start": "2024-01-09",
+    "end": "2026-02-23",
+    "total_trades": 464,
+    "win_rate": 56.46551724137932,
+    "total_return_pct": -99.72689810426918,
+    "max_drawdown_pct": 99.74167922677329,
+    "sharpe_ratio": -1.8927126288478515,
+    "wfo_windows": 3,
+    "wfo_total_trades": 158,
+    "wfo_mean_sharpe": -0.8977460242336993,
+    "wfo_total_return_pct": -75.36785867148623,
+    "bootstrap_p_loss_pct": 100.0,
+    "mc_drawdown_p95_pct": 99.9851601422858,
+    "mc_drawdown_p50_pct": 99.81797617003407,
+    "profit_concentration_pct": 100.0,
+    "passes_gates": false,
+    "failure_reasons": [
+      "min_wfo_sharpe failed (-0.90 < 0.50)",
+      "max_drawdown_pct failed (99.74% > 10.00%)",
+      "max_bootstrap_p_loss_pct failed (100.00% > 25.00%)",
+      "min_oos_return_pct failed (-75.37% < 0.00%)",
+      "max_profit_concentration_pct failed (100.00% > 50.00%)"
+    ],
+    "blocked_buy_count": 0,
+    "basis_blocked_buy_count": 0,
+    "dislocation_blocked_buy_count": 0
+  },
+  "gates": {
+    "min_trades": 0,
+    "min_wfo_trades": 20,
+    "min_wfo_sharpe": 0.5,
+    "max_drawdown_pct": 10.0,
+    "max_bootstrap_p_loss_pct": 25.0,
+    "min_oos_return_pct": 0.0,
+    "max_profit_concentration_pct": 50.0,
+    "max_mc_drawdown_p95_pct": 0.0
+  },
+  "windows": [
+    {
+      "window_index": 1,
+      "train_start": "2024-01-09T00:00:00",
+      "train_end": "2024-07-09T00:00:00",
+      "test_start": "2024-07-09T00:00:00",
+      "test_end": "2024-10-09T00:00:00",
+      "total_trades": 56,
+      "win_rate": 67.85714285714286,
+      "total_return_pct": 1.8785133099579254,
+      "max_drawdown_pct": 42.83619817383422,
+      "sharpe_ratio": 0.5070132160711389
+    },
+    {
+      "window_index": 2,
+      "train_start": "2024-07-09T00:00:00",
+      "train_end": "2025-01-09T00:00:00",
+      "test_start": "2025-01-09T00:00:00",
+      "test_end": "2025-04-09T00:00:00",
+      "total_trades": 34,
+      "win_rate": 50.0,
+      "total_return_pct": -56.03330675474027,
+      "max_drawdown_pct": 63.20872647294477,
+      "sharpe_ratio": -1.3948823828774772
+    },
+    {
+      "window_index": 3,
+      "train_start": "2025-01-09T00:00:00",
+      "train_end": "2025-07-09T00:00:00",
+      "test_start": "2025-07-09T00:00:00",
+      "test_end": "2025-10-09T00:00:00",
+      "total_trades": 68,
+      "win_rate": 60.29411764705882,
+      "total_return_pct": -45.00847474080374,
+      "max_drawdown_pct": 54.96183131886999,
+      "sharpe_ratio": -1.8053689058947597
+    }
+  ],
+  "resolved_backtest_config": {
+    "symbol": "SOLUSDT",
+    "timeframe": "1h",
+    "start_date": "2024-01-09",
+    "end_date": "2026-02-23",
+    "initial_capital": 10000.0,
+    "fee_rate": 0.0004,
+    "stop_loss_pct": 0.01,
+    "take_profit_pct": 0.03,
+    "sl_atr_multiplier": 2.38,
+    "tp_atr_multiplier": 4.23,
+    "trailing_activate_atr": 1.82,
+    "trailing_offset_atr": 1.07,
+    "slippage_pct": 0.0002,
+    "risk_per_trade": 0.02,
+    "use_atr_sizing": false,
+    "atr_multiplier": 1.0,
+    "apply_global_trend_filter": true,
+    "global_trend_filter_buffer_pct": 0.0,
+    "global_trend_filter_source": "cost_profile_override",
+    "config_global_trend_filter_enabled": null,
+    "session_liquidity_router": {
+      "enabled": false,
+      "allowed_windows": [
+        "americas"
+      ],
+      "block_entries_outside_windows": true
+    },
+    "basis_premium_filter": {
+      "enabled": false,
+      "exchange": "binance_usdm",
+      "tail_metric": "basis_bps",
+      "positive_tail_pct": 0.05,
+      "block_positive_tail_longs": true,
+      "missing_data_policy": "allow",
+      "calibrated_positive_threshold": null
+    },
+    "cross_venue_dislocation": {
+      "enabled": false,
+      "metric": "basis_spread",
+      "mode": "require",
+      "min_spread_bps": 5.0,
+      "side": "both",
+      "missing_data_policy": "allow"
+    },
+    "allow_short": false,
+    "use_executor_exit_model": true,
+    "ignore_signal_sells": false,
+    "strategy_configs": [
+      {
+        "rsi_period": 7,
+        "oversold_threshold": 35,
+        "overbought_threshold": 65
+      },
+      {
+        "min_histogram_threshold": 0.0,
+        "use_atr_filter": true,
+        "atr_min_pct": 0.0078
+      },
+      {
+        "band_distance_threshold": 0.0049,
+        "rsi_oversold": 35,
+        "rsi_overbought": 70
+      },
+      {
+        "cci_buy_threshold": 100,
+        "cci_sell_threshold": -100,
+        "atr_min_pct": 0.0114
+      },
+      {
+        "vwap_atr_multiplier": 2.02,
+        "rsi_oversold": 40,
+        "rsi_overbought": 60
+      },
+      {
+        "rsi_reclaim_level": 50,
+        "min_trend_strength_pct": 0.0089,
+        "max_pullback_distance_pct": 0.0291,
+        "vwap_pullback_distance_pct": 0.0151,
+        "min_atr_pct": 0.0064,
+        "min_macd_hist": -0.0084,
+        "strong_trend_strength_pct": 0.0153,
+        "continuation_rsi_level": 52,
+        "continuation_max_vwap_distance_pct": 0.0434,
+        "continuation_max_ema50_extension_pct": 0.0361,
+        "continuation_min_macd_hist": -0.0054
+      }
+    ],
+    "aggregator_config": {
+      "buy_threshold": 0.5,
+      "buy_threshold_uptrend": 0.5,
+      "sell_threshold": -0.79,
+      "btc_regime_filter_enabled": true,
+      "btc_reference_symbol": "BTCUSDT",
+      "btc_dump_threshold_pct": -1.0,
+      "btc_dump_require_below_ema200": true,
+      "min_confidence": 0.04
+    },
+    "time_stop_minutes": 0.0,
+    "replay_sentiment_path": null,
+    "replay_sentiment_max_age_seconds": null,
+    "futures_mode": true,
+    "futures_leverage": 3,
+    "futures_funding_rate": 0.0001,
+    "funding_cadence": "scaled_8h",
+    "fixed_notional_usdt": 0.0,
+    "quantity_step_size": 0.0,
+    "min_notional_usdt": 0.0
+  },
+  "cost_audit": {
+    "name": "corrected",
+    "fee_rate": 0.0004,
+    "slippage_pct": 0.0002,
+    "apply_global_trend_filter": true,
+    "funding_cadence": "scaled_8h",
+    "base_futures_funding_rate": 0.0001,
+    "round_trip_cost_pct": 0.12000000000000001,
+    "funding_method": "scale per-bar rate by tf_hours/8 (equivalent to 8h settlement cadence)",
+    "effective_futures_funding_rate": 1.25e-05
+  },
+  "global_trend_filter_audit": {
+    "active": true,
+    "buffer_pct": 0.0,
+    "source": "cost_profile_override",
+    "config_explicit": null
+  },
+  "buy_threshold_binding_audit": {
+    "aggregator.buy_threshold": 0.5,
+    "aggregator.buy_threshold_uptrend": 0.5,
+    "per_symbol_aggregator_config.SOLUSDT.buy_threshold": 0.5,
+    "per_symbol_aggregator_config.SOLUSDT.buy_threshold_uptrend": 0.5
+  },
+  "effective_start": "2024-01-09",
+  "effective_end": "2026-02-23",
+  "coverage": {
+    "requested_start": "2024-01-01",
+    "requested_end": "2026-06-01",
+    "data_start": "2024-01-09T07:00:00+00:00",
+    "data_end": "2026-02-23T19:00:00+00:00",
+    "effective_start": "2024-01-09",
+    "effective_end": "2026-02-23",
+    "clamped_start": true,
+    "clamped_end": true
+  }
+}

--- a/research/overlay-threshold-sweep/0.60.json
+++ b/research/overlay-threshold-sweep/0.60.json
@@ -1,0 +1,225 @@
+{
+  "buy_threshold": 0.6,
+  "summary": {
+    "symbol": "SOLUSDT",
+    "timeframe": "1h",
+    "start": "2024-01-09",
+    "end": "2026-02-23",
+    "total_trades": 357,
+    "win_rate": 58.543417366946784,
+    "total_return_pct": -96.71344598608319,
+    "max_drawdown_pct": 97.50709786965834,
+    "sharpe_ratio": -1.1871069949894264,
+    "wfo_windows": 3,
+    "wfo_total_trades": 121,
+    "wfo_mean_sharpe": -0.488139525974997,
+    "wfo_total_return_pct": -50.734290366303945,
+    "bootstrap_p_loss_pct": 99.6,
+    "mc_drawdown_p95_pct": 99.75626123945236,
+    "mc_drawdown_p50_pct": 97.79726432240965,
+    "profit_concentration_pct": 100.0,
+    "passes_gates": false,
+    "failure_reasons": [
+      "min_wfo_sharpe failed (-0.49 < 0.50)",
+      "max_drawdown_pct failed (97.51% > 10.00%)",
+      "max_bootstrap_p_loss_pct failed (99.60% > 25.00%)",
+      "min_oos_return_pct failed (-50.73% < 0.00%)",
+      "max_profit_concentration_pct failed (100.00% > 50.00%)"
+    ],
+    "blocked_buy_count": 0,
+    "basis_blocked_buy_count": 0,
+    "dislocation_blocked_buy_count": 0
+  },
+  "gates": {
+    "min_trades": 0,
+    "min_wfo_trades": 20,
+    "min_wfo_sharpe": 0.5,
+    "max_drawdown_pct": 10.0,
+    "max_bootstrap_p_loss_pct": 25.0,
+    "min_oos_return_pct": 0.0,
+    "max_profit_concentration_pct": 50.0,
+    "max_mc_drawdown_p95_pct": 0.0
+  },
+  "windows": [
+    {
+      "window_index": 1,
+      "train_start": "2024-01-09T00:00:00",
+      "train_end": "2024-07-09T00:00:00",
+      "test_start": "2024-07-09T00:00:00",
+      "test_end": "2024-10-09T00:00:00",
+      "total_trades": 40,
+      "win_rate": 65.0,
+      "total_return_pct": -1.9167119943087527,
+      "max_drawdown_pct": 28.507157893495695,
+      "sharpe_ratio": 0.24174747545886863
+    },
+    {
+      "window_index": 2,
+      "train_start": "2024-07-09T00:00:00",
+      "train_end": "2025-01-09T00:00:00",
+      "test_start": "2025-01-09T00:00:00",
+      "test_end": "2025-04-09T00:00:00",
+      "total_trades": 26,
+      "win_rate": 53.84615384615385,
+      "total_return_pct": -25.918977958710965,
+      "max_drawdown_pct": 38.52762055121766,
+      "sharpe_ratio": -0.28426060285470245
+    },
+    {
+      "window_index": 3,
+      "train_start": "2025-01-09T00:00:00",
+      "train_end": "2025-07-09T00:00:00",
+      "test_start": "2025-07-09T00:00:00",
+      "test_end": "2025-10-09T00:00:00",
+      "total_trades": 55,
+      "win_rate": 60.0,
+      "total_return_pct": -32.197959929359705,
+      "max_drawdown_pct": 48.442398580021354,
+      "sharpe_ratio": -1.421905450529157
+    }
+  ],
+  "resolved_backtest_config": {
+    "symbol": "SOLUSDT",
+    "timeframe": "1h",
+    "start_date": "2024-01-09",
+    "end_date": "2026-02-23",
+    "initial_capital": 10000.0,
+    "fee_rate": 0.0004,
+    "stop_loss_pct": 0.01,
+    "take_profit_pct": 0.03,
+    "sl_atr_multiplier": 2.38,
+    "tp_atr_multiplier": 4.23,
+    "trailing_activate_atr": 1.82,
+    "trailing_offset_atr": 1.07,
+    "slippage_pct": 0.0002,
+    "risk_per_trade": 0.02,
+    "use_atr_sizing": false,
+    "atr_multiplier": 1.0,
+    "apply_global_trend_filter": true,
+    "global_trend_filter_buffer_pct": 0.0,
+    "global_trend_filter_source": "cost_profile_override",
+    "config_global_trend_filter_enabled": null,
+    "session_liquidity_router": {
+      "enabled": false,
+      "allowed_windows": [
+        "americas"
+      ],
+      "block_entries_outside_windows": true
+    },
+    "basis_premium_filter": {
+      "enabled": false,
+      "exchange": "binance_usdm",
+      "tail_metric": "basis_bps",
+      "positive_tail_pct": 0.05,
+      "block_positive_tail_longs": true,
+      "missing_data_policy": "allow",
+      "calibrated_positive_threshold": null
+    },
+    "cross_venue_dislocation": {
+      "enabled": false,
+      "metric": "basis_spread",
+      "mode": "require",
+      "min_spread_bps": 5.0,
+      "side": "both",
+      "missing_data_policy": "allow"
+    },
+    "allow_short": false,
+    "use_executor_exit_model": true,
+    "ignore_signal_sells": false,
+    "strategy_configs": [
+      {
+        "rsi_period": 7,
+        "oversold_threshold": 35,
+        "overbought_threshold": 65
+      },
+      {
+        "min_histogram_threshold": 0.0,
+        "use_atr_filter": true,
+        "atr_min_pct": 0.0078
+      },
+      {
+        "band_distance_threshold": 0.0049,
+        "rsi_oversold": 35,
+        "rsi_overbought": 70
+      },
+      {
+        "cci_buy_threshold": 100,
+        "cci_sell_threshold": -100,
+        "atr_min_pct": 0.0114
+      },
+      {
+        "vwap_atr_multiplier": 2.02,
+        "rsi_oversold": 40,
+        "rsi_overbought": 60
+      },
+      {
+        "rsi_reclaim_level": 50,
+        "min_trend_strength_pct": 0.0089,
+        "max_pullback_distance_pct": 0.0291,
+        "vwap_pullback_distance_pct": 0.0151,
+        "min_atr_pct": 0.0064,
+        "min_macd_hist": -0.0084,
+        "strong_trend_strength_pct": 0.0153,
+        "continuation_rsi_level": 52,
+        "continuation_max_vwap_distance_pct": 0.0434,
+        "continuation_max_ema50_extension_pct": 0.0361,
+        "continuation_min_macd_hist": -0.0054
+      }
+    ],
+    "aggregator_config": {
+      "buy_threshold": 0.6,
+      "buy_threshold_uptrend": 0.6,
+      "sell_threshold": -0.79,
+      "btc_regime_filter_enabled": true,
+      "btc_reference_symbol": "BTCUSDT",
+      "btc_dump_threshold_pct": -1.0,
+      "btc_dump_require_below_ema200": true,
+      "min_confidence": 0.04
+    },
+    "time_stop_minutes": 0.0,
+    "replay_sentiment_path": null,
+    "replay_sentiment_max_age_seconds": null,
+    "futures_mode": true,
+    "futures_leverage": 3,
+    "futures_funding_rate": 0.0001,
+    "funding_cadence": "scaled_8h",
+    "fixed_notional_usdt": 0.0,
+    "quantity_step_size": 0.0,
+    "min_notional_usdt": 0.0
+  },
+  "cost_audit": {
+    "name": "corrected",
+    "fee_rate": 0.0004,
+    "slippage_pct": 0.0002,
+    "apply_global_trend_filter": true,
+    "funding_cadence": "scaled_8h",
+    "base_futures_funding_rate": 0.0001,
+    "round_trip_cost_pct": 0.12000000000000001,
+    "funding_method": "scale per-bar rate by tf_hours/8 (equivalent to 8h settlement cadence)",
+    "effective_futures_funding_rate": 1.25e-05
+  },
+  "global_trend_filter_audit": {
+    "active": true,
+    "buffer_pct": 0.0,
+    "source": "cost_profile_override",
+    "config_explicit": null
+  },
+  "buy_threshold_binding_audit": {
+    "aggregator.buy_threshold": 0.6,
+    "aggregator.buy_threshold_uptrend": 0.6,
+    "per_symbol_aggregator_config.SOLUSDT.buy_threshold": 0.6,
+    "per_symbol_aggregator_config.SOLUSDT.buy_threshold_uptrend": 0.6
+  },
+  "effective_start": "2024-01-09",
+  "effective_end": "2026-02-23",
+  "coverage": {
+    "requested_start": "2024-01-01",
+    "requested_end": "2026-06-01",
+    "data_start": "2024-01-09T07:00:00+00:00",
+    "data_end": "2026-02-23T19:00:00+00:00",
+    "effective_start": "2024-01-09",
+    "effective_end": "2026-02-23",
+    "clamped_start": true,
+    "clamped_end": true
+  }
+}

--- a/research/overlay-threshold-sweep/0.70.json
+++ b/research/overlay-threshold-sweep/0.70.json
@@ -1,0 +1,225 @@
+{
+  "buy_threshold": 0.7,
+  "summary": {
+    "symbol": "SOLUSDT",
+    "timeframe": "1h",
+    "start": "2024-01-09",
+    "end": "2026-02-23",
+    "total_trades": 223,
+    "win_rate": 56.05381165919282,
+    "total_return_pct": -92.60528040232914,
+    "max_drawdown_pct": 93.89931682723264,
+    "sharpe_ratio": -1.128667516847773,
+    "wfo_windows": 3,
+    "wfo_total_trades": 70,
+    "wfo_mean_sharpe": -0.3330592093800882,
+    "wfo_total_return_pct": -26.079959723551195,
+    "bootstrap_p_loss_pct": 98.6,
+    "mc_drawdown_p95_pct": 99.12674500154058,
+    "mc_drawdown_p50_pct": 94.63808156904398,
+    "profit_concentration_pct": 100.0,
+    "passes_gates": false,
+    "failure_reasons": [
+      "min_wfo_sharpe failed (-0.33 < 0.50)",
+      "max_drawdown_pct failed (93.90% > 10.00%)",
+      "max_bootstrap_p_loss_pct failed (98.60% > 25.00%)",
+      "min_oos_return_pct failed (-26.08% < 0.00%)",
+      "max_profit_concentration_pct failed (100.00% > 50.00%)"
+    ],
+    "blocked_buy_count": 0,
+    "basis_blocked_buy_count": 0,
+    "dislocation_blocked_buy_count": 0
+  },
+  "gates": {
+    "min_trades": 0,
+    "min_wfo_trades": 20,
+    "min_wfo_sharpe": 0.5,
+    "max_drawdown_pct": 10.0,
+    "max_bootstrap_p_loss_pct": 25.0,
+    "min_oos_return_pct": 0.0,
+    "max_profit_concentration_pct": 50.0,
+    "max_mc_drawdown_p95_pct": 0.0
+  },
+  "windows": [
+    {
+      "window_index": 1,
+      "train_start": "2024-01-09T00:00:00",
+      "train_end": "2024-07-09T00:00:00",
+      "test_start": "2024-07-09T00:00:00",
+      "test_end": "2024-10-09T00:00:00",
+      "total_trades": 24,
+      "win_rate": 58.333333333333336,
+      "total_return_pct": -6.562311417841739,
+      "max_drawdown_pct": 16.74458980303397,
+      "sharpe_ratio": -0.22382045727092628
+    },
+    {
+      "window_index": 2,
+      "train_start": "2024-07-09T00:00:00",
+      "train_end": "2025-01-09T00:00:00",
+      "test_start": "2025-01-09T00:00:00",
+      "test_end": "2025-04-09T00:00:00",
+      "total_trades": 17,
+      "win_rate": 64.70588235294117,
+      "total_return_pct": 11.349256734105456,
+      "max_drawdown_pct": 37.734113228588825,
+      "sharpe_ratio": 0.9533200769574743
+    },
+    {
+      "window_index": 3,
+      "train_start": "2025-01-09T00:00:00",
+      "train_end": "2025-07-09T00:00:00",
+      "test_start": "2025-07-09T00:00:00",
+      "test_end": "2025-10-09T00:00:00",
+      "total_trades": 29,
+      "win_rate": 58.620689655172406,
+      "total_return_pct": -28.951848047654483,
+      "max_drawdown_pct": 40.58111229275764,
+      "sharpe_ratio": -1.7286772478268126
+    }
+  ],
+  "resolved_backtest_config": {
+    "symbol": "SOLUSDT",
+    "timeframe": "1h",
+    "start_date": "2024-01-09",
+    "end_date": "2026-02-23",
+    "initial_capital": 10000.0,
+    "fee_rate": 0.0004,
+    "stop_loss_pct": 0.01,
+    "take_profit_pct": 0.03,
+    "sl_atr_multiplier": 2.38,
+    "tp_atr_multiplier": 4.23,
+    "trailing_activate_atr": 1.82,
+    "trailing_offset_atr": 1.07,
+    "slippage_pct": 0.0002,
+    "risk_per_trade": 0.02,
+    "use_atr_sizing": false,
+    "atr_multiplier": 1.0,
+    "apply_global_trend_filter": true,
+    "global_trend_filter_buffer_pct": 0.0,
+    "global_trend_filter_source": "cost_profile_override",
+    "config_global_trend_filter_enabled": null,
+    "session_liquidity_router": {
+      "enabled": false,
+      "allowed_windows": [
+        "americas"
+      ],
+      "block_entries_outside_windows": true
+    },
+    "basis_premium_filter": {
+      "enabled": false,
+      "exchange": "binance_usdm",
+      "tail_metric": "basis_bps",
+      "positive_tail_pct": 0.05,
+      "block_positive_tail_longs": true,
+      "missing_data_policy": "allow",
+      "calibrated_positive_threshold": null
+    },
+    "cross_venue_dislocation": {
+      "enabled": false,
+      "metric": "basis_spread",
+      "mode": "require",
+      "min_spread_bps": 5.0,
+      "side": "both",
+      "missing_data_policy": "allow"
+    },
+    "allow_short": false,
+    "use_executor_exit_model": true,
+    "ignore_signal_sells": false,
+    "strategy_configs": [
+      {
+        "rsi_period": 7,
+        "oversold_threshold": 35,
+        "overbought_threshold": 65
+      },
+      {
+        "min_histogram_threshold": 0.0,
+        "use_atr_filter": true,
+        "atr_min_pct": 0.0078
+      },
+      {
+        "band_distance_threshold": 0.0049,
+        "rsi_oversold": 35,
+        "rsi_overbought": 70
+      },
+      {
+        "cci_buy_threshold": 100,
+        "cci_sell_threshold": -100,
+        "atr_min_pct": 0.0114
+      },
+      {
+        "vwap_atr_multiplier": 2.02,
+        "rsi_oversold": 40,
+        "rsi_overbought": 60
+      },
+      {
+        "rsi_reclaim_level": 50,
+        "min_trend_strength_pct": 0.0089,
+        "max_pullback_distance_pct": 0.0291,
+        "vwap_pullback_distance_pct": 0.0151,
+        "min_atr_pct": 0.0064,
+        "min_macd_hist": -0.0084,
+        "strong_trend_strength_pct": 0.0153,
+        "continuation_rsi_level": 52,
+        "continuation_max_vwap_distance_pct": 0.0434,
+        "continuation_max_ema50_extension_pct": 0.0361,
+        "continuation_min_macd_hist": -0.0054
+      }
+    ],
+    "aggregator_config": {
+      "buy_threshold": 0.7,
+      "buy_threshold_uptrend": 0.7,
+      "sell_threshold": -0.79,
+      "btc_regime_filter_enabled": true,
+      "btc_reference_symbol": "BTCUSDT",
+      "btc_dump_threshold_pct": -1.0,
+      "btc_dump_require_below_ema200": true,
+      "min_confidence": 0.04
+    },
+    "time_stop_minutes": 0.0,
+    "replay_sentiment_path": null,
+    "replay_sentiment_max_age_seconds": null,
+    "futures_mode": true,
+    "futures_leverage": 3,
+    "futures_funding_rate": 0.0001,
+    "funding_cadence": "scaled_8h",
+    "fixed_notional_usdt": 0.0,
+    "quantity_step_size": 0.0,
+    "min_notional_usdt": 0.0
+  },
+  "cost_audit": {
+    "name": "corrected",
+    "fee_rate": 0.0004,
+    "slippage_pct": 0.0002,
+    "apply_global_trend_filter": true,
+    "funding_cadence": "scaled_8h",
+    "base_futures_funding_rate": 0.0001,
+    "round_trip_cost_pct": 0.12000000000000001,
+    "funding_method": "scale per-bar rate by tf_hours/8 (equivalent to 8h settlement cadence)",
+    "effective_futures_funding_rate": 1.25e-05
+  },
+  "global_trend_filter_audit": {
+    "active": true,
+    "buffer_pct": 0.0,
+    "source": "cost_profile_override",
+    "config_explicit": null
+  },
+  "buy_threshold_binding_audit": {
+    "aggregator.buy_threshold": 0.7,
+    "aggregator.buy_threshold_uptrend": 0.7,
+    "per_symbol_aggregator_config.SOLUSDT.buy_threshold": 0.7,
+    "per_symbol_aggregator_config.SOLUSDT.buy_threshold_uptrend": 0.7
+  },
+  "effective_start": "2024-01-09",
+  "effective_end": "2026-02-23",
+  "coverage": {
+    "requested_start": "2024-01-01",
+    "requested_end": "2026-06-01",
+    "data_start": "2024-01-09T07:00:00+00:00",
+    "data_end": "2026-02-23T19:00:00+00:00",
+    "effective_start": "2024-01-09",
+    "effective_end": "2026-02-23",
+    "clamped_start": true,
+    "clamped_end": true
+  }
+}

--- a/research/overlay-threshold-sweep/0.80.json
+++ b/research/overlay-threshold-sweep/0.80.json
@@ -1,0 +1,225 @@
+{
+  "buy_threshold": 0.8,
+  "summary": {
+    "symbol": "SOLUSDT",
+    "timeframe": "1h",
+    "start": "2024-01-09",
+    "end": "2026-02-23",
+    "total_trades": 149,
+    "win_rate": 56.375838926174495,
+    "total_return_pct": -74.68405346080712,
+    "max_drawdown_pct": 79.15236733302814,
+    "sharpe_ratio": -0.5892349272071247,
+    "wfo_windows": 3,
+    "wfo_total_trades": 51,
+    "wfo_mean_sharpe": -0.3970070274588852,
+    "wfo_total_return_pct": -17.44728462571833,
+    "bootstrap_p_loss_pct": 91.2,
+    "mc_drawdown_p95_pct": 96.8279070069929,
+    "mc_drawdown_p50_pct": 83.49766254997158,
+    "profit_concentration_pct": 100.0,
+    "passes_gates": false,
+    "failure_reasons": [
+      "min_wfo_sharpe failed (-0.40 < 0.50)",
+      "max_drawdown_pct failed (79.15% > 10.00%)",
+      "max_bootstrap_p_loss_pct failed (91.20% > 25.00%)",
+      "min_oos_return_pct failed (-17.45% < 0.00%)",
+      "max_profit_concentration_pct failed (100.00% > 50.00%)"
+    ],
+    "blocked_buy_count": 0,
+    "basis_blocked_buy_count": 0,
+    "dislocation_blocked_buy_count": 0
+  },
+  "gates": {
+    "min_trades": 0,
+    "min_wfo_trades": 20,
+    "min_wfo_sharpe": 0.5,
+    "max_drawdown_pct": 10.0,
+    "max_bootstrap_p_loss_pct": 25.0,
+    "min_oos_return_pct": 0.0,
+    "max_profit_concentration_pct": 50.0,
+    "max_mc_drawdown_p95_pct": 0.0
+  },
+  "windows": [
+    {
+      "window_index": 1,
+      "train_start": "2024-01-09T00:00:00",
+      "train_end": "2024-07-09T00:00:00",
+      "test_start": "2024-07-09T00:00:00",
+      "test_end": "2024-10-09T00:00:00",
+      "total_trades": 15,
+      "win_rate": 46.666666666666664,
+      "total_return_pct": -12.753205275044985,
+      "max_drawdown_pct": 17.117412243230806,
+      "sharpe_ratio": -0.8917853051657967
+    },
+    {
+      "window_index": 2,
+      "train_start": "2024-07-09T00:00:00",
+      "train_end": "2025-01-09T00:00:00",
+      "test_start": "2025-01-09T00:00:00",
+      "test_end": "2025-04-09T00:00:00",
+      "total_trades": 11,
+      "win_rate": 72.72727272727273,
+      "total_return_pct": 30.208154120926515,
+      "max_drawdown_pct": 37.734113228588825,
+      "sharpe_ratio": 1.4864021231687852
+    },
+    {
+      "window_index": 3,
+      "train_start": "2025-01-09T00:00:00",
+      "train_end": "2025-07-09T00:00:00",
+      "test_start": "2025-07-09T00:00:00",
+      "test_end": "2025-10-09T00:00:00",
+      "total_trades": 25,
+      "win_rate": 56.00000000000001,
+      "total_return_pct": -27.33191761510797,
+      "max_drawdown_pct": 35.302406181640606,
+      "sharpe_ratio": -1.785637900379644
+    }
+  ],
+  "resolved_backtest_config": {
+    "symbol": "SOLUSDT",
+    "timeframe": "1h",
+    "start_date": "2024-01-09",
+    "end_date": "2026-02-23",
+    "initial_capital": 10000.0,
+    "fee_rate": 0.0004,
+    "stop_loss_pct": 0.01,
+    "take_profit_pct": 0.03,
+    "sl_atr_multiplier": 2.38,
+    "tp_atr_multiplier": 4.23,
+    "trailing_activate_atr": 1.82,
+    "trailing_offset_atr": 1.07,
+    "slippage_pct": 0.0002,
+    "risk_per_trade": 0.02,
+    "use_atr_sizing": false,
+    "atr_multiplier": 1.0,
+    "apply_global_trend_filter": true,
+    "global_trend_filter_buffer_pct": 0.0,
+    "global_trend_filter_source": "cost_profile_override",
+    "config_global_trend_filter_enabled": null,
+    "session_liquidity_router": {
+      "enabled": false,
+      "allowed_windows": [
+        "americas"
+      ],
+      "block_entries_outside_windows": true
+    },
+    "basis_premium_filter": {
+      "enabled": false,
+      "exchange": "binance_usdm",
+      "tail_metric": "basis_bps",
+      "positive_tail_pct": 0.05,
+      "block_positive_tail_longs": true,
+      "missing_data_policy": "allow",
+      "calibrated_positive_threshold": null
+    },
+    "cross_venue_dislocation": {
+      "enabled": false,
+      "metric": "basis_spread",
+      "mode": "require",
+      "min_spread_bps": 5.0,
+      "side": "both",
+      "missing_data_policy": "allow"
+    },
+    "allow_short": false,
+    "use_executor_exit_model": true,
+    "ignore_signal_sells": false,
+    "strategy_configs": [
+      {
+        "rsi_period": 7,
+        "oversold_threshold": 35,
+        "overbought_threshold": 65
+      },
+      {
+        "min_histogram_threshold": 0.0,
+        "use_atr_filter": true,
+        "atr_min_pct": 0.0078
+      },
+      {
+        "band_distance_threshold": 0.0049,
+        "rsi_oversold": 35,
+        "rsi_overbought": 70
+      },
+      {
+        "cci_buy_threshold": 100,
+        "cci_sell_threshold": -100,
+        "atr_min_pct": 0.0114
+      },
+      {
+        "vwap_atr_multiplier": 2.02,
+        "rsi_oversold": 40,
+        "rsi_overbought": 60
+      },
+      {
+        "rsi_reclaim_level": 50,
+        "min_trend_strength_pct": 0.0089,
+        "max_pullback_distance_pct": 0.0291,
+        "vwap_pullback_distance_pct": 0.0151,
+        "min_atr_pct": 0.0064,
+        "min_macd_hist": -0.0084,
+        "strong_trend_strength_pct": 0.0153,
+        "continuation_rsi_level": 52,
+        "continuation_max_vwap_distance_pct": 0.0434,
+        "continuation_max_ema50_extension_pct": 0.0361,
+        "continuation_min_macd_hist": -0.0054
+      }
+    ],
+    "aggregator_config": {
+      "buy_threshold": 0.8,
+      "buy_threshold_uptrend": 0.8,
+      "sell_threshold": -0.79,
+      "btc_regime_filter_enabled": true,
+      "btc_reference_symbol": "BTCUSDT",
+      "btc_dump_threshold_pct": -1.0,
+      "btc_dump_require_below_ema200": true,
+      "min_confidence": 0.04
+    },
+    "time_stop_minutes": 0.0,
+    "replay_sentiment_path": null,
+    "replay_sentiment_max_age_seconds": null,
+    "futures_mode": true,
+    "futures_leverage": 3,
+    "futures_funding_rate": 0.0001,
+    "funding_cadence": "scaled_8h",
+    "fixed_notional_usdt": 0.0,
+    "quantity_step_size": 0.0,
+    "min_notional_usdt": 0.0
+  },
+  "cost_audit": {
+    "name": "corrected",
+    "fee_rate": 0.0004,
+    "slippage_pct": 0.0002,
+    "apply_global_trend_filter": true,
+    "funding_cadence": "scaled_8h",
+    "base_futures_funding_rate": 0.0001,
+    "round_trip_cost_pct": 0.12000000000000001,
+    "funding_method": "scale per-bar rate by tf_hours/8 (equivalent to 8h settlement cadence)",
+    "effective_futures_funding_rate": 1.25e-05
+  },
+  "global_trend_filter_audit": {
+    "active": true,
+    "buffer_pct": 0.0,
+    "source": "cost_profile_override",
+    "config_explicit": null
+  },
+  "buy_threshold_binding_audit": {
+    "aggregator.buy_threshold": 0.8,
+    "aggregator.buy_threshold_uptrend": 0.8,
+    "per_symbol_aggregator_config.SOLUSDT.buy_threshold": 0.8,
+    "per_symbol_aggregator_config.SOLUSDT.buy_threshold_uptrend": 0.8
+  },
+  "effective_start": "2024-01-09",
+  "effective_end": "2026-02-23",
+  "coverage": {
+    "requested_start": "2024-01-01",
+    "requested_end": "2026-06-01",
+    "data_start": "2024-01-09T07:00:00+00:00",
+    "data_end": "2026-02-23T19:00:00+00:00",
+    "effective_start": "2024-01-09",
+    "effective_end": "2026-02-23",
+    "clamped_start": true,
+    "clamped_end": true
+  }
+}

--- a/research/overlay-threshold-sweep/0.90.json
+++ b/research/overlay-threshold-sweep/0.90.json
@@ -1,0 +1,224 @@
+{
+  "buy_threshold": 0.9,
+  "summary": {
+    "symbol": "SOLUSDT",
+    "timeframe": "1h",
+    "start": "2024-01-09",
+    "end": "2026-02-23",
+    "total_trades": 112,
+    "win_rate": 58.03571428571429,
+    "total_return_pct": -66.41679525052224,
+    "max_drawdown_pct": 76.66761717470757,
+    "sharpe_ratio": -0.5090939863413726,
+    "wfo_windows": 3,
+    "wfo_total_trades": 41,
+    "wfo_mean_sharpe": 0.3598716584588384,
+    "wfo_total_return_pct": 3.418606401869506,
+    "bootstrap_p_loss_pct": 86.8,
+    "mc_drawdown_p95_pct": 94.37039160281834,
+    "mc_drawdown_p50_pct": 77.1260260671864,
+    "profit_concentration_pct": 60.39839944891576,
+    "passes_gates": false,
+    "failure_reasons": [
+      "min_wfo_sharpe failed (0.36 < 0.50)",
+      "max_drawdown_pct failed (76.67% > 10.00%)",
+      "max_bootstrap_p_loss_pct failed (86.80% > 25.00%)",
+      "max_profit_concentration_pct failed (60.40% > 50.00%)"
+    ],
+    "blocked_buy_count": 0,
+    "basis_blocked_buy_count": 0,
+    "dislocation_blocked_buy_count": 0
+  },
+  "gates": {
+    "min_trades": 0,
+    "min_wfo_trades": 20,
+    "min_wfo_sharpe": 0.5,
+    "max_drawdown_pct": 10.0,
+    "max_bootstrap_p_loss_pct": 25.0,
+    "min_oos_return_pct": 0.0,
+    "max_profit_concentration_pct": 50.0,
+    "max_mc_drawdown_p95_pct": 0.0
+  },
+  "windows": [
+    {
+      "window_index": 1,
+      "train_start": "2024-01-09T00:00:00",
+      "train_end": "2024-07-09T00:00:00",
+      "test_start": "2024-07-09T00:00:00",
+      "test_end": "2024-10-09T00:00:00",
+      "total_trades": 11,
+      "win_rate": 54.54545454545454,
+      "total_return_pct": 8.906816612389248,
+      "max_drawdown_pct": 11.847805201905258,
+      "sharpe_ratio": 0.9770497308856578
+    },
+    {
+      "window_index": 2,
+      "train_start": "2024-07-09T00:00:00",
+      "train_end": "2025-01-09T00:00:00",
+      "test_start": "2025-01-09T00:00:00",
+      "test_end": "2025-04-09T00:00:00",
+      "total_trades": 8,
+      "win_rate": 75.0,
+      "total_return_pct": 13.584235487638544,
+      "max_drawdown_pct": 39.54701664853449,
+      "sharpe_ratio": 1.0005749939770148
+    },
+    {
+      "window_index": 3,
+      "train_start": "2025-01-09T00:00:00",
+      "train_end": "2025-07-09T00:00:00",
+      "test_start": "2025-07-09T00:00:00",
+      "test_end": "2025-10-09T00:00:00",
+      "total_trades": 22,
+      "win_rate": 59.09090909090909,
+      "total_return_pct": -16.39628841581034,
+      "max_drawdown_pct": 30.264472131573854,
+      "sharpe_ratio": -0.8980097494861574
+    }
+  ],
+  "resolved_backtest_config": {
+    "symbol": "SOLUSDT",
+    "timeframe": "1h",
+    "start_date": "2024-01-09",
+    "end_date": "2026-02-23",
+    "initial_capital": 10000.0,
+    "fee_rate": 0.0004,
+    "stop_loss_pct": 0.01,
+    "take_profit_pct": 0.03,
+    "sl_atr_multiplier": 2.38,
+    "tp_atr_multiplier": 4.23,
+    "trailing_activate_atr": 1.82,
+    "trailing_offset_atr": 1.07,
+    "slippage_pct": 0.0002,
+    "risk_per_trade": 0.02,
+    "use_atr_sizing": false,
+    "atr_multiplier": 1.0,
+    "apply_global_trend_filter": true,
+    "global_trend_filter_buffer_pct": 0.0,
+    "global_trend_filter_source": "cost_profile_override",
+    "config_global_trend_filter_enabled": null,
+    "session_liquidity_router": {
+      "enabled": false,
+      "allowed_windows": [
+        "americas"
+      ],
+      "block_entries_outside_windows": true
+    },
+    "basis_premium_filter": {
+      "enabled": false,
+      "exchange": "binance_usdm",
+      "tail_metric": "basis_bps",
+      "positive_tail_pct": 0.05,
+      "block_positive_tail_longs": true,
+      "missing_data_policy": "allow",
+      "calibrated_positive_threshold": null
+    },
+    "cross_venue_dislocation": {
+      "enabled": false,
+      "metric": "basis_spread",
+      "mode": "require",
+      "min_spread_bps": 5.0,
+      "side": "both",
+      "missing_data_policy": "allow"
+    },
+    "allow_short": false,
+    "use_executor_exit_model": true,
+    "ignore_signal_sells": false,
+    "strategy_configs": [
+      {
+        "rsi_period": 7,
+        "oversold_threshold": 35,
+        "overbought_threshold": 65
+      },
+      {
+        "min_histogram_threshold": 0.0,
+        "use_atr_filter": true,
+        "atr_min_pct": 0.0078
+      },
+      {
+        "band_distance_threshold": 0.0049,
+        "rsi_oversold": 35,
+        "rsi_overbought": 70
+      },
+      {
+        "cci_buy_threshold": 100,
+        "cci_sell_threshold": -100,
+        "atr_min_pct": 0.0114
+      },
+      {
+        "vwap_atr_multiplier": 2.02,
+        "rsi_oversold": 40,
+        "rsi_overbought": 60
+      },
+      {
+        "rsi_reclaim_level": 50,
+        "min_trend_strength_pct": 0.0089,
+        "max_pullback_distance_pct": 0.0291,
+        "vwap_pullback_distance_pct": 0.0151,
+        "min_atr_pct": 0.0064,
+        "min_macd_hist": -0.0084,
+        "strong_trend_strength_pct": 0.0153,
+        "continuation_rsi_level": 52,
+        "continuation_max_vwap_distance_pct": 0.0434,
+        "continuation_max_ema50_extension_pct": 0.0361,
+        "continuation_min_macd_hist": -0.0054
+      }
+    ],
+    "aggregator_config": {
+      "buy_threshold": 0.9,
+      "buy_threshold_uptrend": 0.9,
+      "sell_threshold": -0.79,
+      "btc_regime_filter_enabled": true,
+      "btc_reference_symbol": "BTCUSDT",
+      "btc_dump_threshold_pct": -1.0,
+      "btc_dump_require_below_ema200": true,
+      "min_confidence": 0.04
+    },
+    "time_stop_minutes": 0.0,
+    "replay_sentiment_path": null,
+    "replay_sentiment_max_age_seconds": null,
+    "futures_mode": true,
+    "futures_leverage": 3,
+    "futures_funding_rate": 0.0001,
+    "funding_cadence": "scaled_8h",
+    "fixed_notional_usdt": 0.0,
+    "quantity_step_size": 0.0,
+    "min_notional_usdt": 0.0
+  },
+  "cost_audit": {
+    "name": "corrected",
+    "fee_rate": 0.0004,
+    "slippage_pct": 0.0002,
+    "apply_global_trend_filter": true,
+    "funding_cadence": "scaled_8h",
+    "base_futures_funding_rate": 0.0001,
+    "round_trip_cost_pct": 0.12000000000000001,
+    "funding_method": "scale per-bar rate by tf_hours/8 (equivalent to 8h settlement cadence)",
+    "effective_futures_funding_rate": 1.25e-05
+  },
+  "global_trend_filter_audit": {
+    "active": true,
+    "buffer_pct": 0.0,
+    "source": "cost_profile_override",
+    "config_explicit": null
+  },
+  "buy_threshold_binding_audit": {
+    "aggregator.buy_threshold": 0.9,
+    "aggregator.buy_threshold_uptrend": 0.9,
+    "per_symbol_aggregator_config.SOLUSDT.buy_threshold": 0.9,
+    "per_symbol_aggregator_config.SOLUSDT.buy_threshold_uptrend": 0.9
+  },
+  "effective_start": "2024-01-09",
+  "effective_end": "2026-02-23",
+  "coverage": {
+    "requested_start": "2024-01-01",
+    "requested_end": "2026-06-01",
+    "data_start": "2024-01-09T07:00:00+00:00",
+    "data_end": "2026-02-23T19:00:00+00:00",
+    "effective_start": "2024-01-09",
+    "effective_end": "2026-02-23",
+    "clamped_start": true,
+    "clamped_end": true
+  }
+}

--- a/research/overlay-threshold-sweep/1.00.json
+++ b/research/overlay-threshold-sweep/1.00.json
@@ -1,0 +1,225 @@
+{
+  "buy_threshold": 1.0,
+  "summary": {
+    "symbol": "SOLUSDT",
+    "timeframe": "1h",
+    "start": "2024-01-09",
+    "end": "2026-02-23",
+    "total_trades": 81,
+    "win_rate": 53.086419753086425,
+    "total_return_pct": -70.89683663960457,
+    "max_drawdown_pct": 79.14492081754365,
+    "sharpe_ratio": -0.7185010551757466,
+    "wfo_windows": 3,
+    "wfo_total_trades": 27,
+    "wfo_mean_sharpe": -0.3553431250158031,
+    "wfo_total_return_pct": -21.58333971788966,
+    "bootstrap_p_loss_pct": 94.8,
+    "mc_drawdown_p95_pct": 93.89342070137401,
+    "mc_drawdown_p50_pct": 78.4644887187165,
+    "profit_concentration_pct": 100.0,
+    "passes_gates": false,
+    "failure_reasons": [
+      "min_wfo_sharpe failed (-0.36 < 0.50)",
+      "max_drawdown_pct failed (79.14% > 10.00%)",
+      "max_bootstrap_p_loss_pct failed (94.80% > 25.00%)",
+      "min_oos_return_pct failed (-21.58% < 0.00%)",
+      "max_profit_concentration_pct failed (100.00% > 50.00%)"
+    ],
+    "blocked_buy_count": 0,
+    "basis_blocked_buy_count": 0,
+    "dislocation_blocked_buy_count": 0
+  },
+  "gates": {
+    "min_trades": 0,
+    "min_wfo_trades": 20,
+    "min_wfo_sharpe": 0.5,
+    "max_drawdown_pct": 10.0,
+    "max_bootstrap_p_loss_pct": 25.0,
+    "min_oos_return_pct": 0.0,
+    "max_profit_concentration_pct": 50.0,
+    "max_mc_drawdown_p95_pct": 0.0
+  },
+  "windows": [
+    {
+      "window_index": 1,
+      "train_start": "2024-01-09T00:00:00",
+      "train_end": "2024-07-09T00:00:00",
+      "test_start": "2024-07-09T00:00:00",
+      "test_end": "2024-10-09T00:00:00",
+      "total_trades": 8,
+      "win_rate": 50.0,
+      "total_return_pct": -3.8144790727410514,
+      "max_drawdown_pct": 10.407163978498318,
+      "sharpe_ratio": -0.2742964326449168
+    },
+    {
+      "window_index": 2,
+      "train_start": "2024-07-09T00:00:00",
+      "train_end": "2025-01-09T00:00:00",
+      "test_start": "2025-01-09T00:00:00",
+      "test_end": "2025-04-09T00:00:00",
+      "total_trades": 5,
+      "win_rate": 60.0,
+      "total_return_pct": -0.28662798096333064,
+      "max_drawdown_pct": 39.54701664853449,
+      "sharpe_ratio": 0.49712660137466347
+    },
+    {
+      "window_index": 3,
+      "train_start": "2025-01-09T00:00:00",
+      "train_end": "2025-07-09T00:00:00",
+      "test_start": "2025-07-09T00:00:00",
+      "test_end": "2025-10-09T00:00:00",
+      "total_trades": 14,
+      "win_rate": 50.0,
+      "total_return_pct": -18.239180177301595,
+      "max_drawdown_pct": 25.533028234829214,
+      "sharpe_ratio": -1.288859543777156
+    }
+  ],
+  "resolved_backtest_config": {
+    "symbol": "SOLUSDT",
+    "timeframe": "1h",
+    "start_date": "2024-01-09",
+    "end_date": "2026-02-23",
+    "initial_capital": 10000.0,
+    "fee_rate": 0.0004,
+    "stop_loss_pct": 0.01,
+    "take_profit_pct": 0.03,
+    "sl_atr_multiplier": 2.38,
+    "tp_atr_multiplier": 4.23,
+    "trailing_activate_atr": 1.82,
+    "trailing_offset_atr": 1.07,
+    "slippage_pct": 0.0002,
+    "risk_per_trade": 0.02,
+    "use_atr_sizing": false,
+    "atr_multiplier": 1.0,
+    "apply_global_trend_filter": true,
+    "global_trend_filter_buffer_pct": 0.0,
+    "global_trend_filter_source": "cost_profile_override",
+    "config_global_trend_filter_enabled": null,
+    "session_liquidity_router": {
+      "enabled": false,
+      "allowed_windows": [
+        "americas"
+      ],
+      "block_entries_outside_windows": true
+    },
+    "basis_premium_filter": {
+      "enabled": false,
+      "exchange": "binance_usdm",
+      "tail_metric": "basis_bps",
+      "positive_tail_pct": 0.05,
+      "block_positive_tail_longs": true,
+      "missing_data_policy": "allow",
+      "calibrated_positive_threshold": null
+    },
+    "cross_venue_dislocation": {
+      "enabled": false,
+      "metric": "basis_spread",
+      "mode": "require",
+      "min_spread_bps": 5.0,
+      "side": "both",
+      "missing_data_policy": "allow"
+    },
+    "allow_short": false,
+    "use_executor_exit_model": true,
+    "ignore_signal_sells": false,
+    "strategy_configs": [
+      {
+        "rsi_period": 7,
+        "oversold_threshold": 35,
+        "overbought_threshold": 65
+      },
+      {
+        "min_histogram_threshold": 0.0,
+        "use_atr_filter": true,
+        "atr_min_pct": 0.0078
+      },
+      {
+        "band_distance_threshold": 0.0049,
+        "rsi_oversold": 35,
+        "rsi_overbought": 70
+      },
+      {
+        "cci_buy_threshold": 100,
+        "cci_sell_threshold": -100,
+        "atr_min_pct": 0.0114
+      },
+      {
+        "vwap_atr_multiplier": 2.02,
+        "rsi_oversold": 40,
+        "rsi_overbought": 60
+      },
+      {
+        "rsi_reclaim_level": 50,
+        "min_trend_strength_pct": 0.0089,
+        "max_pullback_distance_pct": 0.0291,
+        "vwap_pullback_distance_pct": 0.0151,
+        "min_atr_pct": 0.0064,
+        "min_macd_hist": -0.0084,
+        "strong_trend_strength_pct": 0.0153,
+        "continuation_rsi_level": 52,
+        "continuation_max_vwap_distance_pct": 0.0434,
+        "continuation_max_ema50_extension_pct": 0.0361,
+        "continuation_min_macd_hist": -0.0054
+      }
+    ],
+    "aggregator_config": {
+      "buy_threshold": 1.0,
+      "buy_threshold_uptrend": 1.0,
+      "sell_threshold": -0.79,
+      "btc_regime_filter_enabled": true,
+      "btc_reference_symbol": "BTCUSDT",
+      "btc_dump_threshold_pct": -1.0,
+      "btc_dump_require_below_ema200": true,
+      "min_confidence": 0.04
+    },
+    "time_stop_minutes": 0.0,
+    "replay_sentiment_path": null,
+    "replay_sentiment_max_age_seconds": null,
+    "futures_mode": true,
+    "futures_leverage": 3,
+    "futures_funding_rate": 0.0001,
+    "funding_cadence": "scaled_8h",
+    "fixed_notional_usdt": 0.0,
+    "quantity_step_size": 0.0,
+    "min_notional_usdt": 0.0
+  },
+  "cost_audit": {
+    "name": "corrected",
+    "fee_rate": 0.0004,
+    "slippage_pct": 0.0002,
+    "apply_global_trend_filter": true,
+    "funding_cadence": "scaled_8h",
+    "base_futures_funding_rate": 0.0001,
+    "round_trip_cost_pct": 0.12000000000000001,
+    "funding_method": "scale per-bar rate by tf_hours/8 (equivalent to 8h settlement cadence)",
+    "effective_futures_funding_rate": 1.25e-05
+  },
+  "global_trend_filter_audit": {
+    "active": true,
+    "buffer_pct": 0.0,
+    "source": "cost_profile_override",
+    "config_explicit": null
+  },
+  "buy_threshold_binding_audit": {
+    "aggregator.buy_threshold": 1.0,
+    "aggregator.buy_threshold_uptrend": 1.0,
+    "per_symbol_aggregator_config.SOLUSDT.buy_threshold": 1.0,
+    "per_symbol_aggregator_config.SOLUSDT.buy_threshold_uptrend": 1.0
+  },
+  "effective_start": "2024-01-09",
+  "effective_end": "2026-02-23",
+  "coverage": {
+    "requested_start": "2024-01-01",
+    "requested_end": "2026-06-01",
+    "data_start": "2024-01-09T07:00:00+00:00",
+    "data_end": "2026-02-23T19:00:00+00:00",
+    "effective_start": "2024-01-09",
+    "effective_end": "2026-02-23",
+    "clamped_start": true,
+    "clamped_end": true
+  }
+}

--- a/research/overlay-threshold-sweep/1.07.json
+++ b/research/overlay-threshold-sweep/1.07.json
@@ -1,0 +1,223 @@
+{
+  "buy_threshold": 1.07,
+  "summary": {
+    "symbol": "SOLUSDT",
+    "timeframe": "1h",
+    "start": "2024-01-09",
+    "end": "2026-02-23",
+    "total_trades": 42,
+    "win_rate": 59.523809523809526,
+    "total_return_pct": 38.368455578641225,
+    "max_drawdown_pct": 29.169602365246906,
+    "sharpe_ratio": 0.5767299024842656,
+    "wfo_windows": 3,
+    "wfo_total_trades": 11,
+    "wfo_mean_sharpe": 0.9999453684547117,
+    "wfo_total_return_pct": 53.46762413547728,
+    "bootstrap_p_loss_pct": 24.6,
+    "mc_drawdown_p95_pct": 57.421134178026456,
+    "mc_drawdown_p50_pct": 31.950425254251254,
+    "profit_concentration_pct": 95.15432747479574,
+    "passes_gates": false,
+    "failure_reasons": [
+      "min_wfo_trades failed (11 < 20)",
+      "max_drawdown_pct failed (29.17% > 10.00%)",
+      "max_profit_concentration_pct failed (95.15% > 50.00%)"
+    ],
+    "blocked_buy_count": 0,
+    "basis_blocked_buy_count": 0,
+    "dislocation_blocked_buy_count": 0
+  },
+  "gates": {
+    "min_trades": 0,
+    "min_wfo_trades": 20,
+    "min_wfo_sharpe": 0.5,
+    "max_drawdown_pct": 10.0,
+    "max_bootstrap_p_loss_pct": 25.0,
+    "min_oos_return_pct": 0.0,
+    "max_profit_concentration_pct": 50.0,
+    "max_mc_drawdown_p95_pct": 0.0
+  },
+  "windows": [
+    {
+      "window_index": 1,
+      "train_start": "2024-01-09T00:00:00",
+      "train_end": "2024-07-09T00:00:00",
+      "test_start": "2024-07-09T00:00:00",
+      "test_end": "2024-10-09T00:00:00",
+      "total_trades": 4,
+      "win_rate": 50.0,
+      "total_return_pct": 2.6901952352623266,
+      "max_drawdown_pct": 7.338719424309017,
+      "sharpe_ratio": 0.6480830255984609
+    },
+    {
+      "window_index": 2,
+      "train_start": "2024-07-09T00:00:00",
+      "train_end": "2025-01-09T00:00:00",
+      "test_start": "2025-01-09T00:00:00",
+      "test_end": "2025-04-09T00:00:00",
+      "total_trades": 2,
+      "win_rate": 100.0,
+      "total_return_pct": 52.827283943728,
+      "max_drawdown_pct": 5.434230140424734,
+      "sharpe_ratio": 2.575235696322529
+    },
+    {
+      "window_index": 3,
+      "train_start": "2025-01-09T00:00:00",
+      "train_end": "2025-07-09T00:00:00",
+      "test_start": "2025-07-09T00:00:00",
+      "test_end": "2025-10-09T00:00:00",
+      "total_trades": 5,
+      "win_rate": 60.0,
+      "total_return_pct": -2.211700191822456,
+      "max_drawdown_pct": 10.553055273056263,
+      "sharpe_ratio": -0.22348261655685475
+    }
+  ],
+  "resolved_backtest_config": {
+    "symbol": "SOLUSDT",
+    "timeframe": "1h",
+    "start_date": "2024-01-09",
+    "end_date": "2026-02-23",
+    "initial_capital": 10000.0,
+    "fee_rate": 0.0004,
+    "stop_loss_pct": 0.01,
+    "take_profit_pct": 0.03,
+    "sl_atr_multiplier": 2.38,
+    "tp_atr_multiplier": 4.23,
+    "trailing_activate_atr": 1.82,
+    "trailing_offset_atr": 1.07,
+    "slippage_pct": 0.0002,
+    "risk_per_trade": 0.02,
+    "use_atr_sizing": false,
+    "atr_multiplier": 1.0,
+    "apply_global_trend_filter": true,
+    "global_trend_filter_buffer_pct": 0.0,
+    "global_trend_filter_source": "cost_profile_override",
+    "config_global_trend_filter_enabled": null,
+    "session_liquidity_router": {
+      "enabled": false,
+      "allowed_windows": [
+        "americas"
+      ],
+      "block_entries_outside_windows": true
+    },
+    "basis_premium_filter": {
+      "enabled": false,
+      "exchange": "binance_usdm",
+      "tail_metric": "basis_bps",
+      "positive_tail_pct": 0.05,
+      "block_positive_tail_longs": true,
+      "missing_data_policy": "allow",
+      "calibrated_positive_threshold": null
+    },
+    "cross_venue_dislocation": {
+      "enabled": false,
+      "metric": "basis_spread",
+      "mode": "require",
+      "min_spread_bps": 5.0,
+      "side": "both",
+      "missing_data_policy": "allow"
+    },
+    "allow_short": false,
+    "use_executor_exit_model": true,
+    "ignore_signal_sells": false,
+    "strategy_configs": [
+      {
+        "rsi_period": 7,
+        "oversold_threshold": 35,
+        "overbought_threshold": 65
+      },
+      {
+        "min_histogram_threshold": 0.0,
+        "use_atr_filter": true,
+        "atr_min_pct": 0.0078
+      },
+      {
+        "band_distance_threshold": 0.0049,
+        "rsi_oversold": 35,
+        "rsi_overbought": 70
+      },
+      {
+        "cci_buy_threshold": 100,
+        "cci_sell_threshold": -100,
+        "atr_min_pct": 0.0114
+      },
+      {
+        "vwap_atr_multiplier": 2.02,
+        "rsi_oversold": 40,
+        "rsi_overbought": 60
+      },
+      {
+        "rsi_reclaim_level": 50,
+        "min_trend_strength_pct": 0.0089,
+        "max_pullback_distance_pct": 0.0291,
+        "vwap_pullback_distance_pct": 0.0151,
+        "min_atr_pct": 0.0064,
+        "min_macd_hist": -0.0084,
+        "strong_trend_strength_pct": 0.0153,
+        "continuation_rsi_level": 52,
+        "continuation_max_vwap_distance_pct": 0.0434,
+        "continuation_max_ema50_extension_pct": 0.0361,
+        "continuation_min_macd_hist": -0.0054
+      }
+    ],
+    "aggregator_config": {
+      "buy_threshold": 1.07,
+      "buy_threshold_uptrend": 1.07,
+      "sell_threshold": -0.79,
+      "btc_regime_filter_enabled": true,
+      "btc_reference_symbol": "BTCUSDT",
+      "btc_dump_threshold_pct": -1.0,
+      "btc_dump_require_below_ema200": true,
+      "min_confidence": 0.04
+    },
+    "time_stop_minutes": 0.0,
+    "replay_sentiment_path": null,
+    "replay_sentiment_max_age_seconds": null,
+    "futures_mode": true,
+    "futures_leverage": 3,
+    "futures_funding_rate": 0.0001,
+    "funding_cadence": "scaled_8h",
+    "fixed_notional_usdt": 0.0,
+    "quantity_step_size": 0.0,
+    "min_notional_usdt": 0.0
+  },
+  "cost_audit": {
+    "name": "corrected",
+    "fee_rate": 0.0004,
+    "slippage_pct": 0.0002,
+    "apply_global_trend_filter": true,
+    "funding_cadence": "scaled_8h",
+    "base_futures_funding_rate": 0.0001,
+    "round_trip_cost_pct": 0.12000000000000001,
+    "funding_method": "scale per-bar rate by tf_hours/8 (equivalent to 8h settlement cadence)",
+    "effective_futures_funding_rate": 1.25e-05
+  },
+  "global_trend_filter_audit": {
+    "active": true,
+    "buffer_pct": 0.0,
+    "source": "cost_profile_override",
+    "config_explicit": null
+  },
+  "buy_threshold_binding_audit": {
+    "aggregator.buy_threshold": 1.07,
+    "aggregator.buy_threshold_uptrend": 1.07,
+    "per_symbol_aggregator_config.SOLUSDT.buy_threshold": 1.07,
+    "per_symbol_aggregator_config.SOLUSDT.buy_threshold_uptrend": 1.07
+  },
+  "effective_start": "2024-01-09",
+  "effective_end": "2026-02-23",
+  "coverage": {
+    "requested_start": "2024-01-01",
+    "requested_end": "2026-06-01",
+    "data_start": "2024-01-09T07:00:00+00:00",
+    "data_end": "2026-02-23T19:00:00+00:00",
+    "effective_start": "2024-01-09",
+    "effective_end": "2026-02-23",
+    "clamped_start": true,
+    "clamped_end": true
+  }
+}

--- a/research/overlay-threshold-sweep/1.27.json
+++ b/research/overlay-threshold-sweep/1.27.json
@@ -1,0 +1,224 @@
+{
+  "buy_threshold": 1.27,
+  "summary": {
+    "symbol": "SOLUSDT",
+    "timeframe": "1h",
+    "start": "2024-01-09",
+    "end": "2026-02-23",
+    "total_trades": 24,
+    "win_rate": 62.5,
+    "total_return_pct": 14.247749607333917,
+    "max_drawdown_pct": 28.425585568696864,
+    "sharpe_ratio": 0.37976601801105586,
+    "wfo_windows": 3,
+    "wfo_total_trades": 6,
+    "wfo_mean_sharpe": 1.0522123094688793,
+    "wfo_total_return_pct": 19.418830126815266,
+    "bootstrap_p_loss_pct": 30.4,
+    "mc_drawdown_p95_pct": 46.006007419626336,
+    "mc_drawdown_p50_pct": 23.408509843833755,
+    "profit_concentration_pct": 53.95262560640962,
+    "passes_gates": false,
+    "failure_reasons": [
+      "min_wfo_trades failed (6 < 20)",
+      "max_drawdown_pct failed (28.43% > 10.00%)",
+      "max_bootstrap_p_loss_pct failed (30.40% > 25.00%)",
+      "max_profit_concentration_pct failed (53.95% > 50.00%)"
+    ],
+    "blocked_buy_count": 0,
+    "basis_blocked_buy_count": 0,
+    "dislocation_blocked_buy_count": 0
+  },
+  "gates": {
+    "min_trades": 0,
+    "min_wfo_trades": 20,
+    "min_wfo_sharpe": 0.5,
+    "max_drawdown_pct": 10.0,
+    "max_bootstrap_p_loss_pct": 25.0,
+    "min_oos_return_pct": 0.0,
+    "max_profit_concentration_pct": 50.0,
+    "max_mc_drawdown_p95_pct": 0.0
+  },
+  "windows": [
+    {
+      "window_index": 1,
+      "train_start": "2024-01-09T00:00:00",
+      "train_end": "2024-07-09T00:00:00",
+      "test_start": "2024-07-09T00:00:00",
+      "test_end": "2024-10-09T00:00:00",
+      "total_trades": 3,
+      "win_rate": 66.66666666666666,
+      "total_return_pct": 10.823198856375784,
+      "max_drawdown_pct": 6.202350019394471,
+      "sharpe_ratio": 2.484574705773612
+    },
+    {
+      "window_index": 2,
+      "train_start": "2024-07-09T00:00:00",
+      "train_end": "2025-01-09T00:00:00",
+      "test_start": "2025-01-09T00:00:00",
+      "test_end": "2025-04-09T00:00:00",
+      "total_trades": 1,
+      "win_rate": 100.0,
+      "total_return_pct": 12.681287553347357,
+      "max_drawdown_pct": 5.434230140424734,
+      "sharpe_ratio": 2.125704845636819
+    },
+    {
+      "window_index": 3,
+      "train_start": "2025-01-09T00:00:00",
+      "train_end": "2025-07-09T00:00:00",
+      "test_start": "2025-07-09T00:00:00",
+      "test_end": "2025-10-09T00:00:00",
+      "total_trades": 2,
+      "win_rate": 50.0,
+      "total_return_pct": -4.370842452832457,
+      "max_drawdown_pct": 10.553055273056287,
+      "sharpe_ratio": -1.4536426230037927
+    }
+  ],
+  "resolved_backtest_config": {
+    "symbol": "SOLUSDT",
+    "timeframe": "1h",
+    "start_date": "2024-01-09",
+    "end_date": "2026-02-23",
+    "initial_capital": 10000.0,
+    "fee_rate": 0.0004,
+    "stop_loss_pct": 0.01,
+    "take_profit_pct": 0.03,
+    "sl_atr_multiplier": 2.38,
+    "tp_atr_multiplier": 4.23,
+    "trailing_activate_atr": 1.82,
+    "trailing_offset_atr": 1.07,
+    "slippage_pct": 0.0002,
+    "risk_per_trade": 0.02,
+    "use_atr_sizing": false,
+    "atr_multiplier": 1.0,
+    "apply_global_trend_filter": true,
+    "global_trend_filter_buffer_pct": 0.0,
+    "global_trend_filter_source": "cost_profile_override",
+    "config_global_trend_filter_enabled": null,
+    "session_liquidity_router": {
+      "enabled": false,
+      "allowed_windows": [
+        "americas"
+      ],
+      "block_entries_outside_windows": true
+    },
+    "basis_premium_filter": {
+      "enabled": false,
+      "exchange": "binance_usdm",
+      "tail_metric": "basis_bps",
+      "positive_tail_pct": 0.05,
+      "block_positive_tail_longs": true,
+      "missing_data_policy": "allow",
+      "calibrated_positive_threshold": null
+    },
+    "cross_venue_dislocation": {
+      "enabled": false,
+      "metric": "basis_spread",
+      "mode": "require",
+      "min_spread_bps": 5.0,
+      "side": "both",
+      "missing_data_policy": "allow"
+    },
+    "allow_short": false,
+    "use_executor_exit_model": true,
+    "ignore_signal_sells": false,
+    "strategy_configs": [
+      {
+        "rsi_period": 7,
+        "oversold_threshold": 35,
+        "overbought_threshold": 65
+      },
+      {
+        "min_histogram_threshold": 0.0,
+        "use_atr_filter": true,
+        "atr_min_pct": 0.0078
+      },
+      {
+        "band_distance_threshold": 0.0049,
+        "rsi_oversold": 35,
+        "rsi_overbought": 70
+      },
+      {
+        "cci_buy_threshold": 100,
+        "cci_sell_threshold": -100,
+        "atr_min_pct": 0.0114
+      },
+      {
+        "vwap_atr_multiplier": 2.02,
+        "rsi_oversold": 40,
+        "rsi_overbought": 60
+      },
+      {
+        "rsi_reclaim_level": 50,
+        "min_trend_strength_pct": 0.0089,
+        "max_pullback_distance_pct": 0.0291,
+        "vwap_pullback_distance_pct": 0.0151,
+        "min_atr_pct": 0.0064,
+        "min_macd_hist": -0.0084,
+        "strong_trend_strength_pct": 0.0153,
+        "continuation_rsi_level": 52,
+        "continuation_max_vwap_distance_pct": 0.0434,
+        "continuation_max_ema50_extension_pct": 0.0361,
+        "continuation_min_macd_hist": -0.0054
+      }
+    ],
+    "aggregator_config": {
+      "buy_threshold": 1.27,
+      "buy_threshold_uptrend": 1.27,
+      "sell_threshold": -0.79,
+      "btc_regime_filter_enabled": true,
+      "btc_reference_symbol": "BTCUSDT",
+      "btc_dump_threshold_pct": -1.0,
+      "btc_dump_require_below_ema200": true,
+      "min_confidence": 0.04
+    },
+    "time_stop_minutes": 0.0,
+    "replay_sentiment_path": null,
+    "replay_sentiment_max_age_seconds": null,
+    "futures_mode": true,
+    "futures_leverage": 3,
+    "futures_funding_rate": 0.0001,
+    "funding_cadence": "scaled_8h",
+    "fixed_notional_usdt": 0.0,
+    "quantity_step_size": 0.0,
+    "min_notional_usdt": 0.0
+  },
+  "cost_audit": {
+    "name": "corrected",
+    "fee_rate": 0.0004,
+    "slippage_pct": 0.0002,
+    "apply_global_trend_filter": true,
+    "funding_cadence": "scaled_8h",
+    "base_futures_funding_rate": 0.0001,
+    "round_trip_cost_pct": 0.12000000000000001,
+    "funding_method": "scale per-bar rate by tf_hours/8 (equivalent to 8h settlement cadence)",
+    "effective_futures_funding_rate": 1.25e-05
+  },
+  "global_trend_filter_audit": {
+    "active": true,
+    "buffer_pct": 0.0,
+    "source": "cost_profile_override",
+    "config_explicit": null
+  },
+  "buy_threshold_binding_audit": {
+    "aggregator.buy_threshold": 1.27,
+    "aggregator.buy_threshold_uptrend": 1.27,
+    "per_symbol_aggregator_config.SOLUSDT.buy_threshold": 1.27,
+    "per_symbol_aggregator_config.SOLUSDT.buy_threshold_uptrend": 1.27
+  },
+  "effective_start": "2024-01-09",
+  "effective_end": "2026-02-23",
+  "coverage": {
+    "requested_start": "2024-01-01",
+    "requested_end": "2026-06-01",
+    "data_start": "2024-01-09T07:00:00+00:00",
+    "data_end": "2026-02-23T19:00:00+00:00",
+    "effective_start": "2024-01-09",
+    "effective_end": "2026-02-23",
+    "clamped_start": true,
+    "clamped_end": true
+  }
+}

--- a/research/overlay-threshold-sweep/combined_results.json
+++ b/research/overlay-threshold-sweep/combined_results.json
@@ -1,0 +1,1798 @@
+[
+  {
+    "buy_threshold": 0.5,
+    "summary": {
+      "symbol": "SOLUSDT",
+      "timeframe": "1h",
+      "start": "2024-01-09",
+      "end": "2026-02-23",
+      "total_trades": 464,
+      "win_rate": 56.46551724137932,
+      "total_return_pct": -99.72689810426918,
+      "max_drawdown_pct": 99.74167922677329,
+      "sharpe_ratio": -1.8927126288478515,
+      "wfo_windows": 3,
+      "wfo_total_trades": 158,
+      "wfo_mean_sharpe": -0.8977460242336993,
+      "wfo_total_return_pct": -75.36785867148623,
+      "bootstrap_p_loss_pct": 100.0,
+      "mc_drawdown_p95_pct": 99.9851601422858,
+      "mc_drawdown_p50_pct": 99.81797617003407,
+      "profit_concentration_pct": 100.0,
+      "passes_gates": false,
+      "failure_reasons": [
+        "min_wfo_sharpe failed (-0.90 < 0.50)",
+        "max_drawdown_pct failed (99.74% > 10.00%)",
+        "max_bootstrap_p_loss_pct failed (100.00% > 25.00%)",
+        "min_oos_return_pct failed (-75.37% < 0.00%)",
+        "max_profit_concentration_pct failed (100.00% > 50.00%)"
+      ],
+      "blocked_buy_count": 0,
+      "basis_blocked_buy_count": 0,
+      "dislocation_blocked_buy_count": 0
+    },
+    "gates": {
+      "min_trades": 0,
+      "min_wfo_trades": 20,
+      "min_wfo_sharpe": 0.5,
+      "max_drawdown_pct": 10.0,
+      "max_bootstrap_p_loss_pct": 25.0,
+      "min_oos_return_pct": 0.0,
+      "max_profit_concentration_pct": 50.0,
+      "max_mc_drawdown_p95_pct": 0.0
+    },
+    "windows": [
+      {
+        "window_index": 1,
+        "train_start": "2024-01-09T00:00:00",
+        "train_end": "2024-07-09T00:00:00",
+        "test_start": "2024-07-09T00:00:00",
+        "test_end": "2024-10-09T00:00:00",
+        "total_trades": 56,
+        "win_rate": 67.85714285714286,
+        "total_return_pct": 1.8785133099579254,
+        "max_drawdown_pct": 42.83619817383422,
+        "sharpe_ratio": 0.5070132160711389
+      },
+      {
+        "window_index": 2,
+        "train_start": "2024-07-09T00:00:00",
+        "train_end": "2025-01-09T00:00:00",
+        "test_start": "2025-01-09T00:00:00",
+        "test_end": "2025-04-09T00:00:00",
+        "total_trades": 34,
+        "win_rate": 50.0,
+        "total_return_pct": -56.03330675474027,
+        "max_drawdown_pct": 63.20872647294477,
+        "sharpe_ratio": -1.3948823828774772
+      },
+      {
+        "window_index": 3,
+        "train_start": "2025-01-09T00:00:00",
+        "train_end": "2025-07-09T00:00:00",
+        "test_start": "2025-07-09T00:00:00",
+        "test_end": "2025-10-09T00:00:00",
+        "total_trades": 68,
+        "win_rate": 60.29411764705882,
+        "total_return_pct": -45.00847474080374,
+        "max_drawdown_pct": 54.96183131886999,
+        "sharpe_ratio": -1.8053689058947597
+      }
+    ],
+    "resolved_backtest_config": {
+      "symbol": "SOLUSDT",
+      "timeframe": "1h",
+      "start_date": "2024-01-09",
+      "end_date": "2026-02-23",
+      "initial_capital": 10000.0,
+      "fee_rate": 0.0004,
+      "stop_loss_pct": 0.01,
+      "take_profit_pct": 0.03,
+      "sl_atr_multiplier": 2.38,
+      "tp_atr_multiplier": 4.23,
+      "trailing_activate_atr": 1.82,
+      "trailing_offset_atr": 1.07,
+      "slippage_pct": 0.0002,
+      "risk_per_trade": 0.02,
+      "use_atr_sizing": false,
+      "atr_multiplier": 1.0,
+      "apply_global_trend_filter": true,
+      "global_trend_filter_buffer_pct": 0.0,
+      "global_trend_filter_source": "cost_profile_override",
+      "config_global_trend_filter_enabled": null,
+      "session_liquidity_router": {
+        "enabled": false,
+        "allowed_windows": [
+          "americas"
+        ],
+        "block_entries_outside_windows": true
+      },
+      "basis_premium_filter": {
+        "enabled": false,
+        "exchange": "binance_usdm",
+        "tail_metric": "basis_bps",
+        "positive_tail_pct": 0.05,
+        "block_positive_tail_longs": true,
+        "missing_data_policy": "allow",
+        "calibrated_positive_threshold": null
+      },
+      "cross_venue_dislocation": {
+        "enabled": false,
+        "metric": "basis_spread",
+        "mode": "require",
+        "min_spread_bps": 5.0,
+        "side": "both",
+        "missing_data_policy": "allow"
+      },
+      "allow_short": false,
+      "use_executor_exit_model": true,
+      "ignore_signal_sells": false,
+      "strategy_configs": [
+        {
+          "rsi_period": 7,
+          "oversold_threshold": 35,
+          "overbought_threshold": 65
+        },
+        {
+          "min_histogram_threshold": 0.0,
+          "use_atr_filter": true,
+          "atr_min_pct": 0.0078
+        },
+        {
+          "band_distance_threshold": 0.0049,
+          "rsi_oversold": 35,
+          "rsi_overbought": 70
+        },
+        {
+          "cci_buy_threshold": 100,
+          "cci_sell_threshold": -100,
+          "atr_min_pct": 0.0114
+        },
+        {
+          "vwap_atr_multiplier": 2.02,
+          "rsi_oversold": 40,
+          "rsi_overbought": 60
+        },
+        {
+          "rsi_reclaim_level": 50,
+          "min_trend_strength_pct": 0.0089,
+          "max_pullback_distance_pct": 0.0291,
+          "vwap_pullback_distance_pct": 0.0151,
+          "min_atr_pct": 0.0064,
+          "min_macd_hist": -0.0084,
+          "strong_trend_strength_pct": 0.0153,
+          "continuation_rsi_level": 52,
+          "continuation_max_vwap_distance_pct": 0.0434,
+          "continuation_max_ema50_extension_pct": 0.0361,
+          "continuation_min_macd_hist": -0.0054
+        }
+      ],
+      "aggregator_config": {
+        "buy_threshold": 0.5,
+        "buy_threshold_uptrend": 0.5,
+        "sell_threshold": -0.79,
+        "btc_regime_filter_enabled": true,
+        "btc_reference_symbol": "BTCUSDT",
+        "btc_dump_threshold_pct": -1.0,
+        "btc_dump_require_below_ema200": true,
+        "min_confidence": 0.04
+      },
+      "time_stop_minutes": 0.0,
+      "replay_sentiment_path": null,
+      "replay_sentiment_max_age_seconds": null,
+      "futures_mode": true,
+      "futures_leverage": 3,
+      "futures_funding_rate": 0.0001,
+      "funding_cadence": "scaled_8h",
+      "fixed_notional_usdt": 0.0,
+      "quantity_step_size": 0.0,
+      "min_notional_usdt": 0.0
+    },
+    "cost_audit": {
+      "name": "corrected",
+      "fee_rate": 0.0004,
+      "slippage_pct": 0.0002,
+      "apply_global_trend_filter": true,
+      "funding_cadence": "scaled_8h",
+      "base_futures_funding_rate": 0.0001,
+      "round_trip_cost_pct": 0.12000000000000001,
+      "funding_method": "scale per-bar rate by tf_hours/8 (equivalent to 8h settlement cadence)",
+      "effective_futures_funding_rate": 1.25e-05
+    },
+    "global_trend_filter_audit": {
+      "active": true,
+      "buffer_pct": 0.0,
+      "source": "cost_profile_override",
+      "config_explicit": null
+    },
+    "buy_threshold_binding_audit": {
+      "aggregator.buy_threshold": 0.5,
+      "aggregator.buy_threshold_uptrend": 0.5,
+      "per_symbol_aggregator_config.SOLUSDT.buy_threshold": 0.5,
+      "per_symbol_aggregator_config.SOLUSDT.buy_threshold_uptrend": 0.5
+    },
+    "effective_start": "2024-01-09",
+    "effective_end": "2026-02-23",
+    "coverage": {
+      "requested_start": "2024-01-01",
+      "requested_end": "2026-06-01",
+      "data_start": "2024-01-09T07:00:00+00:00",
+      "data_end": "2026-02-23T19:00:00+00:00",
+      "effective_start": "2024-01-09",
+      "effective_end": "2026-02-23",
+      "clamped_start": true,
+      "clamped_end": true
+    }
+  },
+  {
+    "buy_threshold": 0.6,
+    "summary": {
+      "symbol": "SOLUSDT",
+      "timeframe": "1h",
+      "start": "2024-01-09",
+      "end": "2026-02-23",
+      "total_trades": 357,
+      "win_rate": 58.543417366946784,
+      "total_return_pct": -96.71344598608319,
+      "max_drawdown_pct": 97.50709786965834,
+      "sharpe_ratio": -1.1871069949894264,
+      "wfo_windows": 3,
+      "wfo_total_trades": 121,
+      "wfo_mean_sharpe": -0.488139525974997,
+      "wfo_total_return_pct": -50.734290366303945,
+      "bootstrap_p_loss_pct": 99.6,
+      "mc_drawdown_p95_pct": 99.75626123945236,
+      "mc_drawdown_p50_pct": 97.79726432240965,
+      "profit_concentration_pct": 100.0,
+      "passes_gates": false,
+      "failure_reasons": [
+        "min_wfo_sharpe failed (-0.49 < 0.50)",
+        "max_drawdown_pct failed (97.51% > 10.00%)",
+        "max_bootstrap_p_loss_pct failed (99.60% > 25.00%)",
+        "min_oos_return_pct failed (-50.73% < 0.00%)",
+        "max_profit_concentration_pct failed (100.00% > 50.00%)"
+      ],
+      "blocked_buy_count": 0,
+      "basis_blocked_buy_count": 0,
+      "dislocation_blocked_buy_count": 0
+    },
+    "gates": {
+      "min_trades": 0,
+      "min_wfo_trades": 20,
+      "min_wfo_sharpe": 0.5,
+      "max_drawdown_pct": 10.0,
+      "max_bootstrap_p_loss_pct": 25.0,
+      "min_oos_return_pct": 0.0,
+      "max_profit_concentration_pct": 50.0,
+      "max_mc_drawdown_p95_pct": 0.0
+    },
+    "windows": [
+      {
+        "window_index": 1,
+        "train_start": "2024-01-09T00:00:00",
+        "train_end": "2024-07-09T00:00:00",
+        "test_start": "2024-07-09T00:00:00",
+        "test_end": "2024-10-09T00:00:00",
+        "total_trades": 40,
+        "win_rate": 65.0,
+        "total_return_pct": -1.9167119943087527,
+        "max_drawdown_pct": 28.507157893495695,
+        "sharpe_ratio": 0.24174747545886863
+      },
+      {
+        "window_index": 2,
+        "train_start": "2024-07-09T00:00:00",
+        "train_end": "2025-01-09T00:00:00",
+        "test_start": "2025-01-09T00:00:00",
+        "test_end": "2025-04-09T00:00:00",
+        "total_trades": 26,
+        "win_rate": 53.84615384615385,
+        "total_return_pct": -25.918977958710965,
+        "max_drawdown_pct": 38.52762055121766,
+        "sharpe_ratio": -0.28426060285470245
+      },
+      {
+        "window_index": 3,
+        "train_start": "2025-01-09T00:00:00",
+        "train_end": "2025-07-09T00:00:00",
+        "test_start": "2025-07-09T00:00:00",
+        "test_end": "2025-10-09T00:00:00",
+        "total_trades": 55,
+        "win_rate": 60.0,
+        "total_return_pct": -32.197959929359705,
+        "max_drawdown_pct": 48.442398580021354,
+        "sharpe_ratio": -1.421905450529157
+      }
+    ],
+    "resolved_backtest_config": {
+      "symbol": "SOLUSDT",
+      "timeframe": "1h",
+      "start_date": "2024-01-09",
+      "end_date": "2026-02-23",
+      "initial_capital": 10000.0,
+      "fee_rate": 0.0004,
+      "stop_loss_pct": 0.01,
+      "take_profit_pct": 0.03,
+      "sl_atr_multiplier": 2.38,
+      "tp_atr_multiplier": 4.23,
+      "trailing_activate_atr": 1.82,
+      "trailing_offset_atr": 1.07,
+      "slippage_pct": 0.0002,
+      "risk_per_trade": 0.02,
+      "use_atr_sizing": false,
+      "atr_multiplier": 1.0,
+      "apply_global_trend_filter": true,
+      "global_trend_filter_buffer_pct": 0.0,
+      "global_trend_filter_source": "cost_profile_override",
+      "config_global_trend_filter_enabled": null,
+      "session_liquidity_router": {
+        "enabled": false,
+        "allowed_windows": [
+          "americas"
+        ],
+        "block_entries_outside_windows": true
+      },
+      "basis_premium_filter": {
+        "enabled": false,
+        "exchange": "binance_usdm",
+        "tail_metric": "basis_bps",
+        "positive_tail_pct": 0.05,
+        "block_positive_tail_longs": true,
+        "missing_data_policy": "allow",
+        "calibrated_positive_threshold": null
+      },
+      "cross_venue_dislocation": {
+        "enabled": false,
+        "metric": "basis_spread",
+        "mode": "require",
+        "min_spread_bps": 5.0,
+        "side": "both",
+        "missing_data_policy": "allow"
+      },
+      "allow_short": false,
+      "use_executor_exit_model": true,
+      "ignore_signal_sells": false,
+      "strategy_configs": [
+        {
+          "rsi_period": 7,
+          "oversold_threshold": 35,
+          "overbought_threshold": 65
+        },
+        {
+          "min_histogram_threshold": 0.0,
+          "use_atr_filter": true,
+          "atr_min_pct": 0.0078
+        },
+        {
+          "band_distance_threshold": 0.0049,
+          "rsi_oversold": 35,
+          "rsi_overbought": 70
+        },
+        {
+          "cci_buy_threshold": 100,
+          "cci_sell_threshold": -100,
+          "atr_min_pct": 0.0114
+        },
+        {
+          "vwap_atr_multiplier": 2.02,
+          "rsi_oversold": 40,
+          "rsi_overbought": 60
+        },
+        {
+          "rsi_reclaim_level": 50,
+          "min_trend_strength_pct": 0.0089,
+          "max_pullback_distance_pct": 0.0291,
+          "vwap_pullback_distance_pct": 0.0151,
+          "min_atr_pct": 0.0064,
+          "min_macd_hist": -0.0084,
+          "strong_trend_strength_pct": 0.0153,
+          "continuation_rsi_level": 52,
+          "continuation_max_vwap_distance_pct": 0.0434,
+          "continuation_max_ema50_extension_pct": 0.0361,
+          "continuation_min_macd_hist": -0.0054
+        }
+      ],
+      "aggregator_config": {
+        "buy_threshold": 0.6,
+        "buy_threshold_uptrend": 0.6,
+        "sell_threshold": -0.79,
+        "btc_regime_filter_enabled": true,
+        "btc_reference_symbol": "BTCUSDT",
+        "btc_dump_threshold_pct": -1.0,
+        "btc_dump_require_below_ema200": true,
+        "min_confidence": 0.04
+      },
+      "time_stop_minutes": 0.0,
+      "replay_sentiment_path": null,
+      "replay_sentiment_max_age_seconds": null,
+      "futures_mode": true,
+      "futures_leverage": 3,
+      "futures_funding_rate": 0.0001,
+      "funding_cadence": "scaled_8h",
+      "fixed_notional_usdt": 0.0,
+      "quantity_step_size": 0.0,
+      "min_notional_usdt": 0.0
+    },
+    "cost_audit": {
+      "name": "corrected",
+      "fee_rate": 0.0004,
+      "slippage_pct": 0.0002,
+      "apply_global_trend_filter": true,
+      "funding_cadence": "scaled_8h",
+      "base_futures_funding_rate": 0.0001,
+      "round_trip_cost_pct": 0.12000000000000001,
+      "funding_method": "scale per-bar rate by tf_hours/8 (equivalent to 8h settlement cadence)",
+      "effective_futures_funding_rate": 1.25e-05
+    },
+    "global_trend_filter_audit": {
+      "active": true,
+      "buffer_pct": 0.0,
+      "source": "cost_profile_override",
+      "config_explicit": null
+    },
+    "buy_threshold_binding_audit": {
+      "aggregator.buy_threshold": 0.6,
+      "aggregator.buy_threshold_uptrend": 0.6,
+      "per_symbol_aggregator_config.SOLUSDT.buy_threshold": 0.6,
+      "per_symbol_aggregator_config.SOLUSDT.buy_threshold_uptrend": 0.6
+    },
+    "effective_start": "2024-01-09",
+    "effective_end": "2026-02-23",
+    "coverage": {
+      "requested_start": "2024-01-01",
+      "requested_end": "2026-06-01",
+      "data_start": "2024-01-09T07:00:00+00:00",
+      "data_end": "2026-02-23T19:00:00+00:00",
+      "effective_start": "2024-01-09",
+      "effective_end": "2026-02-23",
+      "clamped_start": true,
+      "clamped_end": true
+    }
+  },
+  {
+    "buy_threshold": 0.7,
+    "summary": {
+      "symbol": "SOLUSDT",
+      "timeframe": "1h",
+      "start": "2024-01-09",
+      "end": "2026-02-23",
+      "total_trades": 223,
+      "win_rate": 56.05381165919282,
+      "total_return_pct": -92.60528040232914,
+      "max_drawdown_pct": 93.89931682723264,
+      "sharpe_ratio": -1.128667516847773,
+      "wfo_windows": 3,
+      "wfo_total_trades": 70,
+      "wfo_mean_sharpe": -0.3330592093800882,
+      "wfo_total_return_pct": -26.079959723551195,
+      "bootstrap_p_loss_pct": 98.6,
+      "mc_drawdown_p95_pct": 99.12674500154058,
+      "mc_drawdown_p50_pct": 94.63808156904398,
+      "profit_concentration_pct": 100.0,
+      "passes_gates": false,
+      "failure_reasons": [
+        "min_wfo_sharpe failed (-0.33 < 0.50)",
+        "max_drawdown_pct failed (93.90% > 10.00%)",
+        "max_bootstrap_p_loss_pct failed (98.60% > 25.00%)",
+        "min_oos_return_pct failed (-26.08% < 0.00%)",
+        "max_profit_concentration_pct failed (100.00% > 50.00%)"
+      ],
+      "blocked_buy_count": 0,
+      "basis_blocked_buy_count": 0,
+      "dislocation_blocked_buy_count": 0
+    },
+    "gates": {
+      "min_trades": 0,
+      "min_wfo_trades": 20,
+      "min_wfo_sharpe": 0.5,
+      "max_drawdown_pct": 10.0,
+      "max_bootstrap_p_loss_pct": 25.0,
+      "min_oos_return_pct": 0.0,
+      "max_profit_concentration_pct": 50.0,
+      "max_mc_drawdown_p95_pct": 0.0
+    },
+    "windows": [
+      {
+        "window_index": 1,
+        "train_start": "2024-01-09T00:00:00",
+        "train_end": "2024-07-09T00:00:00",
+        "test_start": "2024-07-09T00:00:00",
+        "test_end": "2024-10-09T00:00:00",
+        "total_trades": 24,
+        "win_rate": 58.333333333333336,
+        "total_return_pct": -6.562311417841739,
+        "max_drawdown_pct": 16.74458980303397,
+        "sharpe_ratio": -0.22382045727092628
+      },
+      {
+        "window_index": 2,
+        "train_start": "2024-07-09T00:00:00",
+        "train_end": "2025-01-09T00:00:00",
+        "test_start": "2025-01-09T00:00:00",
+        "test_end": "2025-04-09T00:00:00",
+        "total_trades": 17,
+        "win_rate": 64.70588235294117,
+        "total_return_pct": 11.349256734105456,
+        "max_drawdown_pct": 37.734113228588825,
+        "sharpe_ratio": 0.9533200769574743
+      },
+      {
+        "window_index": 3,
+        "train_start": "2025-01-09T00:00:00",
+        "train_end": "2025-07-09T00:00:00",
+        "test_start": "2025-07-09T00:00:00",
+        "test_end": "2025-10-09T00:00:00",
+        "total_trades": 29,
+        "win_rate": 58.620689655172406,
+        "total_return_pct": -28.951848047654483,
+        "max_drawdown_pct": 40.58111229275764,
+        "sharpe_ratio": -1.7286772478268126
+      }
+    ],
+    "resolved_backtest_config": {
+      "symbol": "SOLUSDT",
+      "timeframe": "1h",
+      "start_date": "2024-01-09",
+      "end_date": "2026-02-23",
+      "initial_capital": 10000.0,
+      "fee_rate": 0.0004,
+      "stop_loss_pct": 0.01,
+      "take_profit_pct": 0.03,
+      "sl_atr_multiplier": 2.38,
+      "tp_atr_multiplier": 4.23,
+      "trailing_activate_atr": 1.82,
+      "trailing_offset_atr": 1.07,
+      "slippage_pct": 0.0002,
+      "risk_per_trade": 0.02,
+      "use_atr_sizing": false,
+      "atr_multiplier": 1.0,
+      "apply_global_trend_filter": true,
+      "global_trend_filter_buffer_pct": 0.0,
+      "global_trend_filter_source": "cost_profile_override",
+      "config_global_trend_filter_enabled": null,
+      "session_liquidity_router": {
+        "enabled": false,
+        "allowed_windows": [
+          "americas"
+        ],
+        "block_entries_outside_windows": true
+      },
+      "basis_premium_filter": {
+        "enabled": false,
+        "exchange": "binance_usdm",
+        "tail_metric": "basis_bps",
+        "positive_tail_pct": 0.05,
+        "block_positive_tail_longs": true,
+        "missing_data_policy": "allow",
+        "calibrated_positive_threshold": null
+      },
+      "cross_venue_dislocation": {
+        "enabled": false,
+        "metric": "basis_spread",
+        "mode": "require",
+        "min_spread_bps": 5.0,
+        "side": "both",
+        "missing_data_policy": "allow"
+      },
+      "allow_short": false,
+      "use_executor_exit_model": true,
+      "ignore_signal_sells": false,
+      "strategy_configs": [
+        {
+          "rsi_period": 7,
+          "oversold_threshold": 35,
+          "overbought_threshold": 65
+        },
+        {
+          "min_histogram_threshold": 0.0,
+          "use_atr_filter": true,
+          "atr_min_pct": 0.0078
+        },
+        {
+          "band_distance_threshold": 0.0049,
+          "rsi_oversold": 35,
+          "rsi_overbought": 70
+        },
+        {
+          "cci_buy_threshold": 100,
+          "cci_sell_threshold": -100,
+          "atr_min_pct": 0.0114
+        },
+        {
+          "vwap_atr_multiplier": 2.02,
+          "rsi_oversold": 40,
+          "rsi_overbought": 60
+        },
+        {
+          "rsi_reclaim_level": 50,
+          "min_trend_strength_pct": 0.0089,
+          "max_pullback_distance_pct": 0.0291,
+          "vwap_pullback_distance_pct": 0.0151,
+          "min_atr_pct": 0.0064,
+          "min_macd_hist": -0.0084,
+          "strong_trend_strength_pct": 0.0153,
+          "continuation_rsi_level": 52,
+          "continuation_max_vwap_distance_pct": 0.0434,
+          "continuation_max_ema50_extension_pct": 0.0361,
+          "continuation_min_macd_hist": -0.0054
+        }
+      ],
+      "aggregator_config": {
+        "buy_threshold": 0.7,
+        "buy_threshold_uptrend": 0.7,
+        "sell_threshold": -0.79,
+        "btc_regime_filter_enabled": true,
+        "btc_reference_symbol": "BTCUSDT",
+        "btc_dump_threshold_pct": -1.0,
+        "btc_dump_require_below_ema200": true,
+        "min_confidence": 0.04
+      },
+      "time_stop_minutes": 0.0,
+      "replay_sentiment_path": null,
+      "replay_sentiment_max_age_seconds": null,
+      "futures_mode": true,
+      "futures_leverage": 3,
+      "futures_funding_rate": 0.0001,
+      "funding_cadence": "scaled_8h",
+      "fixed_notional_usdt": 0.0,
+      "quantity_step_size": 0.0,
+      "min_notional_usdt": 0.0
+    },
+    "cost_audit": {
+      "name": "corrected",
+      "fee_rate": 0.0004,
+      "slippage_pct": 0.0002,
+      "apply_global_trend_filter": true,
+      "funding_cadence": "scaled_8h",
+      "base_futures_funding_rate": 0.0001,
+      "round_trip_cost_pct": 0.12000000000000001,
+      "funding_method": "scale per-bar rate by tf_hours/8 (equivalent to 8h settlement cadence)",
+      "effective_futures_funding_rate": 1.25e-05
+    },
+    "global_trend_filter_audit": {
+      "active": true,
+      "buffer_pct": 0.0,
+      "source": "cost_profile_override",
+      "config_explicit": null
+    },
+    "buy_threshold_binding_audit": {
+      "aggregator.buy_threshold": 0.7,
+      "aggregator.buy_threshold_uptrend": 0.7,
+      "per_symbol_aggregator_config.SOLUSDT.buy_threshold": 0.7,
+      "per_symbol_aggregator_config.SOLUSDT.buy_threshold_uptrend": 0.7
+    },
+    "effective_start": "2024-01-09",
+    "effective_end": "2026-02-23",
+    "coverage": {
+      "requested_start": "2024-01-01",
+      "requested_end": "2026-06-01",
+      "data_start": "2024-01-09T07:00:00+00:00",
+      "data_end": "2026-02-23T19:00:00+00:00",
+      "effective_start": "2024-01-09",
+      "effective_end": "2026-02-23",
+      "clamped_start": true,
+      "clamped_end": true
+    }
+  },
+  {
+    "buy_threshold": 0.8,
+    "summary": {
+      "symbol": "SOLUSDT",
+      "timeframe": "1h",
+      "start": "2024-01-09",
+      "end": "2026-02-23",
+      "total_trades": 149,
+      "win_rate": 56.375838926174495,
+      "total_return_pct": -74.68405346080712,
+      "max_drawdown_pct": 79.15236733302814,
+      "sharpe_ratio": -0.5892349272071247,
+      "wfo_windows": 3,
+      "wfo_total_trades": 51,
+      "wfo_mean_sharpe": -0.3970070274588852,
+      "wfo_total_return_pct": -17.44728462571833,
+      "bootstrap_p_loss_pct": 91.2,
+      "mc_drawdown_p95_pct": 96.8279070069929,
+      "mc_drawdown_p50_pct": 83.49766254997158,
+      "profit_concentration_pct": 100.0,
+      "passes_gates": false,
+      "failure_reasons": [
+        "min_wfo_sharpe failed (-0.40 < 0.50)",
+        "max_drawdown_pct failed (79.15% > 10.00%)",
+        "max_bootstrap_p_loss_pct failed (91.20% > 25.00%)",
+        "min_oos_return_pct failed (-17.45% < 0.00%)",
+        "max_profit_concentration_pct failed (100.00% > 50.00%)"
+      ],
+      "blocked_buy_count": 0,
+      "basis_blocked_buy_count": 0,
+      "dislocation_blocked_buy_count": 0
+    },
+    "gates": {
+      "min_trades": 0,
+      "min_wfo_trades": 20,
+      "min_wfo_sharpe": 0.5,
+      "max_drawdown_pct": 10.0,
+      "max_bootstrap_p_loss_pct": 25.0,
+      "min_oos_return_pct": 0.0,
+      "max_profit_concentration_pct": 50.0,
+      "max_mc_drawdown_p95_pct": 0.0
+    },
+    "windows": [
+      {
+        "window_index": 1,
+        "train_start": "2024-01-09T00:00:00",
+        "train_end": "2024-07-09T00:00:00",
+        "test_start": "2024-07-09T00:00:00",
+        "test_end": "2024-10-09T00:00:00",
+        "total_trades": 15,
+        "win_rate": 46.666666666666664,
+        "total_return_pct": -12.753205275044985,
+        "max_drawdown_pct": 17.117412243230806,
+        "sharpe_ratio": -0.8917853051657967
+      },
+      {
+        "window_index": 2,
+        "train_start": "2024-07-09T00:00:00",
+        "train_end": "2025-01-09T00:00:00",
+        "test_start": "2025-01-09T00:00:00",
+        "test_end": "2025-04-09T00:00:00",
+        "total_trades": 11,
+        "win_rate": 72.72727272727273,
+        "total_return_pct": 30.208154120926515,
+        "max_drawdown_pct": 37.734113228588825,
+        "sharpe_ratio": 1.4864021231687852
+      },
+      {
+        "window_index": 3,
+        "train_start": "2025-01-09T00:00:00",
+        "train_end": "2025-07-09T00:00:00",
+        "test_start": "2025-07-09T00:00:00",
+        "test_end": "2025-10-09T00:00:00",
+        "total_trades": 25,
+        "win_rate": 56.00000000000001,
+        "total_return_pct": -27.33191761510797,
+        "max_drawdown_pct": 35.302406181640606,
+        "sharpe_ratio": -1.785637900379644
+      }
+    ],
+    "resolved_backtest_config": {
+      "symbol": "SOLUSDT",
+      "timeframe": "1h",
+      "start_date": "2024-01-09",
+      "end_date": "2026-02-23",
+      "initial_capital": 10000.0,
+      "fee_rate": 0.0004,
+      "stop_loss_pct": 0.01,
+      "take_profit_pct": 0.03,
+      "sl_atr_multiplier": 2.38,
+      "tp_atr_multiplier": 4.23,
+      "trailing_activate_atr": 1.82,
+      "trailing_offset_atr": 1.07,
+      "slippage_pct": 0.0002,
+      "risk_per_trade": 0.02,
+      "use_atr_sizing": false,
+      "atr_multiplier": 1.0,
+      "apply_global_trend_filter": true,
+      "global_trend_filter_buffer_pct": 0.0,
+      "global_trend_filter_source": "cost_profile_override",
+      "config_global_trend_filter_enabled": null,
+      "session_liquidity_router": {
+        "enabled": false,
+        "allowed_windows": [
+          "americas"
+        ],
+        "block_entries_outside_windows": true
+      },
+      "basis_premium_filter": {
+        "enabled": false,
+        "exchange": "binance_usdm",
+        "tail_metric": "basis_bps",
+        "positive_tail_pct": 0.05,
+        "block_positive_tail_longs": true,
+        "missing_data_policy": "allow",
+        "calibrated_positive_threshold": null
+      },
+      "cross_venue_dislocation": {
+        "enabled": false,
+        "metric": "basis_spread",
+        "mode": "require",
+        "min_spread_bps": 5.0,
+        "side": "both",
+        "missing_data_policy": "allow"
+      },
+      "allow_short": false,
+      "use_executor_exit_model": true,
+      "ignore_signal_sells": false,
+      "strategy_configs": [
+        {
+          "rsi_period": 7,
+          "oversold_threshold": 35,
+          "overbought_threshold": 65
+        },
+        {
+          "min_histogram_threshold": 0.0,
+          "use_atr_filter": true,
+          "atr_min_pct": 0.0078
+        },
+        {
+          "band_distance_threshold": 0.0049,
+          "rsi_oversold": 35,
+          "rsi_overbought": 70
+        },
+        {
+          "cci_buy_threshold": 100,
+          "cci_sell_threshold": -100,
+          "atr_min_pct": 0.0114
+        },
+        {
+          "vwap_atr_multiplier": 2.02,
+          "rsi_oversold": 40,
+          "rsi_overbought": 60
+        },
+        {
+          "rsi_reclaim_level": 50,
+          "min_trend_strength_pct": 0.0089,
+          "max_pullback_distance_pct": 0.0291,
+          "vwap_pullback_distance_pct": 0.0151,
+          "min_atr_pct": 0.0064,
+          "min_macd_hist": -0.0084,
+          "strong_trend_strength_pct": 0.0153,
+          "continuation_rsi_level": 52,
+          "continuation_max_vwap_distance_pct": 0.0434,
+          "continuation_max_ema50_extension_pct": 0.0361,
+          "continuation_min_macd_hist": -0.0054
+        }
+      ],
+      "aggregator_config": {
+        "buy_threshold": 0.8,
+        "buy_threshold_uptrend": 0.8,
+        "sell_threshold": -0.79,
+        "btc_regime_filter_enabled": true,
+        "btc_reference_symbol": "BTCUSDT",
+        "btc_dump_threshold_pct": -1.0,
+        "btc_dump_require_below_ema200": true,
+        "min_confidence": 0.04
+      },
+      "time_stop_minutes": 0.0,
+      "replay_sentiment_path": null,
+      "replay_sentiment_max_age_seconds": null,
+      "futures_mode": true,
+      "futures_leverage": 3,
+      "futures_funding_rate": 0.0001,
+      "funding_cadence": "scaled_8h",
+      "fixed_notional_usdt": 0.0,
+      "quantity_step_size": 0.0,
+      "min_notional_usdt": 0.0
+    },
+    "cost_audit": {
+      "name": "corrected",
+      "fee_rate": 0.0004,
+      "slippage_pct": 0.0002,
+      "apply_global_trend_filter": true,
+      "funding_cadence": "scaled_8h",
+      "base_futures_funding_rate": 0.0001,
+      "round_trip_cost_pct": 0.12000000000000001,
+      "funding_method": "scale per-bar rate by tf_hours/8 (equivalent to 8h settlement cadence)",
+      "effective_futures_funding_rate": 1.25e-05
+    },
+    "global_trend_filter_audit": {
+      "active": true,
+      "buffer_pct": 0.0,
+      "source": "cost_profile_override",
+      "config_explicit": null
+    },
+    "buy_threshold_binding_audit": {
+      "aggregator.buy_threshold": 0.8,
+      "aggregator.buy_threshold_uptrend": 0.8,
+      "per_symbol_aggregator_config.SOLUSDT.buy_threshold": 0.8,
+      "per_symbol_aggregator_config.SOLUSDT.buy_threshold_uptrend": 0.8
+    },
+    "effective_start": "2024-01-09",
+    "effective_end": "2026-02-23",
+    "coverage": {
+      "requested_start": "2024-01-01",
+      "requested_end": "2026-06-01",
+      "data_start": "2024-01-09T07:00:00+00:00",
+      "data_end": "2026-02-23T19:00:00+00:00",
+      "effective_start": "2024-01-09",
+      "effective_end": "2026-02-23",
+      "clamped_start": true,
+      "clamped_end": true
+    }
+  },
+  {
+    "buy_threshold": 0.9,
+    "summary": {
+      "symbol": "SOLUSDT",
+      "timeframe": "1h",
+      "start": "2024-01-09",
+      "end": "2026-02-23",
+      "total_trades": 112,
+      "win_rate": 58.03571428571429,
+      "total_return_pct": -66.41679525052224,
+      "max_drawdown_pct": 76.66761717470757,
+      "sharpe_ratio": -0.5090939863413726,
+      "wfo_windows": 3,
+      "wfo_total_trades": 41,
+      "wfo_mean_sharpe": 0.3598716584588384,
+      "wfo_total_return_pct": 3.418606401869506,
+      "bootstrap_p_loss_pct": 86.8,
+      "mc_drawdown_p95_pct": 94.37039160281834,
+      "mc_drawdown_p50_pct": 77.1260260671864,
+      "profit_concentration_pct": 60.39839944891576,
+      "passes_gates": false,
+      "failure_reasons": [
+        "min_wfo_sharpe failed (0.36 < 0.50)",
+        "max_drawdown_pct failed (76.67% > 10.00%)",
+        "max_bootstrap_p_loss_pct failed (86.80% > 25.00%)",
+        "max_profit_concentration_pct failed (60.40% > 50.00%)"
+      ],
+      "blocked_buy_count": 0,
+      "basis_blocked_buy_count": 0,
+      "dislocation_blocked_buy_count": 0
+    },
+    "gates": {
+      "min_trades": 0,
+      "min_wfo_trades": 20,
+      "min_wfo_sharpe": 0.5,
+      "max_drawdown_pct": 10.0,
+      "max_bootstrap_p_loss_pct": 25.0,
+      "min_oos_return_pct": 0.0,
+      "max_profit_concentration_pct": 50.0,
+      "max_mc_drawdown_p95_pct": 0.0
+    },
+    "windows": [
+      {
+        "window_index": 1,
+        "train_start": "2024-01-09T00:00:00",
+        "train_end": "2024-07-09T00:00:00",
+        "test_start": "2024-07-09T00:00:00",
+        "test_end": "2024-10-09T00:00:00",
+        "total_trades": 11,
+        "win_rate": 54.54545454545454,
+        "total_return_pct": 8.906816612389248,
+        "max_drawdown_pct": 11.847805201905258,
+        "sharpe_ratio": 0.9770497308856578
+      },
+      {
+        "window_index": 2,
+        "train_start": "2024-07-09T00:00:00",
+        "train_end": "2025-01-09T00:00:00",
+        "test_start": "2025-01-09T00:00:00",
+        "test_end": "2025-04-09T00:00:00",
+        "total_trades": 8,
+        "win_rate": 75.0,
+        "total_return_pct": 13.584235487638544,
+        "max_drawdown_pct": 39.54701664853449,
+        "sharpe_ratio": 1.0005749939770148
+      },
+      {
+        "window_index": 3,
+        "train_start": "2025-01-09T00:00:00",
+        "train_end": "2025-07-09T00:00:00",
+        "test_start": "2025-07-09T00:00:00",
+        "test_end": "2025-10-09T00:00:00",
+        "total_trades": 22,
+        "win_rate": 59.09090909090909,
+        "total_return_pct": -16.39628841581034,
+        "max_drawdown_pct": 30.264472131573854,
+        "sharpe_ratio": -0.8980097494861574
+      }
+    ],
+    "resolved_backtest_config": {
+      "symbol": "SOLUSDT",
+      "timeframe": "1h",
+      "start_date": "2024-01-09",
+      "end_date": "2026-02-23",
+      "initial_capital": 10000.0,
+      "fee_rate": 0.0004,
+      "stop_loss_pct": 0.01,
+      "take_profit_pct": 0.03,
+      "sl_atr_multiplier": 2.38,
+      "tp_atr_multiplier": 4.23,
+      "trailing_activate_atr": 1.82,
+      "trailing_offset_atr": 1.07,
+      "slippage_pct": 0.0002,
+      "risk_per_trade": 0.02,
+      "use_atr_sizing": false,
+      "atr_multiplier": 1.0,
+      "apply_global_trend_filter": true,
+      "global_trend_filter_buffer_pct": 0.0,
+      "global_trend_filter_source": "cost_profile_override",
+      "config_global_trend_filter_enabled": null,
+      "session_liquidity_router": {
+        "enabled": false,
+        "allowed_windows": [
+          "americas"
+        ],
+        "block_entries_outside_windows": true
+      },
+      "basis_premium_filter": {
+        "enabled": false,
+        "exchange": "binance_usdm",
+        "tail_metric": "basis_bps",
+        "positive_tail_pct": 0.05,
+        "block_positive_tail_longs": true,
+        "missing_data_policy": "allow",
+        "calibrated_positive_threshold": null
+      },
+      "cross_venue_dislocation": {
+        "enabled": false,
+        "metric": "basis_spread",
+        "mode": "require",
+        "min_spread_bps": 5.0,
+        "side": "both",
+        "missing_data_policy": "allow"
+      },
+      "allow_short": false,
+      "use_executor_exit_model": true,
+      "ignore_signal_sells": false,
+      "strategy_configs": [
+        {
+          "rsi_period": 7,
+          "oversold_threshold": 35,
+          "overbought_threshold": 65
+        },
+        {
+          "min_histogram_threshold": 0.0,
+          "use_atr_filter": true,
+          "atr_min_pct": 0.0078
+        },
+        {
+          "band_distance_threshold": 0.0049,
+          "rsi_oversold": 35,
+          "rsi_overbought": 70
+        },
+        {
+          "cci_buy_threshold": 100,
+          "cci_sell_threshold": -100,
+          "atr_min_pct": 0.0114
+        },
+        {
+          "vwap_atr_multiplier": 2.02,
+          "rsi_oversold": 40,
+          "rsi_overbought": 60
+        },
+        {
+          "rsi_reclaim_level": 50,
+          "min_trend_strength_pct": 0.0089,
+          "max_pullback_distance_pct": 0.0291,
+          "vwap_pullback_distance_pct": 0.0151,
+          "min_atr_pct": 0.0064,
+          "min_macd_hist": -0.0084,
+          "strong_trend_strength_pct": 0.0153,
+          "continuation_rsi_level": 52,
+          "continuation_max_vwap_distance_pct": 0.0434,
+          "continuation_max_ema50_extension_pct": 0.0361,
+          "continuation_min_macd_hist": -0.0054
+        }
+      ],
+      "aggregator_config": {
+        "buy_threshold": 0.9,
+        "buy_threshold_uptrend": 0.9,
+        "sell_threshold": -0.79,
+        "btc_regime_filter_enabled": true,
+        "btc_reference_symbol": "BTCUSDT",
+        "btc_dump_threshold_pct": -1.0,
+        "btc_dump_require_below_ema200": true,
+        "min_confidence": 0.04
+      },
+      "time_stop_minutes": 0.0,
+      "replay_sentiment_path": null,
+      "replay_sentiment_max_age_seconds": null,
+      "futures_mode": true,
+      "futures_leverage": 3,
+      "futures_funding_rate": 0.0001,
+      "funding_cadence": "scaled_8h",
+      "fixed_notional_usdt": 0.0,
+      "quantity_step_size": 0.0,
+      "min_notional_usdt": 0.0
+    },
+    "cost_audit": {
+      "name": "corrected",
+      "fee_rate": 0.0004,
+      "slippage_pct": 0.0002,
+      "apply_global_trend_filter": true,
+      "funding_cadence": "scaled_8h",
+      "base_futures_funding_rate": 0.0001,
+      "round_trip_cost_pct": 0.12000000000000001,
+      "funding_method": "scale per-bar rate by tf_hours/8 (equivalent to 8h settlement cadence)",
+      "effective_futures_funding_rate": 1.25e-05
+    },
+    "global_trend_filter_audit": {
+      "active": true,
+      "buffer_pct": 0.0,
+      "source": "cost_profile_override",
+      "config_explicit": null
+    },
+    "buy_threshold_binding_audit": {
+      "aggregator.buy_threshold": 0.9,
+      "aggregator.buy_threshold_uptrend": 0.9,
+      "per_symbol_aggregator_config.SOLUSDT.buy_threshold": 0.9,
+      "per_symbol_aggregator_config.SOLUSDT.buy_threshold_uptrend": 0.9
+    },
+    "effective_start": "2024-01-09",
+    "effective_end": "2026-02-23",
+    "coverage": {
+      "requested_start": "2024-01-01",
+      "requested_end": "2026-06-01",
+      "data_start": "2024-01-09T07:00:00+00:00",
+      "data_end": "2026-02-23T19:00:00+00:00",
+      "effective_start": "2024-01-09",
+      "effective_end": "2026-02-23",
+      "clamped_start": true,
+      "clamped_end": true
+    }
+  },
+  {
+    "buy_threshold": 1.0,
+    "summary": {
+      "symbol": "SOLUSDT",
+      "timeframe": "1h",
+      "start": "2024-01-09",
+      "end": "2026-02-23",
+      "total_trades": 81,
+      "win_rate": 53.086419753086425,
+      "total_return_pct": -70.89683663960457,
+      "max_drawdown_pct": 79.14492081754365,
+      "sharpe_ratio": -0.7185010551757466,
+      "wfo_windows": 3,
+      "wfo_total_trades": 27,
+      "wfo_mean_sharpe": -0.3553431250158031,
+      "wfo_total_return_pct": -21.58333971788966,
+      "bootstrap_p_loss_pct": 94.8,
+      "mc_drawdown_p95_pct": 93.89342070137401,
+      "mc_drawdown_p50_pct": 78.4644887187165,
+      "profit_concentration_pct": 100.0,
+      "passes_gates": false,
+      "failure_reasons": [
+        "min_wfo_sharpe failed (-0.36 < 0.50)",
+        "max_drawdown_pct failed (79.14% > 10.00%)",
+        "max_bootstrap_p_loss_pct failed (94.80% > 25.00%)",
+        "min_oos_return_pct failed (-21.58% < 0.00%)",
+        "max_profit_concentration_pct failed (100.00% > 50.00%)"
+      ],
+      "blocked_buy_count": 0,
+      "basis_blocked_buy_count": 0,
+      "dislocation_blocked_buy_count": 0
+    },
+    "gates": {
+      "min_trades": 0,
+      "min_wfo_trades": 20,
+      "min_wfo_sharpe": 0.5,
+      "max_drawdown_pct": 10.0,
+      "max_bootstrap_p_loss_pct": 25.0,
+      "min_oos_return_pct": 0.0,
+      "max_profit_concentration_pct": 50.0,
+      "max_mc_drawdown_p95_pct": 0.0
+    },
+    "windows": [
+      {
+        "window_index": 1,
+        "train_start": "2024-01-09T00:00:00",
+        "train_end": "2024-07-09T00:00:00",
+        "test_start": "2024-07-09T00:00:00",
+        "test_end": "2024-10-09T00:00:00",
+        "total_trades": 8,
+        "win_rate": 50.0,
+        "total_return_pct": -3.8144790727410514,
+        "max_drawdown_pct": 10.407163978498318,
+        "sharpe_ratio": -0.2742964326449168
+      },
+      {
+        "window_index": 2,
+        "train_start": "2024-07-09T00:00:00",
+        "train_end": "2025-01-09T00:00:00",
+        "test_start": "2025-01-09T00:00:00",
+        "test_end": "2025-04-09T00:00:00",
+        "total_trades": 5,
+        "win_rate": 60.0,
+        "total_return_pct": -0.28662798096333064,
+        "max_drawdown_pct": 39.54701664853449,
+        "sharpe_ratio": 0.49712660137466347
+      },
+      {
+        "window_index": 3,
+        "train_start": "2025-01-09T00:00:00",
+        "train_end": "2025-07-09T00:00:00",
+        "test_start": "2025-07-09T00:00:00",
+        "test_end": "2025-10-09T00:00:00",
+        "total_trades": 14,
+        "win_rate": 50.0,
+        "total_return_pct": -18.239180177301595,
+        "max_drawdown_pct": 25.533028234829214,
+        "sharpe_ratio": -1.288859543777156
+      }
+    ],
+    "resolved_backtest_config": {
+      "symbol": "SOLUSDT",
+      "timeframe": "1h",
+      "start_date": "2024-01-09",
+      "end_date": "2026-02-23",
+      "initial_capital": 10000.0,
+      "fee_rate": 0.0004,
+      "stop_loss_pct": 0.01,
+      "take_profit_pct": 0.03,
+      "sl_atr_multiplier": 2.38,
+      "tp_atr_multiplier": 4.23,
+      "trailing_activate_atr": 1.82,
+      "trailing_offset_atr": 1.07,
+      "slippage_pct": 0.0002,
+      "risk_per_trade": 0.02,
+      "use_atr_sizing": false,
+      "atr_multiplier": 1.0,
+      "apply_global_trend_filter": true,
+      "global_trend_filter_buffer_pct": 0.0,
+      "global_trend_filter_source": "cost_profile_override",
+      "config_global_trend_filter_enabled": null,
+      "session_liquidity_router": {
+        "enabled": false,
+        "allowed_windows": [
+          "americas"
+        ],
+        "block_entries_outside_windows": true
+      },
+      "basis_premium_filter": {
+        "enabled": false,
+        "exchange": "binance_usdm",
+        "tail_metric": "basis_bps",
+        "positive_tail_pct": 0.05,
+        "block_positive_tail_longs": true,
+        "missing_data_policy": "allow",
+        "calibrated_positive_threshold": null
+      },
+      "cross_venue_dislocation": {
+        "enabled": false,
+        "metric": "basis_spread",
+        "mode": "require",
+        "min_spread_bps": 5.0,
+        "side": "both",
+        "missing_data_policy": "allow"
+      },
+      "allow_short": false,
+      "use_executor_exit_model": true,
+      "ignore_signal_sells": false,
+      "strategy_configs": [
+        {
+          "rsi_period": 7,
+          "oversold_threshold": 35,
+          "overbought_threshold": 65
+        },
+        {
+          "min_histogram_threshold": 0.0,
+          "use_atr_filter": true,
+          "atr_min_pct": 0.0078
+        },
+        {
+          "band_distance_threshold": 0.0049,
+          "rsi_oversold": 35,
+          "rsi_overbought": 70
+        },
+        {
+          "cci_buy_threshold": 100,
+          "cci_sell_threshold": -100,
+          "atr_min_pct": 0.0114
+        },
+        {
+          "vwap_atr_multiplier": 2.02,
+          "rsi_oversold": 40,
+          "rsi_overbought": 60
+        },
+        {
+          "rsi_reclaim_level": 50,
+          "min_trend_strength_pct": 0.0089,
+          "max_pullback_distance_pct": 0.0291,
+          "vwap_pullback_distance_pct": 0.0151,
+          "min_atr_pct": 0.0064,
+          "min_macd_hist": -0.0084,
+          "strong_trend_strength_pct": 0.0153,
+          "continuation_rsi_level": 52,
+          "continuation_max_vwap_distance_pct": 0.0434,
+          "continuation_max_ema50_extension_pct": 0.0361,
+          "continuation_min_macd_hist": -0.0054
+        }
+      ],
+      "aggregator_config": {
+        "buy_threshold": 1.0,
+        "buy_threshold_uptrend": 1.0,
+        "sell_threshold": -0.79,
+        "btc_regime_filter_enabled": true,
+        "btc_reference_symbol": "BTCUSDT",
+        "btc_dump_threshold_pct": -1.0,
+        "btc_dump_require_below_ema200": true,
+        "min_confidence": 0.04
+      },
+      "time_stop_minutes": 0.0,
+      "replay_sentiment_path": null,
+      "replay_sentiment_max_age_seconds": null,
+      "futures_mode": true,
+      "futures_leverage": 3,
+      "futures_funding_rate": 0.0001,
+      "funding_cadence": "scaled_8h",
+      "fixed_notional_usdt": 0.0,
+      "quantity_step_size": 0.0,
+      "min_notional_usdt": 0.0
+    },
+    "cost_audit": {
+      "name": "corrected",
+      "fee_rate": 0.0004,
+      "slippage_pct": 0.0002,
+      "apply_global_trend_filter": true,
+      "funding_cadence": "scaled_8h",
+      "base_futures_funding_rate": 0.0001,
+      "round_trip_cost_pct": 0.12000000000000001,
+      "funding_method": "scale per-bar rate by tf_hours/8 (equivalent to 8h settlement cadence)",
+      "effective_futures_funding_rate": 1.25e-05
+    },
+    "global_trend_filter_audit": {
+      "active": true,
+      "buffer_pct": 0.0,
+      "source": "cost_profile_override",
+      "config_explicit": null
+    },
+    "buy_threshold_binding_audit": {
+      "aggregator.buy_threshold": 1.0,
+      "aggregator.buy_threshold_uptrend": 1.0,
+      "per_symbol_aggregator_config.SOLUSDT.buy_threshold": 1.0,
+      "per_symbol_aggregator_config.SOLUSDT.buy_threshold_uptrend": 1.0
+    },
+    "effective_start": "2024-01-09",
+    "effective_end": "2026-02-23",
+    "coverage": {
+      "requested_start": "2024-01-01",
+      "requested_end": "2026-06-01",
+      "data_start": "2024-01-09T07:00:00+00:00",
+      "data_end": "2026-02-23T19:00:00+00:00",
+      "effective_start": "2024-01-09",
+      "effective_end": "2026-02-23",
+      "clamped_start": true,
+      "clamped_end": true
+    }
+  },
+  {
+    "buy_threshold": 1.07,
+    "summary": {
+      "symbol": "SOLUSDT",
+      "timeframe": "1h",
+      "start": "2024-01-09",
+      "end": "2026-02-23",
+      "total_trades": 42,
+      "win_rate": 59.523809523809526,
+      "total_return_pct": 38.368455578641225,
+      "max_drawdown_pct": 29.169602365246906,
+      "sharpe_ratio": 0.5767299024842656,
+      "wfo_windows": 3,
+      "wfo_total_trades": 11,
+      "wfo_mean_sharpe": 0.9999453684547117,
+      "wfo_total_return_pct": 53.46762413547728,
+      "bootstrap_p_loss_pct": 24.6,
+      "mc_drawdown_p95_pct": 57.421134178026456,
+      "mc_drawdown_p50_pct": 31.950425254251254,
+      "profit_concentration_pct": 95.15432747479574,
+      "passes_gates": false,
+      "failure_reasons": [
+        "min_wfo_trades failed (11 < 20)",
+        "max_drawdown_pct failed (29.17% > 10.00%)",
+        "max_profit_concentration_pct failed (95.15% > 50.00%)"
+      ],
+      "blocked_buy_count": 0,
+      "basis_blocked_buy_count": 0,
+      "dislocation_blocked_buy_count": 0
+    },
+    "gates": {
+      "min_trades": 0,
+      "min_wfo_trades": 20,
+      "min_wfo_sharpe": 0.5,
+      "max_drawdown_pct": 10.0,
+      "max_bootstrap_p_loss_pct": 25.0,
+      "min_oos_return_pct": 0.0,
+      "max_profit_concentration_pct": 50.0,
+      "max_mc_drawdown_p95_pct": 0.0
+    },
+    "windows": [
+      {
+        "window_index": 1,
+        "train_start": "2024-01-09T00:00:00",
+        "train_end": "2024-07-09T00:00:00",
+        "test_start": "2024-07-09T00:00:00",
+        "test_end": "2024-10-09T00:00:00",
+        "total_trades": 4,
+        "win_rate": 50.0,
+        "total_return_pct": 2.6901952352623266,
+        "max_drawdown_pct": 7.338719424309017,
+        "sharpe_ratio": 0.6480830255984609
+      },
+      {
+        "window_index": 2,
+        "train_start": "2024-07-09T00:00:00",
+        "train_end": "2025-01-09T00:00:00",
+        "test_start": "2025-01-09T00:00:00",
+        "test_end": "2025-04-09T00:00:00",
+        "total_trades": 2,
+        "win_rate": 100.0,
+        "total_return_pct": 52.827283943728,
+        "max_drawdown_pct": 5.434230140424734,
+        "sharpe_ratio": 2.575235696322529
+      },
+      {
+        "window_index": 3,
+        "train_start": "2025-01-09T00:00:00",
+        "train_end": "2025-07-09T00:00:00",
+        "test_start": "2025-07-09T00:00:00",
+        "test_end": "2025-10-09T00:00:00",
+        "total_trades": 5,
+        "win_rate": 60.0,
+        "total_return_pct": -2.211700191822456,
+        "max_drawdown_pct": 10.553055273056263,
+        "sharpe_ratio": -0.22348261655685475
+      }
+    ],
+    "resolved_backtest_config": {
+      "symbol": "SOLUSDT",
+      "timeframe": "1h",
+      "start_date": "2024-01-09",
+      "end_date": "2026-02-23",
+      "initial_capital": 10000.0,
+      "fee_rate": 0.0004,
+      "stop_loss_pct": 0.01,
+      "take_profit_pct": 0.03,
+      "sl_atr_multiplier": 2.38,
+      "tp_atr_multiplier": 4.23,
+      "trailing_activate_atr": 1.82,
+      "trailing_offset_atr": 1.07,
+      "slippage_pct": 0.0002,
+      "risk_per_trade": 0.02,
+      "use_atr_sizing": false,
+      "atr_multiplier": 1.0,
+      "apply_global_trend_filter": true,
+      "global_trend_filter_buffer_pct": 0.0,
+      "global_trend_filter_source": "cost_profile_override",
+      "config_global_trend_filter_enabled": null,
+      "session_liquidity_router": {
+        "enabled": false,
+        "allowed_windows": [
+          "americas"
+        ],
+        "block_entries_outside_windows": true
+      },
+      "basis_premium_filter": {
+        "enabled": false,
+        "exchange": "binance_usdm",
+        "tail_metric": "basis_bps",
+        "positive_tail_pct": 0.05,
+        "block_positive_tail_longs": true,
+        "missing_data_policy": "allow",
+        "calibrated_positive_threshold": null
+      },
+      "cross_venue_dislocation": {
+        "enabled": false,
+        "metric": "basis_spread",
+        "mode": "require",
+        "min_spread_bps": 5.0,
+        "side": "both",
+        "missing_data_policy": "allow"
+      },
+      "allow_short": false,
+      "use_executor_exit_model": true,
+      "ignore_signal_sells": false,
+      "strategy_configs": [
+        {
+          "rsi_period": 7,
+          "oversold_threshold": 35,
+          "overbought_threshold": 65
+        },
+        {
+          "min_histogram_threshold": 0.0,
+          "use_atr_filter": true,
+          "atr_min_pct": 0.0078
+        },
+        {
+          "band_distance_threshold": 0.0049,
+          "rsi_oversold": 35,
+          "rsi_overbought": 70
+        },
+        {
+          "cci_buy_threshold": 100,
+          "cci_sell_threshold": -100,
+          "atr_min_pct": 0.0114
+        },
+        {
+          "vwap_atr_multiplier": 2.02,
+          "rsi_oversold": 40,
+          "rsi_overbought": 60
+        },
+        {
+          "rsi_reclaim_level": 50,
+          "min_trend_strength_pct": 0.0089,
+          "max_pullback_distance_pct": 0.0291,
+          "vwap_pullback_distance_pct": 0.0151,
+          "min_atr_pct": 0.0064,
+          "min_macd_hist": -0.0084,
+          "strong_trend_strength_pct": 0.0153,
+          "continuation_rsi_level": 52,
+          "continuation_max_vwap_distance_pct": 0.0434,
+          "continuation_max_ema50_extension_pct": 0.0361,
+          "continuation_min_macd_hist": -0.0054
+        }
+      ],
+      "aggregator_config": {
+        "buy_threshold": 1.07,
+        "buy_threshold_uptrend": 1.07,
+        "sell_threshold": -0.79,
+        "btc_regime_filter_enabled": true,
+        "btc_reference_symbol": "BTCUSDT",
+        "btc_dump_threshold_pct": -1.0,
+        "btc_dump_require_below_ema200": true,
+        "min_confidence": 0.04
+      },
+      "time_stop_minutes": 0.0,
+      "replay_sentiment_path": null,
+      "replay_sentiment_max_age_seconds": null,
+      "futures_mode": true,
+      "futures_leverage": 3,
+      "futures_funding_rate": 0.0001,
+      "funding_cadence": "scaled_8h",
+      "fixed_notional_usdt": 0.0,
+      "quantity_step_size": 0.0,
+      "min_notional_usdt": 0.0
+    },
+    "cost_audit": {
+      "name": "corrected",
+      "fee_rate": 0.0004,
+      "slippage_pct": 0.0002,
+      "apply_global_trend_filter": true,
+      "funding_cadence": "scaled_8h",
+      "base_futures_funding_rate": 0.0001,
+      "round_trip_cost_pct": 0.12000000000000001,
+      "funding_method": "scale per-bar rate by tf_hours/8 (equivalent to 8h settlement cadence)",
+      "effective_futures_funding_rate": 1.25e-05
+    },
+    "global_trend_filter_audit": {
+      "active": true,
+      "buffer_pct": 0.0,
+      "source": "cost_profile_override",
+      "config_explicit": null
+    },
+    "buy_threshold_binding_audit": {
+      "aggregator.buy_threshold": 1.07,
+      "aggregator.buy_threshold_uptrend": 1.07,
+      "per_symbol_aggregator_config.SOLUSDT.buy_threshold": 1.07,
+      "per_symbol_aggregator_config.SOLUSDT.buy_threshold_uptrend": 1.07
+    },
+    "effective_start": "2024-01-09",
+    "effective_end": "2026-02-23",
+    "coverage": {
+      "requested_start": "2024-01-01",
+      "requested_end": "2026-06-01",
+      "data_start": "2024-01-09T07:00:00+00:00",
+      "data_end": "2026-02-23T19:00:00+00:00",
+      "effective_start": "2024-01-09",
+      "effective_end": "2026-02-23",
+      "clamped_start": true,
+      "clamped_end": true
+    }
+  },
+  {
+    "buy_threshold": 1.27,
+    "summary": {
+      "symbol": "SOLUSDT",
+      "timeframe": "1h",
+      "start": "2024-01-09",
+      "end": "2026-02-23",
+      "total_trades": 24,
+      "win_rate": 62.5,
+      "total_return_pct": 14.247749607333917,
+      "max_drawdown_pct": 28.425585568696864,
+      "sharpe_ratio": 0.37976601801105586,
+      "wfo_windows": 3,
+      "wfo_total_trades": 6,
+      "wfo_mean_sharpe": 1.0522123094688793,
+      "wfo_total_return_pct": 19.418830126815266,
+      "bootstrap_p_loss_pct": 30.4,
+      "mc_drawdown_p95_pct": 46.006007419626336,
+      "mc_drawdown_p50_pct": 23.408509843833755,
+      "profit_concentration_pct": 53.95262560640962,
+      "passes_gates": false,
+      "failure_reasons": [
+        "min_wfo_trades failed (6 < 20)",
+        "max_drawdown_pct failed (28.43% > 10.00%)",
+        "max_bootstrap_p_loss_pct failed (30.40% > 25.00%)",
+        "max_profit_concentration_pct failed (53.95% > 50.00%)"
+      ],
+      "blocked_buy_count": 0,
+      "basis_blocked_buy_count": 0,
+      "dislocation_blocked_buy_count": 0
+    },
+    "gates": {
+      "min_trades": 0,
+      "min_wfo_trades": 20,
+      "min_wfo_sharpe": 0.5,
+      "max_drawdown_pct": 10.0,
+      "max_bootstrap_p_loss_pct": 25.0,
+      "min_oos_return_pct": 0.0,
+      "max_profit_concentration_pct": 50.0,
+      "max_mc_drawdown_p95_pct": 0.0
+    },
+    "windows": [
+      {
+        "window_index": 1,
+        "train_start": "2024-01-09T00:00:00",
+        "train_end": "2024-07-09T00:00:00",
+        "test_start": "2024-07-09T00:00:00",
+        "test_end": "2024-10-09T00:00:00",
+        "total_trades": 3,
+        "win_rate": 66.66666666666666,
+        "total_return_pct": 10.823198856375784,
+        "max_drawdown_pct": 6.202350019394471,
+        "sharpe_ratio": 2.484574705773612
+      },
+      {
+        "window_index": 2,
+        "train_start": "2024-07-09T00:00:00",
+        "train_end": "2025-01-09T00:00:00",
+        "test_start": "2025-01-09T00:00:00",
+        "test_end": "2025-04-09T00:00:00",
+        "total_trades": 1,
+        "win_rate": 100.0,
+        "total_return_pct": 12.681287553347357,
+        "max_drawdown_pct": 5.434230140424734,
+        "sharpe_ratio": 2.125704845636819
+      },
+      {
+        "window_index": 3,
+        "train_start": "2025-01-09T00:00:00",
+        "train_end": "2025-07-09T00:00:00",
+        "test_start": "2025-07-09T00:00:00",
+        "test_end": "2025-10-09T00:00:00",
+        "total_trades": 2,
+        "win_rate": 50.0,
+        "total_return_pct": -4.370842452832457,
+        "max_drawdown_pct": 10.553055273056287,
+        "sharpe_ratio": -1.4536426230037927
+      }
+    ],
+    "resolved_backtest_config": {
+      "symbol": "SOLUSDT",
+      "timeframe": "1h",
+      "start_date": "2024-01-09",
+      "end_date": "2026-02-23",
+      "initial_capital": 10000.0,
+      "fee_rate": 0.0004,
+      "stop_loss_pct": 0.01,
+      "take_profit_pct": 0.03,
+      "sl_atr_multiplier": 2.38,
+      "tp_atr_multiplier": 4.23,
+      "trailing_activate_atr": 1.82,
+      "trailing_offset_atr": 1.07,
+      "slippage_pct": 0.0002,
+      "risk_per_trade": 0.02,
+      "use_atr_sizing": false,
+      "atr_multiplier": 1.0,
+      "apply_global_trend_filter": true,
+      "global_trend_filter_buffer_pct": 0.0,
+      "global_trend_filter_source": "cost_profile_override",
+      "config_global_trend_filter_enabled": null,
+      "session_liquidity_router": {
+        "enabled": false,
+        "allowed_windows": [
+          "americas"
+        ],
+        "block_entries_outside_windows": true
+      },
+      "basis_premium_filter": {
+        "enabled": false,
+        "exchange": "binance_usdm",
+        "tail_metric": "basis_bps",
+        "positive_tail_pct": 0.05,
+        "block_positive_tail_longs": true,
+        "missing_data_policy": "allow",
+        "calibrated_positive_threshold": null
+      },
+      "cross_venue_dislocation": {
+        "enabled": false,
+        "metric": "basis_spread",
+        "mode": "require",
+        "min_spread_bps": 5.0,
+        "side": "both",
+        "missing_data_policy": "allow"
+      },
+      "allow_short": false,
+      "use_executor_exit_model": true,
+      "ignore_signal_sells": false,
+      "strategy_configs": [
+        {
+          "rsi_period": 7,
+          "oversold_threshold": 35,
+          "overbought_threshold": 65
+        },
+        {
+          "min_histogram_threshold": 0.0,
+          "use_atr_filter": true,
+          "atr_min_pct": 0.0078
+        },
+        {
+          "band_distance_threshold": 0.0049,
+          "rsi_oversold": 35,
+          "rsi_overbought": 70
+        },
+        {
+          "cci_buy_threshold": 100,
+          "cci_sell_threshold": -100,
+          "atr_min_pct": 0.0114
+        },
+        {
+          "vwap_atr_multiplier": 2.02,
+          "rsi_oversold": 40,
+          "rsi_overbought": 60
+        },
+        {
+          "rsi_reclaim_level": 50,
+          "min_trend_strength_pct": 0.0089,
+          "max_pullback_distance_pct": 0.0291,
+          "vwap_pullback_distance_pct": 0.0151,
+          "min_atr_pct": 0.0064,
+          "min_macd_hist": -0.0084,
+          "strong_trend_strength_pct": 0.0153,
+          "continuation_rsi_level": 52,
+          "continuation_max_vwap_distance_pct": 0.0434,
+          "continuation_max_ema50_extension_pct": 0.0361,
+          "continuation_min_macd_hist": -0.0054
+        }
+      ],
+      "aggregator_config": {
+        "buy_threshold": 1.27,
+        "buy_threshold_uptrend": 1.27,
+        "sell_threshold": -0.79,
+        "btc_regime_filter_enabled": true,
+        "btc_reference_symbol": "BTCUSDT",
+        "btc_dump_threshold_pct": -1.0,
+        "btc_dump_require_below_ema200": true,
+        "min_confidence": 0.04
+      },
+      "time_stop_minutes": 0.0,
+      "replay_sentiment_path": null,
+      "replay_sentiment_max_age_seconds": null,
+      "futures_mode": true,
+      "futures_leverage": 3,
+      "futures_funding_rate": 0.0001,
+      "funding_cadence": "scaled_8h",
+      "fixed_notional_usdt": 0.0,
+      "quantity_step_size": 0.0,
+      "min_notional_usdt": 0.0
+    },
+    "cost_audit": {
+      "name": "corrected",
+      "fee_rate": 0.0004,
+      "slippage_pct": 0.0002,
+      "apply_global_trend_filter": true,
+      "funding_cadence": "scaled_8h",
+      "base_futures_funding_rate": 0.0001,
+      "round_trip_cost_pct": 0.12000000000000001,
+      "funding_method": "scale per-bar rate by tf_hours/8 (equivalent to 8h settlement cadence)",
+      "effective_futures_funding_rate": 1.25e-05
+    },
+    "global_trend_filter_audit": {
+      "active": true,
+      "buffer_pct": 0.0,
+      "source": "cost_profile_override",
+      "config_explicit": null
+    },
+    "buy_threshold_binding_audit": {
+      "aggregator.buy_threshold": 1.27,
+      "aggregator.buy_threshold_uptrend": 1.27,
+      "per_symbol_aggregator_config.SOLUSDT.buy_threshold": 1.27,
+      "per_symbol_aggregator_config.SOLUSDT.buy_threshold_uptrend": 1.27
+    },
+    "effective_start": "2024-01-09",
+    "effective_end": "2026-02-23",
+    "coverage": {
+      "requested_start": "2024-01-01",
+      "requested_end": "2026-06-01",
+      "data_start": "2024-01-09T07:00:00+00:00",
+      "data_end": "2026-02-23T19:00:00+00:00",
+      "effective_start": "2024-01-09",
+      "effective_end": "2026-02-23",
+      "clamped_start": true,
+      "clamped_end": true
+    }
+  }
+]

--- a/research/overlay-threshold-sweep/resolved/0.50.yaml
+++ b/research/overlay-threshold-sweep/resolved/0.50.yaml
@@ -1,0 +1,93 @@
+agent_id: sol-1h-trend-pullback-overlay-live
+display_name: sol-1h-trend-pullback-overlay-live
+mode: live
+trading:
+  pairs:
+  - SOLUSDT
+  timeframe: 1h
+ingest:
+  use_websocket: false
+telegram:
+  daily_summary_enabled: true
+trading_execution:
+  enabled: true
+  test_mode: false
+  use_atr_sizing: false
+  order_size_usdt: 22.0
+  sl_atr_multiplier: 2.38
+  tp_atr_multiplier: 4.23
+  trailing_activate_atr: 1.82
+  trailing_offset_atr: 1.07
+  exit_rules:
+    backtest_use_executor_exit_model: true
+futures:
+  enabled: true
+  test_mode: false
+  default_leverage: 3
+  max_leverage: 3
+  margin_mode: isolated
+  position_mode: one-way
+  liquidation_buffer_pct: 5.0
+  max_concurrent_longs: 1
+  sl_cooldown_minutes: 240
+  symbols:
+  - SOLUSDT
+strategy:
+  default_trading_mode: futures
+  evaluation_interval_seconds: 3600
+  global_trend_filter_buffer_pct: 0.0
+  strategies:
+  - name: rsi_reversal
+    config:
+      rsi_period: 7
+      oversold_threshold: 35
+      overbought_threshold: 65
+  - name: macd_histogram
+    config:
+      min_histogram_threshold: 0.0
+      use_atr_filter: true
+      atr_min_pct: 0.0078
+  - name: bollinger_bounce
+    config:
+      band_distance_threshold: 0.0049
+      rsi_oversold: 35
+      rsi_overbought: 70
+  - name: cci_breakout
+    config:
+      cci_buy_threshold: 100
+      cci_sell_threshold: -100
+      atr_min_pct: 0.0114
+  - name: vwap_reversion
+    config:
+      vwap_atr_multiplier: 2.02
+      rsi_oversold: 40
+      rsi_overbought: 60
+  - name: trend_pullback
+    config:
+      rsi_reclaim_level: 50
+      min_trend_strength_pct: 0.0089
+      max_pullback_distance_pct: 0.0291
+      vwap_pullback_distance_pct: 0.0151
+      min_atr_pct: 0.0064
+      min_macd_hist: -0.0084
+      strong_trend_strength_pct: 0.0153
+      continuation_rsi_level: 52
+      continuation_max_vwap_distance_pct: 0.0434
+      continuation_max_ema50_extension_pct: 0.0361
+      continuation_min_macd_hist: -0.0054
+  aggregator:
+    buy_threshold: 0.5
+    buy_threshold_uptrend: 0.5
+    sell_threshold: -0.79
+    btc_regime_filter_enabled: true
+    btc_reference_symbol: BTCUSDT
+    btc_dump_threshold_pct: -1.0
+    btc_dump_require_below_ema200: true
+    min_confidence: 0.04
+  per_symbol_aggregator_config:
+    SOLUSDT:
+      min_agreement: 1
+      buy_threshold: 0.5
+      buy_threshold_uptrend: 0.5
+      sell_threshold: -0.79
+      sell_min_agreement: 1

--- a/research/overlay-threshold-sweep/resolved/0.60.yaml
+++ b/research/overlay-threshold-sweep/resolved/0.60.yaml
@@ -1,0 +1,93 @@
+agent_id: sol-1h-trend-pullback-overlay-live
+display_name: sol-1h-trend-pullback-overlay-live
+mode: live
+trading:
+  pairs:
+  - SOLUSDT
+  timeframe: 1h
+ingest:
+  use_websocket: false
+telegram:
+  daily_summary_enabled: true
+trading_execution:
+  enabled: true
+  test_mode: false
+  use_atr_sizing: false
+  order_size_usdt: 22.0
+  sl_atr_multiplier: 2.38
+  tp_atr_multiplier: 4.23
+  trailing_activate_atr: 1.82
+  trailing_offset_atr: 1.07
+  exit_rules:
+    backtest_use_executor_exit_model: true
+futures:
+  enabled: true
+  test_mode: false
+  default_leverage: 3
+  max_leverage: 3
+  margin_mode: isolated
+  position_mode: one-way
+  liquidation_buffer_pct: 5.0
+  max_concurrent_longs: 1
+  sl_cooldown_minutes: 240
+  symbols:
+  - SOLUSDT
+strategy:
+  default_trading_mode: futures
+  evaluation_interval_seconds: 3600
+  global_trend_filter_buffer_pct: 0.0
+  strategies:
+  - name: rsi_reversal
+    config:
+      rsi_period: 7
+      oversold_threshold: 35
+      overbought_threshold: 65
+  - name: macd_histogram
+    config:
+      min_histogram_threshold: 0.0
+      use_atr_filter: true
+      atr_min_pct: 0.0078
+  - name: bollinger_bounce
+    config:
+      band_distance_threshold: 0.0049
+      rsi_oversold: 35
+      rsi_overbought: 70
+  - name: cci_breakout
+    config:
+      cci_buy_threshold: 100
+      cci_sell_threshold: -100
+      atr_min_pct: 0.0114
+  - name: vwap_reversion
+    config:
+      vwap_atr_multiplier: 2.02
+      rsi_oversold: 40
+      rsi_overbought: 60
+  - name: trend_pullback
+    config:
+      rsi_reclaim_level: 50
+      min_trend_strength_pct: 0.0089
+      max_pullback_distance_pct: 0.0291
+      vwap_pullback_distance_pct: 0.0151
+      min_atr_pct: 0.0064
+      min_macd_hist: -0.0084
+      strong_trend_strength_pct: 0.0153
+      continuation_rsi_level: 52
+      continuation_max_vwap_distance_pct: 0.0434
+      continuation_max_ema50_extension_pct: 0.0361
+      continuation_min_macd_hist: -0.0054
+  aggregator:
+    buy_threshold: 0.6
+    buy_threshold_uptrend: 0.6
+    sell_threshold: -0.79
+    btc_regime_filter_enabled: true
+    btc_reference_symbol: BTCUSDT
+    btc_dump_threshold_pct: -1.0
+    btc_dump_require_below_ema200: true
+    min_confidence: 0.04
+  per_symbol_aggregator_config:
+    SOLUSDT:
+      min_agreement: 1
+      buy_threshold: 0.6
+      buy_threshold_uptrend: 0.6
+      sell_threshold: -0.79
+      sell_min_agreement: 1

--- a/research/overlay-threshold-sweep/resolved/0.70.yaml
+++ b/research/overlay-threshold-sweep/resolved/0.70.yaml
@@ -1,0 +1,93 @@
+agent_id: sol-1h-trend-pullback-overlay-live
+display_name: sol-1h-trend-pullback-overlay-live
+mode: live
+trading:
+  pairs:
+  - SOLUSDT
+  timeframe: 1h
+ingest:
+  use_websocket: false
+telegram:
+  daily_summary_enabled: true
+trading_execution:
+  enabled: true
+  test_mode: false
+  use_atr_sizing: false
+  order_size_usdt: 22.0
+  sl_atr_multiplier: 2.38
+  tp_atr_multiplier: 4.23
+  trailing_activate_atr: 1.82
+  trailing_offset_atr: 1.07
+  exit_rules:
+    backtest_use_executor_exit_model: true
+futures:
+  enabled: true
+  test_mode: false
+  default_leverage: 3
+  max_leverage: 3
+  margin_mode: isolated
+  position_mode: one-way
+  liquidation_buffer_pct: 5.0
+  max_concurrent_longs: 1
+  sl_cooldown_minutes: 240
+  symbols:
+  - SOLUSDT
+strategy:
+  default_trading_mode: futures
+  evaluation_interval_seconds: 3600
+  global_trend_filter_buffer_pct: 0.0
+  strategies:
+  - name: rsi_reversal
+    config:
+      rsi_period: 7
+      oversold_threshold: 35
+      overbought_threshold: 65
+  - name: macd_histogram
+    config:
+      min_histogram_threshold: 0.0
+      use_atr_filter: true
+      atr_min_pct: 0.0078
+  - name: bollinger_bounce
+    config:
+      band_distance_threshold: 0.0049
+      rsi_oversold: 35
+      rsi_overbought: 70
+  - name: cci_breakout
+    config:
+      cci_buy_threshold: 100
+      cci_sell_threshold: -100
+      atr_min_pct: 0.0114
+  - name: vwap_reversion
+    config:
+      vwap_atr_multiplier: 2.02
+      rsi_oversold: 40
+      rsi_overbought: 60
+  - name: trend_pullback
+    config:
+      rsi_reclaim_level: 50
+      min_trend_strength_pct: 0.0089
+      max_pullback_distance_pct: 0.0291
+      vwap_pullback_distance_pct: 0.0151
+      min_atr_pct: 0.0064
+      min_macd_hist: -0.0084
+      strong_trend_strength_pct: 0.0153
+      continuation_rsi_level: 52
+      continuation_max_vwap_distance_pct: 0.0434
+      continuation_max_ema50_extension_pct: 0.0361
+      continuation_min_macd_hist: -0.0054
+  aggregator:
+    buy_threshold: 0.7
+    buy_threshold_uptrend: 0.7
+    sell_threshold: -0.79
+    btc_regime_filter_enabled: true
+    btc_reference_symbol: BTCUSDT
+    btc_dump_threshold_pct: -1.0
+    btc_dump_require_below_ema200: true
+    min_confidence: 0.04
+  per_symbol_aggregator_config:
+    SOLUSDT:
+      min_agreement: 1
+      buy_threshold: 0.7
+      buy_threshold_uptrend: 0.7
+      sell_threshold: -0.79
+      sell_min_agreement: 1

--- a/research/overlay-threshold-sweep/resolved/0.80.yaml
+++ b/research/overlay-threshold-sweep/resolved/0.80.yaml
@@ -1,0 +1,93 @@
+agent_id: sol-1h-trend-pullback-overlay-live
+display_name: sol-1h-trend-pullback-overlay-live
+mode: live
+trading:
+  pairs:
+  - SOLUSDT
+  timeframe: 1h
+ingest:
+  use_websocket: false
+telegram:
+  daily_summary_enabled: true
+trading_execution:
+  enabled: true
+  test_mode: false
+  use_atr_sizing: false
+  order_size_usdt: 22.0
+  sl_atr_multiplier: 2.38
+  tp_atr_multiplier: 4.23
+  trailing_activate_atr: 1.82
+  trailing_offset_atr: 1.07
+  exit_rules:
+    backtest_use_executor_exit_model: true
+futures:
+  enabled: true
+  test_mode: false
+  default_leverage: 3
+  max_leverage: 3
+  margin_mode: isolated
+  position_mode: one-way
+  liquidation_buffer_pct: 5.0
+  max_concurrent_longs: 1
+  sl_cooldown_minutes: 240
+  symbols:
+  - SOLUSDT
+strategy:
+  default_trading_mode: futures
+  evaluation_interval_seconds: 3600
+  global_trend_filter_buffer_pct: 0.0
+  strategies:
+  - name: rsi_reversal
+    config:
+      rsi_period: 7
+      oversold_threshold: 35
+      overbought_threshold: 65
+  - name: macd_histogram
+    config:
+      min_histogram_threshold: 0.0
+      use_atr_filter: true
+      atr_min_pct: 0.0078
+  - name: bollinger_bounce
+    config:
+      band_distance_threshold: 0.0049
+      rsi_oversold: 35
+      rsi_overbought: 70
+  - name: cci_breakout
+    config:
+      cci_buy_threshold: 100
+      cci_sell_threshold: -100
+      atr_min_pct: 0.0114
+  - name: vwap_reversion
+    config:
+      vwap_atr_multiplier: 2.02
+      rsi_oversold: 40
+      rsi_overbought: 60
+  - name: trend_pullback
+    config:
+      rsi_reclaim_level: 50
+      min_trend_strength_pct: 0.0089
+      max_pullback_distance_pct: 0.0291
+      vwap_pullback_distance_pct: 0.0151
+      min_atr_pct: 0.0064
+      min_macd_hist: -0.0084
+      strong_trend_strength_pct: 0.0153
+      continuation_rsi_level: 52
+      continuation_max_vwap_distance_pct: 0.0434
+      continuation_max_ema50_extension_pct: 0.0361
+      continuation_min_macd_hist: -0.0054
+  aggregator:
+    buy_threshold: 0.8
+    buy_threshold_uptrend: 0.8
+    sell_threshold: -0.79
+    btc_regime_filter_enabled: true
+    btc_reference_symbol: BTCUSDT
+    btc_dump_threshold_pct: -1.0
+    btc_dump_require_below_ema200: true
+    min_confidence: 0.04
+  per_symbol_aggregator_config:
+    SOLUSDT:
+      min_agreement: 1
+      buy_threshold: 0.8
+      buy_threshold_uptrend: 0.8
+      sell_threshold: -0.79
+      sell_min_agreement: 1

--- a/research/overlay-threshold-sweep/resolved/0.90.yaml
+++ b/research/overlay-threshold-sweep/resolved/0.90.yaml
@@ -1,0 +1,93 @@
+agent_id: sol-1h-trend-pullback-overlay-live
+display_name: sol-1h-trend-pullback-overlay-live
+mode: live
+trading:
+  pairs:
+  - SOLUSDT
+  timeframe: 1h
+ingest:
+  use_websocket: false
+telegram:
+  daily_summary_enabled: true
+trading_execution:
+  enabled: true
+  test_mode: false
+  use_atr_sizing: false
+  order_size_usdt: 22.0
+  sl_atr_multiplier: 2.38
+  tp_atr_multiplier: 4.23
+  trailing_activate_atr: 1.82
+  trailing_offset_atr: 1.07
+  exit_rules:
+    backtest_use_executor_exit_model: true
+futures:
+  enabled: true
+  test_mode: false
+  default_leverage: 3
+  max_leverage: 3
+  margin_mode: isolated
+  position_mode: one-way
+  liquidation_buffer_pct: 5.0
+  max_concurrent_longs: 1
+  sl_cooldown_minutes: 240
+  symbols:
+  - SOLUSDT
+strategy:
+  default_trading_mode: futures
+  evaluation_interval_seconds: 3600
+  global_trend_filter_buffer_pct: 0.0
+  strategies:
+  - name: rsi_reversal
+    config:
+      rsi_period: 7
+      oversold_threshold: 35
+      overbought_threshold: 65
+  - name: macd_histogram
+    config:
+      min_histogram_threshold: 0.0
+      use_atr_filter: true
+      atr_min_pct: 0.0078
+  - name: bollinger_bounce
+    config:
+      band_distance_threshold: 0.0049
+      rsi_oversold: 35
+      rsi_overbought: 70
+  - name: cci_breakout
+    config:
+      cci_buy_threshold: 100
+      cci_sell_threshold: -100
+      atr_min_pct: 0.0114
+  - name: vwap_reversion
+    config:
+      vwap_atr_multiplier: 2.02
+      rsi_oversold: 40
+      rsi_overbought: 60
+  - name: trend_pullback
+    config:
+      rsi_reclaim_level: 50
+      min_trend_strength_pct: 0.0089
+      max_pullback_distance_pct: 0.0291
+      vwap_pullback_distance_pct: 0.0151
+      min_atr_pct: 0.0064
+      min_macd_hist: -0.0084
+      strong_trend_strength_pct: 0.0153
+      continuation_rsi_level: 52
+      continuation_max_vwap_distance_pct: 0.0434
+      continuation_max_ema50_extension_pct: 0.0361
+      continuation_min_macd_hist: -0.0054
+  aggregator:
+    buy_threshold: 0.9
+    buy_threshold_uptrend: 0.9
+    sell_threshold: -0.79
+    btc_regime_filter_enabled: true
+    btc_reference_symbol: BTCUSDT
+    btc_dump_threshold_pct: -1.0
+    btc_dump_require_below_ema200: true
+    min_confidence: 0.04
+  per_symbol_aggregator_config:
+    SOLUSDT:
+      min_agreement: 1
+      buy_threshold: 0.9
+      buy_threshold_uptrend: 0.9
+      sell_threshold: -0.79
+      sell_min_agreement: 1

--- a/research/overlay-threshold-sweep/resolved/1.00.yaml
+++ b/research/overlay-threshold-sweep/resolved/1.00.yaml
@@ -1,0 +1,93 @@
+agent_id: sol-1h-trend-pullback-overlay-live
+display_name: sol-1h-trend-pullback-overlay-live
+mode: live
+trading:
+  pairs:
+  - SOLUSDT
+  timeframe: 1h
+ingest:
+  use_websocket: false
+telegram:
+  daily_summary_enabled: true
+trading_execution:
+  enabled: true
+  test_mode: false
+  use_atr_sizing: false
+  order_size_usdt: 22.0
+  sl_atr_multiplier: 2.38
+  tp_atr_multiplier: 4.23
+  trailing_activate_atr: 1.82
+  trailing_offset_atr: 1.07
+  exit_rules:
+    backtest_use_executor_exit_model: true
+futures:
+  enabled: true
+  test_mode: false
+  default_leverage: 3
+  max_leverage: 3
+  margin_mode: isolated
+  position_mode: one-way
+  liquidation_buffer_pct: 5.0
+  max_concurrent_longs: 1
+  sl_cooldown_minutes: 240
+  symbols:
+  - SOLUSDT
+strategy:
+  default_trading_mode: futures
+  evaluation_interval_seconds: 3600
+  global_trend_filter_buffer_pct: 0.0
+  strategies:
+  - name: rsi_reversal
+    config:
+      rsi_period: 7
+      oversold_threshold: 35
+      overbought_threshold: 65
+  - name: macd_histogram
+    config:
+      min_histogram_threshold: 0.0
+      use_atr_filter: true
+      atr_min_pct: 0.0078
+  - name: bollinger_bounce
+    config:
+      band_distance_threshold: 0.0049
+      rsi_oversold: 35
+      rsi_overbought: 70
+  - name: cci_breakout
+    config:
+      cci_buy_threshold: 100
+      cci_sell_threshold: -100
+      atr_min_pct: 0.0114
+  - name: vwap_reversion
+    config:
+      vwap_atr_multiplier: 2.02
+      rsi_oversold: 40
+      rsi_overbought: 60
+  - name: trend_pullback
+    config:
+      rsi_reclaim_level: 50
+      min_trend_strength_pct: 0.0089
+      max_pullback_distance_pct: 0.0291
+      vwap_pullback_distance_pct: 0.0151
+      min_atr_pct: 0.0064
+      min_macd_hist: -0.0084
+      strong_trend_strength_pct: 0.0153
+      continuation_rsi_level: 52
+      continuation_max_vwap_distance_pct: 0.0434
+      continuation_max_ema50_extension_pct: 0.0361
+      continuation_min_macd_hist: -0.0054
+  aggregator:
+    buy_threshold: 1.0
+    buy_threshold_uptrend: 1.0
+    sell_threshold: -0.79
+    btc_regime_filter_enabled: true
+    btc_reference_symbol: BTCUSDT
+    btc_dump_threshold_pct: -1.0
+    btc_dump_require_below_ema200: true
+    min_confidence: 0.04
+  per_symbol_aggregator_config:
+    SOLUSDT:
+      min_agreement: 1
+      buy_threshold: 1.0
+      buy_threshold_uptrend: 1.0
+      sell_threshold: -0.79
+      sell_min_agreement: 1

--- a/research/overlay-threshold-sweep/resolved/1.07.yaml
+++ b/research/overlay-threshold-sweep/resolved/1.07.yaml
@@ -1,0 +1,93 @@
+agent_id: sol-1h-trend-pullback-overlay-live
+display_name: sol-1h-trend-pullback-overlay-live
+mode: live
+trading:
+  pairs:
+  - SOLUSDT
+  timeframe: 1h
+ingest:
+  use_websocket: false
+telegram:
+  daily_summary_enabled: true
+trading_execution:
+  enabled: true
+  test_mode: false
+  use_atr_sizing: false
+  order_size_usdt: 22.0
+  sl_atr_multiplier: 2.38
+  tp_atr_multiplier: 4.23
+  trailing_activate_atr: 1.82
+  trailing_offset_atr: 1.07
+  exit_rules:
+    backtest_use_executor_exit_model: true
+futures:
+  enabled: true
+  test_mode: false
+  default_leverage: 3
+  max_leverage: 3
+  margin_mode: isolated
+  position_mode: one-way
+  liquidation_buffer_pct: 5.0
+  max_concurrent_longs: 1
+  sl_cooldown_minutes: 240
+  symbols:
+  - SOLUSDT
+strategy:
+  default_trading_mode: futures
+  evaluation_interval_seconds: 3600
+  global_trend_filter_buffer_pct: 0.0
+  strategies:
+  - name: rsi_reversal
+    config:
+      rsi_period: 7
+      oversold_threshold: 35
+      overbought_threshold: 65
+  - name: macd_histogram
+    config:
+      min_histogram_threshold: 0.0
+      use_atr_filter: true
+      atr_min_pct: 0.0078
+  - name: bollinger_bounce
+    config:
+      band_distance_threshold: 0.0049
+      rsi_oversold: 35
+      rsi_overbought: 70
+  - name: cci_breakout
+    config:
+      cci_buy_threshold: 100
+      cci_sell_threshold: -100
+      atr_min_pct: 0.0114
+  - name: vwap_reversion
+    config:
+      vwap_atr_multiplier: 2.02
+      rsi_oversold: 40
+      rsi_overbought: 60
+  - name: trend_pullback
+    config:
+      rsi_reclaim_level: 50
+      min_trend_strength_pct: 0.0089
+      max_pullback_distance_pct: 0.0291
+      vwap_pullback_distance_pct: 0.0151
+      min_atr_pct: 0.0064
+      min_macd_hist: -0.0084
+      strong_trend_strength_pct: 0.0153
+      continuation_rsi_level: 52
+      continuation_max_vwap_distance_pct: 0.0434
+      continuation_max_ema50_extension_pct: 0.0361
+      continuation_min_macd_hist: -0.0054
+  aggregator:
+    buy_threshold: 1.07
+    buy_threshold_uptrend: 1.07
+    sell_threshold: -0.79
+    btc_regime_filter_enabled: true
+    btc_reference_symbol: BTCUSDT
+    btc_dump_threshold_pct: -1.0
+    btc_dump_require_below_ema200: true
+    min_confidence: 0.04
+  per_symbol_aggregator_config:
+    SOLUSDT:
+      min_agreement: 1
+      buy_threshold: 1.07
+      buy_threshold_uptrend: 1.07
+      sell_threshold: -0.79
+      sell_min_agreement: 1

--- a/research/overlay-threshold-sweep/resolved/1.27.yaml
+++ b/research/overlay-threshold-sweep/resolved/1.27.yaml
@@ -1,0 +1,93 @@
+agent_id: sol-1h-trend-pullback-overlay-live
+display_name: sol-1h-trend-pullback-overlay-live
+mode: live
+trading:
+  pairs:
+  - SOLUSDT
+  timeframe: 1h
+ingest:
+  use_websocket: false
+telegram:
+  daily_summary_enabled: true
+trading_execution:
+  enabled: true
+  test_mode: false
+  use_atr_sizing: false
+  order_size_usdt: 22.0
+  sl_atr_multiplier: 2.38
+  tp_atr_multiplier: 4.23
+  trailing_activate_atr: 1.82
+  trailing_offset_atr: 1.07
+  exit_rules:
+    backtest_use_executor_exit_model: true
+futures:
+  enabled: true
+  test_mode: false
+  default_leverage: 3
+  max_leverage: 3
+  margin_mode: isolated
+  position_mode: one-way
+  liquidation_buffer_pct: 5.0
+  max_concurrent_longs: 1
+  sl_cooldown_minutes: 240
+  symbols:
+  - SOLUSDT
+strategy:
+  default_trading_mode: futures
+  evaluation_interval_seconds: 3600
+  global_trend_filter_buffer_pct: 0.0
+  strategies:
+  - name: rsi_reversal
+    config:
+      rsi_period: 7
+      oversold_threshold: 35
+      overbought_threshold: 65
+  - name: macd_histogram
+    config:
+      min_histogram_threshold: 0.0
+      use_atr_filter: true
+      atr_min_pct: 0.0078
+  - name: bollinger_bounce
+    config:
+      band_distance_threshold: 0.0049
+      rsi_oversold: 35
+      rsi_overbought: 70
+  - name: cci_breakout
+    config:
+      cci_buy_threshold: 100
+      cci_sell_threshold: -100
+      atr_min_pct: 0.0114
+  - name: vwap_reversion
+    config:
+      vwap_atr_multiplier: 2.02
+      rsi_oversold: 40
+      rsi_overbought: 60
+  - name: trend_pullback
+    config:
+      rsi_reclaim_level: 50
+      min_trend_strength_pct: 0.0089
+      max_pullback_distance_pct: 0.0291
+      vwap_pullback_distance_pct: 0.0151
+      min_atr_pct: 0.0064
+      min_macd_hist: -0.0084
+      strong_trend_strength_pct: 0.0153
+      continuation_rsi_level: 52
+      continuation_max_vwap_distance_pct: 0.0434
+      continuation_max_ema50_extension_pct: 0.0361
+      continuation_min_macd_hist: -0.0054
+  aggregator:
+    buy_threshold: 1.27
+    buy_threshold_uptrend: 1.27
+    sell_threshold: -0.79
+    btc_regime_filter_enabled: true
+    btc_reference_symbol: BTCUSDT
+    btc_dump_threshold_pct: -1.0
+    btc_dump_require_below_ema200: true
+    min_confidence: 0.04
+  per_symbol_aggregator_config:
+    SOLUSDT:
+      min_agreement: 1
+      buy_threshold: 1.27
+      buy_threshold_uptrend: 1.27
+      sell_threshold: -0.79
+      sell_min_agreement: 1

--- a/scripts/run_closed_family_cost_rescreen.py
+++ b/scripts/run_closed_family_cost_rescreen.py
@@ -1,0 +1,548 @@
+#!/usr/bin/env python3
+"""Closed-family cost-corrected re-screen per closed-family-cost-corrected-rescreen-v0.md.
+
+Re-runs frozen mean-reversion lanes at corrected main defaults (fee 0.04%, slippage
+0.02%, 8h funding) with trend filter OFF (Cell A) vs ON (Cell B). Best-of per lane.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from scripts.experiment_autopilot import (  # noqa: E402
+    _db_config_from_settings,
+    run_experiment_evaluation,
+)
+from scripts.run_autoresearch import _gate_config_from_profile  # noqa: E402
+from scripts.run_cost_realism_rerun import _resolve_lane_config  # noqa: E402
+from src.backtest.cost_overrides import CostProfile, corrected_main_cost_profile  # noqa: E402
+from src.backtest.experiment_autopilot import GateConfig  # noqa: E402
+from src.db import close_pool, init_pool  # noqa: E402
+from src.main import load_settings  # noqa: E402
+from src.utils.logger import configure_logger, get_logger  # noqa: E402
+
+ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_OUTPUT = ROOT / "research" / "closed-family-cost-rescreen"
+DEFAULT_REPORT = ROOT / "docs" / "reports" / "closed-family-cost-corrected-rescreen-2026-06-18.md"
+
+
+@dataclass(frozen=True)
+class OriginalVerdict:
+    """Legacy-cost reference verdict (cited, not re-run)."""
+
+    wfo_return_pct: float | None
+    wfo_sharpe: float | None
+    wfo_trades: int | None
+    max_drawdown_pct: float | None
+    profit_concentration: float | None
+    verdict: str
+    source: str
+    note: str = ""
+
+
+@dataclass(frozen=True)
+class LaneSpec:
+    """Frozen mean-reversion lane (pre-registered)."""
+
+    lane_id: str
+    label: str
+    rationale: str
+    base_config: Path
+    overlay: Path | None
+    symbol: str
+    timeframe: str
+    gate_profile: str
+    start: str
+    end: str
+    train_months: int
+    test_months: int
+    bootstrap: int
+    original: OriginalVerdict
+    skipped: bool = False
+    skip_reason: str = ""
+
+
+FROZEN_LANES: tuple[LaneSpec, ...] = (
+    LaneSpec(
+        lane_id="sol-4h-rsi-reversal",
+        label="SOLUSDT 4h rsi_reversal standalone",
+        rationale=(
+            "Production/autoresearch mean-reversion vote on SOL 4h (BASE_STRATEGY_CONFIGS "
+            "params). Original closure: five-strategy stack 0/704 config-search passes."
+        ),
+        base_config=ROOT / "config" / "settings.autoresearch.yaml",
+        overlay=ROOT / "config" / "autoresearch" / "overlays" / "rescreen-sol-4h-rsi-reversal.yaml",
+        symbol="SOLUSDT",
+        timeframe="4h",
+        gate_profile="standard",
+        start="2024-01-01",
+        end="2026-06-01",
+        train_months=6,
+        test_months=3,
+        bootstrap=500,
+        original=OriginalVerdict(
+            wfo_return_pct=None,
+            wfo_sharpe=None,
+            wfo_trades=None,
+            max_drawdown_pct=20.66,
+            profit_concentration=None,
+            verdict="FAIL",
+            source="docs/reports/current-strategy-review-2026-03-03.md (SOL 4h stack)",
+            note=(
+                "Standalone legacy WFO not archived; ensemble best-cluster DD ~20.7%, "
+                "bootstrap P(loss) 48–56%, concentration fail, 0/704 passes."
+            ),
+        ),
+    ),
+    LaneSpec(
+        lane_id="avax-4h-bollinger-strategy",
+        label="AVAXUSDT 4h bollinger_bounce standalone",
+        rationale=(
+            "AVAX 4h WFO sweep best-shape config BB_D0.0_RSI30_70_TS720_SL2.0_TP3.0 "
+            "(docs/reports/avax-wfo-bollinger-20260408-153456.json)."
+        ),
+        base_config=ROOT / "config" / "settings.autoresearch.yaml",
+        overlay=ROOT
+        / "config"
+        / "autoresearch"
+        / "overlays"
+        / "rescreen-avax-4h-bollinger-strategy.yaml",
+        symbol="AVAXUSDT",
+        timeframe="4h",
+        gate_profile="standard",
+        start="2024-02-11",
+        end="2026-04-08",
+        train_months=6,
+        test_months=3,
+        bootstrap=500,
+        original=OriginalVerdict(
+            wfo_return_pct=-25.27,
+            wfo_sharpe=-1.45,
+            wfo_trades=65,
+            max_drawdown_pct=60.31,
+            profit_concentration=None,
+            verdict="FAIL",
+            source="docs/reports/avax-wfo-bollinger-20260408-153456.json (legacy costs)",
+            note="AVAX WFO oos_* metrics under pre-#94 engine defaults.",
+        ),
+    ),
+    LaneSpec(
+        lane_id="avax-4h-mean-reversion",
+        label="AVAXUSDT 4h mean_reversion standalone",
+        rationale=(
+            "AVAX 4h WFO best candidate MR_L120_ZE2.0_ZX0.25_TS1440_SL2.5_TP3.0 — "
+            "positive OOS return but sparse trades."
+        ),
+        base_config=ROOT / "config" / "settings.autoresearch.yaml",
+        overlay=None,
+        symbol="AVAXUSDT",
+        timeframe="4h",
+        gate_profile="standard",
+        start="2024-02-11",
+        end="2026-04-08",
+        train_months=6,
+        test_months=3,
+        bootstrap=500,
+        original=OriginalVerdict(
+            wfo_return_pct=14.31,
+            wfo_sharpe=1.61,
+            wfo_trades=4,
+            max_drawdown_pct=5.29,
+            profit_concentration=None,
+            verdict="FAIL",
+            source="docs/reports/avax-wfo-mean_reversion-20260408-153450.json (legacy costs)",
+            note="Failed oos_trades / oos_win_rate gates; pair-spread strategy.",
+        ),
+        skipped=True,
+        skip_reason=(
+            "Config not runnable on current harness: MeanReversionStrategy is not registered "
+            "in settings YAML registry and indicators table lacks pair_close_price required by "
+            "src/strategy/mean_reversion.py. Per brief: document and skip — no new param search."
+        ),
+    ),
+    LaneSpec(
+        lane_id="eth-4h-range-reversion-bounded",
+        label="ETHUSDT 4h range_reversion_bounded (bollinger_bounce)",
+        rationale=(
+            "Wave 7 near-miss (+13.55% OOS, 24 WFO trades, Sharpe 0.48). "
+            "Same overlay as cost-realism rerun #92."
+        ),
+        base_config=ROOT / "config" / "settings.autoresearch.yaml",
+        overlay=ROOT
+        / "config"
+        / "autoresearch"
+        / "overlays"
+        / "cost-realism-eth-4h-range-reversion-bounded.yaml",
+        symbol="ETHUSDT",
+        timeframe="4h",
+        gate_profile="standard",
+        start="2024-01-01",
+        end="2026-06-01",
+        train_months=6,
+        test_months=3,
+        bootstrap=100,
+        original=OriginalVerdict(
+            wfo_return_pct=1.27,
+            wfo_sharpe=-0.71,
+            wfo_trades=15,
+            max_drawdown_pct=28.69,
+            profit_concentration=100.0,
+            verdict="FAIL",
+            source="research/cost-realism-rerun/eth-4h-range-reversion-bounded-legacy.json",
+            note="Ledger Wave 7 NEAR_MISS: +13.55% OOS at b=100 but DD/P(loss)/Sharpe fail.",
+        ),
+    ),
+)
+
+
+@dataclass(frozen=True)
+class FilterCell:
+    """One trend-filter cell at corrected main costs."""
+
+    cell_id: str
+    label: str
+    cost_profile: CostProfile
+
+
+FILTER_CELLS: tuple[FilterCell, ...] = (
+    FilterCell(
+        cell_id="cell_a",
+        label="corrected cost + filter OFF",
+        cost_profile=corrected_main_cost_profile(apply_global_trend_filter=False),
+    ),
+    FilterCell(
+        cell_id="cell_b",
+        label="corrected cost + filter ON",
+        cost_profile=corrected_main_cost_profile(apply_global_trend_filter=True),
+    ),
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Closed-family cost-corrected re-screen")
+    parser.add_argument("--output-dir", type=Path, default=DEFAULT_OUTPUT)
+    parser.add_argument("--write-report", type=Path, default=DEFAULT_REPORT)
+    parser.add_argument("--lane", action="append", dest="lanes", help="Run only these lane_ids")
+    return parser.parse_args()
+
+
+def _verdict_label(passes: bool) -> str:
+    return "PASS" if passes else "FAIL"
+
+
+def _summary_row(payload: dict[str, object]) -> dict[str, object]:
+    summary = payload["summary"]
+    assert isinstance(summary, dict)
+    return {
+        "cell_id": payload["cell_id"],
+        "label": payload["label"],
+        "total_return_pct": summary["total_return_pct"],
+        "wfo_return_pct": summary["wfo_total_return_pct"],
+        "wfo_sharpe": summary["wfo_mean_sharpe"],
+        "wfo_trades": summary["wfo_total_trades"],
+        "max_drawdown_pct": summary["max_drawdown_pct"],
+        "profit_concentration": summary["profit_concentration_pct"],
+        "passes_gates": summary["passes_gates"],
+        "verdict": _verdict_label(bool(summary["passes_gates"])),
+        "failure_reasons": summary.get("failure_reasons", []),
+    }
+
+
+def _fmt_metric(value: float | int | None, *, digits: int = 2) -> str:
+    if value is None:
+        return "—"
+    if isinstance(value, int):
+        return str(value)
+    return f"{value:.{digits}f}"
+
+
+def _pick_best_cell(rows: dict[str, dict[str, object]]) -> str:
+    """Best-of screen: PASS first, else highest wfo_sharpe."""
+
+    passing = [cid for cid, row in rows.items() if bool(row["passes_gates"])]
+    if passing:
+        return max(passing, key=lambda cid: float(rows[cid]["wfo_sharpe"]))
+    return max(rows, key=lambda cid: float(rows[cid]["wfo_sharpe"]))
+
+
+async def _run_cell(
+    *,
+    lane: LaneSpec,
+    resolved_config: Path,
+    cell: FilterCell,
+    db_config: dict[str, object],
+    gates: GateConfig,
+) -> dict[str, object]:
+    summary, _, windows, _, audit = await run_experiment_evaluation(
+        settings_path=resolved_config,
+        symbol=lane.symbol,
+        timeframe=lane.timeframe,
+        start=lane.start,
+        end=lane.end,
+        train_months=lane.train_months,
+        test_months=lane.test_months,
+        bootstrap=lane.bootstrap,
+        gates=gates,
+        cost_profile=cell.cost_profile,
+        db_config=db_config,
+        manage_pool=False,
+    )
+    return {
+        "lane_id": lane.lane_id,
+        "cell_id": cell.cell_id,
+        "label": cell.label,
+        "summary": asdict(summary),
+        "gates": asdict(gates),
+        "windows": [asdict(window) for window in windows],
+        "resolved_backtest_config": audit["backtest_config"],
+        "cost_audit": audit["cost_profile"],
+        "global_trend_filter_audit": audit["global_trend_filter"],
+    }
+
+
+def _render_report(
+    *,
+    results: list[dict[str, object]],
+    skipped_lanes: list[LaneSpec],
+    output_path: Path,
+) -> str:
+    lines: list[str] = []
+    lines.append("# Closed-Family Cost-Corrected Re-Screen — 2026-06-18")
+    lines.append("")
+    lines.append(
+        "**Spec:** [closed-family-cost-corrected-rescreen-v0.md]"
+        "(../specs/closed-family-cost-corrected-rescreen-v0.md)"
+    )
+    lines.append(
+        "**Audit:** [backtest-engine-integrity-audit-2026-06-18.md]"
+        "(backtest-engine-integrity-audit-2026-06-18.md)"
+    )
+    lines.append(
+        "**Predecessors:** [cost-realism-rerun-2026-06-18.md](cost-realism-rerun-2026-06-18.md), "
+        "[dislocation-cost-isolation-2026-06-18.md](dislocation-cost-isolation-2026-06-18.md)"
+    )
+    lines.append("")
+    lines.append("## Frozen lane set (pre-registered)")
+    lines.append("")
+    for lane in FROZEN_LANES:
+        status = "SKIP" if lane.skipped else "RUN"
+        lines.append(f"- **{lane.lane_id}** [{status}] — {lane.label}: {lane.rationale}")
+    lines.append("")
+    lines.append(
+        "Costs: **main defaults post #94** (fee 0.04%/side, slippage 0.02%/side, "
+        "`scaled_8h` funding). Only the global trend filter is swept (Cell A OFF, Cell B ON)."
+    )
+    lines.append("")
+
+    if skipped_lanes:
+        lines.append("## Skipped lanes")
+        lines.append("")
+        for lane in skipped_lanes:
+            lines.append(f"### `{lane.lane_id}`")
+            lines.append("")
+            lines.append(lane.skip_reason)
+            lines.append("")
+            lines.append(
+                f"**Original legacy verdict (reference):** {lane.original.verdict} — "
+                f"{lane.original.source}"
+            )
+            if lane.original.note:
+                lines.append(f"_{lane.original.note}_")
+            lines.append("")
+
+    lane_ids = sorted({str(r["lane_id"]) for r in results})
+    any_pass = False
+
+    for lane_id in lane_ids:
+        lane = next(item for item in FROZEN_LANES if item.lane_id == lane_id)
+        lane_rows = [item for item in results if item["lane_id"] == lane_id]
+        rows = {str(item["cell_id"]): _summary_row(item) for item in lane_rows}
+        best_id = _pick_best_cell(rows)
+        best = rows[best_id]
+        if bool(best["passes_gates"]):
+            any_pass = True
+
+        lines.append(f"## Lane: `{lane_id}`")
+        lines.append("")
+        lines.append(f"**Best-of screen:** {best_id} ({best['label']}) → **{best['verdict']}**")
+        lines.append("")
+        lines.append("| Metric | Cell A (filter OFF) | Cell B (filter ON) | Original (legacy) |")
+        lines.append("|---|---:|---:|---:|")
+        cell_a = rows["cell_a"]
+        cell_b = rows["cell_b"]
+        orig = lane.original
+        for key, label in (
+            ("wfo_return_pct", "wfo_return_pct"),
+            ("wfo_sharpe", "wfo_sharpe"),
+            ("wfo_trades", "wfo_trades"),
+            ("max_drawdown_pct", "max_drawdown_pct"),
+            ("profit_concentration", "profit_concentration"),
+        ):
+            orig_val = getattr(orig, key)
+            a_val = cell_a[key]
+            b_val = cell_b[key]
+            if key == "wfo_trades":
+                lines.append(
+                    f"| {label} | {int(a_val)} | {int(b_val)} | {_fmt_metric(orig_val, digits=0)} |"
+                )
+            else:
+                lines.append(
+                    f"| {label} | {float(a_val):.2f} | {float(b_val):.2f} | "
+                    f"{_fmt_metric(orig_val)} |"
+                )
+        lines.append(f"| verdict | {cell_a['verdict']} | {cell_b['verdict']} | {orig.verdict} |")
+        lines.append("")
+        if orig.note:
+            lines.append(f"_Original reference: {orig.source}. {orig.note}_")
+        else:
+            lines.append(f"_Original reference: {orig.source}_")
+        lines.append("")
+
+        for payload in lane_rows:
+            cell_id = payload["cell_id"]
+            lines.append(f"### {cell_id} — resolved cost + filter audit")
+            lines.append("")
+            lines.append("**Cost audit:**")
+            lines.append("")
+            lines.append("```json")
+            lines.append(json.dumps(payload["cost_audit"], indent=2))
+            lines.append("```")
+            lines.append("")
+            lines.append("**Global trend filter audit:**")
+            lines.append("")
+            lines.append("```json")
+            lines.append(json.dumps(payload["global_trend_filter_audit"], indent=2))
+            lines.append("```")
+            lines.append("")
+            cfg = payload["resolved_backtest_config"]
+            assert isinstance(cfg, dict)
+            lines.append("**BacktestConfig (key fields):**")
+            lines.append("")
+            lines.append("```json")
+            lines.append(
+                json.dumps(
+                    {
+                        "fee_rate": cfg["fee_rate"],
+                        "slippage_pct": cfg["slippage_pct"],
+                        "apply_global_trend_filter": cfg["apply_global_trend_filter"],
+                        "futures_mode": cfg["futures_mode"],
+                        "futures_funding_rate": cfg["futures_funding_rate"],
+                        "funding_cadence": cfg["funding_cadence"],
+                        "global_trend_filter_buffer_pct": cfg["global_trend_filter_buffer_pct"],
+                    },
+                    indent=2,
+                )
+            )
+            lines.append("```")
+            lines.append("")
+
+    lines.append("## Decision")
+    lines.append("")
+    if any_pass:
+        lines.append(
+            "**TOOLING WAS HIDING AN EDGE** — at least one lane's best cell passes the "
+            "standard gate at corrected costs. **Do not auto-promote.** Flag for focused "
+            "cost×filter attribution (like #95) before re-opening; notify for human review."
+        )
+    else:
+        lines.append(
+            "**MEAN-REVERSION FAMILY GENUINELY CLOSED** — no runnable lane's best cell passes "
+            "the standard gate at corrected main defaults under either trend-filter setting. "
+            "Combined with dislocation isolation (#95), the cost bug hid **no deployable edge** "
+            "in fee-marginal / trend-filter-confounded families."
+        )
+        lines.append("")
+        lines.append(
+            "**Recommendation:** Stop the structural-probe program and consolidate on "
+            "sentiment-macro / SOL overlay Phase 0 forward validation."
+        )
+    lines.append("")
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    content = "\n".join(lines)
+    output_path.write_text(content, encoding="utf-8")
+    return content
+
+
+async def main() -> None:
+    args = parse_args()
+    configure_logger("INFO")
+    logger = get_logger("closed_family_cost_rescreen")
+
+    runnable = tuple(
+        lane
+        for lane in FROZEN_LANES
+        if not lane.skipped and (args.lanes is None or lane.lane_id in args.lanes)
+    )
+    skipped = [lane for lane in FROZEN_LANES if lane.skipped]
+    if args.lanes:
+        skipped = [lane for lane in skipped if lane.lane_id in args.lanes]
+
+    if not runnable and not skipped:
+        raise SystemExit("No lanes matched --lane filter")
+
+    output_dir = args.output_dir
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    all_results: list[dict[str, object]] = []
+    if runnable:
+        settings = load_settings(runnable[0].base_config)
+        db_config = _db_config_from_settings(settings)
+        if not db_config.get("password"):
+            import os
+
+            db_config["password"] = os.getenv("POSTGRES_PASSWORD", "change_me")
+        logger.info("DB target: %s:%s", db_config["host"], db_config["port"])
+        await init_pool(db_config)
+
+        try:
+            for lane in runnable:
+                resolved_config = _resolve_lane_config(lane, output_dir)
+                gates = _gate_config_from_profile(lane.gate_profile)
+                logger.info("Lane %s resolved: %s", lane.lane_id, resolved_config)
+                for cell in FILTER_CELLS:
+                    logger.info("Running %s / %s", lane.lane_id, cell.cell_id)
+                    payload = await _run_cell(
+                        lane=lane,
+                        resolved_config=resolved_config,
+                        cell=cell,
+                        db_config=db_config,
+                        gates=gates,
+                    )
+                    artifact = output_dir / f"{lane.lane_id}-{cell.cell_id}.json"
+                    with artifact.open("w", encoding="utf-8") as handle:
+                        json.dump(payload, handle, indent=2)
+                    print(f"\n=== {lane.lane_id} / {cell.cell_id} ===")
+                    print(json.dumps(payload["cost_audit"], indent=2))
+                    print(json.dumps(payload["global_trend_filter_audit"], indent=2))
+                    row = _summary_row(payload)
+                    print(
+                        f"verdict={row['verdict']} wfo_return={row['wfo_return_pct']:.2f}% "
+                        f"sharpe={row['wfo_sharpe']:.2f} trades={row['wfo_trades']}"
+                    )
+                    all_results.append(payload)
+        finally:
+            await close_pool()
+
+    combined_path = output_dir / "combined_results.json"
+    with combined_path.open("w", encoding="utf-8") as handle:
+        json.dump(all_results, handle, indent=2)
+
+    report = _render_report(
+        results=all_results,
+        skipped_lanes=skipped,
+        output_path=args.write_report,
+    )
+    print(f"\nReport written: {args.write_report}")
+    print(report.split("## Decision")[-1].strip())
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/scripts/run_overlay_threshold_sweep.py
+++ b/scripts/run_overlay_threshold_sweep.py
@@ -1,0 +1,535 @@
+#!/usr/bin/env python3
+"""Overlay buy_threshold × frequency sweep per overlay-threshold-frequency-sweep-v0.md.
+
+Sweeps buy_threshold on the frozen sol-1h-trend-pullback-overlay-live lane at
+corrected main costs (fee 0.04%, slippage 0.02%, scaled_8h funding, trend filter ON).
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+
+import yaml
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from scripts.experiment_autopilot import (  # noqa: E402
+    _db_config_from_settings,
+    _resolve_data_range,
+    run_experiment_evaluation,
+)
+from scripts.run_autoresearch import _gate_config_from_profile  # noqa: E402
+from src.backtest.cost_overrides import CostProfile, corrected_main_cost_profile  # noqa: E402
+from src.backtest.experiment_autopilot import GateConfig  # noqa: E402
+from src.db import close_pool, init_pool  # noqa: E402
+from src.main import load_settings  # noqa: E402
+from src.utils.logger import configure_logger, get_logger  # noqa: E402
+
+ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_OUTPUT = ROOT / "research" / "overlay-threshold-sweep"
+DEFAULT_REPORT = ROOT / "docs" / "reports" / "overlay-threshold-sweep-2026-06-18.md"
+
+THRESHOLD_GRID: tuple[float, ...] = (0.50, 0.60, 0.70, 0.80, 0.90, 1.00, 1.07, 1.27)
+FORWARD_VALIDATABLE_TRADES_PER_MONTH = 2.0
+
+BASE_CONFIG = ROOT / "config" / "settings.sol_1h_trend_pullback_overlay_live.yaml"
+SYMBOL = "SOLUSDT"
+TIMEFRAME = "1h"
+REQUESTED_START = "2024-01-01"
+REQUESTED_END = "2026-06-01"
+TRAIN_MONTHS = 6
+TEST_MONTHS = 3
+BOOTSTRAP = 500
+GATE_PROFILE = "standard"
+
+COST_PROFILE = corrected_main_cost_profile(apply_global_trend_filter=True)
+
+
+@dataclass(frozen=True)
+class LaneSpec:
+    """Fixed overlay lane (pre-registered)."""
+
+    base_config: Path
+    symbol: str
+    timeframe: str
+    requested_start: str
+    requested_end: str
+    train_months: int
+    test_months: int
+    bootstrap: int
+    gate_profile: str
+
+
+LANE = LaneSpec(
+    base_config=BASE_CONFIG,
+    symbol=SYMBOL,
+    timeframe=TIMEFRAME,
+    requested_start=REQUESTED_START,
+    requested_end=REQUESTED_END,
+    train_months=TRAIN_MONTHS,
+    test_months=TEST_MONTHS,
+    bootstrap=BOOTSTRAP,
+    gate_profile=GATE_PROFILE,
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Overlay buy_threshold frequency sweep")
+    parser.add_argument("--output-dir", type=Path, default=DEFAULT_OUTPUT)
+    parser.add_argument("--write-report", type=Path, default=DEFAULT_REPORT)
+    parser.add_argument(
+        "--threshold",
+        action="append",
+        dest="thresholds",
+        type=float,
+        help="Run only these buy_threshold values (default: full grid)",
+    )
+    return parser.parse_args()
+
+
+def _read_yaml(path: Path) -> dict[str, object]:
+    with path.open("r", encoding="utf-8") as handle:
+        data = yaml.safe_load(handle) or {}
+    if not isinstance(data, dict):
+        raise ValueError(f"Expected mapping at root of {path}")
+    return data
+
+
+def _threshold_label(threshold: float) -> str:
+    return f"{threshold:.2f}"
+
+
+def _parse_iso(value: str) -> datetime:
+    normalized = value.replace("Z", "+00:00")
+    parsed = datetime.fromisoformat(normalized)
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=UTC)
+    return parsed
+
+
+def _clamp_date_range(
+    *,
+    requested_start: str,
+    requested_end: str,
+    data_start: str,
+    data_end: str,
+) -> tuple[str, str, dict[str, str | bool]]:
+    req_start = _parse_iso(requested_start)
+    req_end = _parse_iso(requested_end)
+    db_start = _parse_iso(data_start)
+    db_end = _parse_iso(data_end)
+
+    effective_start = max(req_start, db_start)
+    effective_end = min(req_end, db_end)
+    if effective_start >= effective_end:
+        raise RuntimeError(
+            f"No overlap between requested range ({requested_start}→{requested_end}) "
+            f"and DB coverage ({data_start}→{data_end})"
+        )
+
+    coverage: dict[str, str | bool] = {
+        "requested_start": requested_start,
+        "requested_end": requested_end,
+        "data_start": data_start,
+        "data_end": data_end,
+        "effective_start": effective_start.date().isoformat(),
+        "effective_end": effective_end.date().isoformat(),
+        "clamped_start": effective_start > req_start,
+        "clamped_end": effective_end < req_end,
+    }
+    return effective_start.date().isoformat(), effective_end.date().isoformat(), coverage
+
+
+def _resolve_threshold_config(
+    *,
+    lane: LaneSpec,
+    threshold: float,
+    output_dir: Path,
+) -> Path:
+    merged = _read_yaml(lane.base_config)
+    strategy = merged.setdefault("strategy", {})
+    if not isinstance(strategy, dict):
+        raise ValueError("strategy must be a mapping")
+    aggregator = strategy.setdefault("aggregator", {})
+    if not isinstance(aggregator, dict):
+        raise ValueError("strategy.aggregator must be a mapping")
+    aggregator["buy_threshold"] = threshold
+    aggregator["buy_threshold_uptrend"] = threshold
+
+    per_symbol = strategy.setdefault("per_symbol_aggregator_config", {})
+    if not isinstance(per_symbol, dict):
+        raise ValueError("strategy.per_symbol_aggregator_config must be a mapping")
+    sol = per_symbol.setdefault(lane.symbol, {})
+    if not isinstance(sol, dict):
+        raise ValueError(f"per_symbol config for {lane.symbol} must be a mapping")
+    sol["buy_threshold"] = threshold
+    sol["buy_threshold_uptrend"] = threshold
+
+    resolved_dir = output_dir / "resolved"
+    resolved_dir.mkdir(parents=True, exist_ok=True)
+    resolved_path = resolved_dir / f"{_threshold_label(threshold)}.yaml"
+    with resolved_path.open("w", encoding="utf-8") as handle:
+        yaml.safe_dump(merged, handle, sort_keys=False)
+    return resolved_path
+
+
+def _threshold_binding_audit(
+    resolved_path: Path, *, symbol: str, threshold: float
+) -> dict[str, float]:
+    raw = _read_yaml(resolved_path)
+    strategy = raw.get("strategy", {})
+    assert isinstance(strategy, dict)
+    aggregator = strategy.get("aggregator", {})
+    assert isinstance(aggregator, dict)
+    per_symbol_root = strategy.get("per_symbol_aggregator_config", {})
+    assert isinstance(per_symbol_root, dict)
+    per_symbol = per_symbol_root.get(symbol, {})
+    assert isinstance(per_symbol, dict)
+
+    binding = {
+        "aggregator.buy_threshold": float(aggregator["buy_threshold"]),
+        "aggregator.buy_threshold_uptrend": float(aggregator["buy_threshold_uptrend"]),
+        f"per_symbol_aggregator_config.{symbol}.buy_threshold": float(per_symbol["buy_threshold"]),
+        f"per_symbol_aggregator_config.{symbol}.buy_threshold_uptrend": float(
+            per_symbol["buy_threshold_uptrend"]
+        ),
+    }
+    for key, value in binding.items():
+        if value != threshold:
+            raise AssertionError(f"{key}={value} != swept threshold {threshold}")
+    return binding
+
+
+def _assert_cost_audit(cost_audit: dict[str, object]) -> None:
+    if cost_audit.get("fee_rate") != 0.0004:
+        raise AssertionError(f"fee_rate mismatch: {cost_audit.get('fee_rate')}")
+    if cost_audit.get("slippage_pct") != 0.0002:
+        raise AssertionError(f"slippage_pct mismatch: {cost_audit.get('slippage_pct')}")
+    if cost_audit.get("funding_cadence") != "scaled_8h":
+        raise AssertionError(f"funding_cadence mismatch: {cost_audit.get('funding_cadence')}")
+    if cost_audit.get("apply_global_trend_filter") is not True:
+        raise AssertionError(
+            f"apply_global_trend_filter mismatch: {cost_audit.get('apply_global_trend_filter')}"
+        )
+
+
+def _assert_filter_audit(filter_audit: dict[str, object]) -> None:
+    if filter_audit.get("active") is not True:
+        raise AssertionError(f"global trend filter expected ON, got {filter_audit}")
+
+
+def _oos_months(*, wfo_windows: int, test_months: int) -> float:
+    return float(wfo_windows * test_months)
+
+
+def _summary_row(
+    *,
+    threshold: float,
+    payload: dict[str, object],
+    test_months: int,
+) -> dict[str, object]:
+    summary = payload["summary"]
+    assert isinstance(summary, dict)
+    wfo_windows = int(summary["wfo_windows"])
+    wfo_total_trades = int(summary["wfo_total_trades"])
+    oos_months = _oos_months(wfo_windows=wfo_windows, test_months=test_months)
+    trades_per_month = wfo_total_trades / oos_months if oos_months else 0.0
+    return {
+        "buy_threshold": threshold,
+        "wfo_total_trades": wfo_total_trades,
+        "trades_per_month": trades_per_month,
+        "wfo_total_return_pct": summary["wfo_total_return_pct"],
+        "wfo_mean_sharpe": summary["wfo_mean_sharpe"],
+        "max_drawdown_pct": summary["max_drawdown_pct"],
+        "profit_concentration_pct": summary["profit_concentration_pct"],
+        "bootstrap_p_loss_pct": summary.get("bootstrap_p_loss_pct"),
+        "passes_gates": summary["passes_gates"],
+        "failure_reasons": summary.get("failure_reasons", []),
+        "oos_months": oos_months,
+    }
+
+
+def _select_thresholds(requested: list[float] | None) -> tuple[float, ...]:
+    if requested is None:
+        return THRESHOLD_GRID
+    grid = set(THRESHOLD_GRID)
+    selected: list[float] = []
+    for value in requested:
+        if value not in grid:
+            raise SystemExit(
+                f"Unknown threshold {value}; allowed values: "
+                + ", ".join(_threshold_label(item) for item in THRESHOLD_GRID)
+            )
+        selected.append(value)
+    return tuple(selected)
+
+
+def _rescuable_rows(rows: list[dict[str, object]]) -> list[dict[str, object]]:
+    return [
+        row
+        for row in rows
+        if bool(row["passes_gates"])
+        and float(row["trades_per_month"]) >= FORWARD_VALIDATABLE_TRADES_PER_MONTH
+    ]
+
+
+def _frequency_only_rows(rows: list[dict[str, object]]) -> list[dict[str, object]]:
+    return [
+        row
+        for row in rows
+        if not bool(row["passes_gates"])
+        and float(row["trades_per_month"]) >= FORWARD_VALIDATABLE_TRADES_PER_MONTH
+    ]
+
+
+def _decision_verdict(rows: list[dict[str, object]]) -> tuple[str, str]:
+    rescuable = _rescuable_rows(rows)
+    if rescuable:
+        lowest = min(rescuable, key=lambda row: float(row["buy_threshold"]))
+        best_sharpe = max(rescuable, key=lambda row: float(row["wfo_mean_sharpe"]))
+        verdict = (
+            "**OVERLAY RESCUABLE** — at least one threshold delivers forward-validatable "
+            f"frequency (≥{FORWARD_VALIDATABLE_TRADES_PER_MONTH:.0f} trades/month) and passes "
+            "the standard gate at corrected costs. "
+            f"Lowest rescuable threshold: **{_threshold_label(float(lowest['buy_threshold']))}** "
+            f"({float(lowest['trades_per_month']):.2f} trades/month). "
+            f"Best-Sharpe rescuable: **{_threshold_label(float(best_sharpe['buy_threshold']))}** "
+            f"(Sharpe {float(best_sharpe['wfo_mean_sharpe']):.2f}). "
+            "**Next step:** re-validate that config as a new strategy (WFO + bootstrap=1000) "
+            "before any live change. **Do not auto-promote.**"
+        )
+        return "rescuable", verdict
+
+    frequency_only = _frequency_only_rows(rows)
+    if frequency_only:
+        verdict = (
+            "**OVERLAY NOT A VIABLE FORWARD VEHICLE** — tradeable frequency appears only where "
+            "the standard gate fails. The overlay edge depends on a confluence gate that is "
+            "live-untradeable at corrected costs. Consolidation direction: document/accept or pivot."
+        )
+        return "frequency_only", verdict
+
+    max_trades = max(float(row["trades_per_month"]) for row in rows)
+    if max_trades < FORWARD_VALIDATABLE_TRADES_PER_MONTH:
+        verdict = (
+            f"**UPSTREAM CONSTRAINT** — whole grid yields <{FORWARD_VALIDATABLE_TRADES_PER_MONTH:.0f} "
+            "trades/month even at buy_threshold=0.50. The binding limiter is likely not the "
+            "aggregator (regime filter / data / sizing). **Next step:** run filter-OFF follow-up, "
+            "then escalate if still starved."
+        )
+        return "upstream", verdict
+
+    verdict = (
+        "**INCONCLUSIVE** — no threshold passes both frequency and gate checks under the "
+        "pre-registered rule. Review the frontier table for manual follow-up."
+    )
+    return "inconclusive", verdict
+
+
+async def _run_threshold(
+    *,
+    lane: LaneSpec,
+    threshold: float,
+    resolved_config: Path,
+    effective_start: str,
+    effective_end: str,
+    cost_profile: CostProfile,
+    db_config: dict[str, object],
+    gates: GateConfig,
+) -> dict[str, object]:
+    summary, _, windows, _, audit = await run_experiment_evaluation(
+        settings_path=resolved_config,
+        symbol=lane.symbol,
+        timeframe=lane.timeframe,
+        start=effective_start,
+        end=effective_end,
+        train_months=lane.train_months,
+        test_months=lane.test_months,
+        bootstrap=lane.bootstrap,
+        gates=gates,
+        cost_profile=cost_profile,
+        db_config=db_config,
+        manage_pool=False,
+    )
+    cost_audit = audit["cost_profile"]
+    filter_audit = audit["global_trend_filter"]
+    assert isinstance(cost_audit, dict)
+    assert isinstance(filter_audit, dict)
+    _assert_cost_audit(cost_audit)
+    _assert_filter_audit(filter_audit)
+    threshold_binding = _threshold_binding_audit(
+        resolved_config,
+        symbol=lane.symbol,
+        threshold=threshold,
+    )
+
+    return {
+        "buy_threshold": threshold,
+        "summary": asdict(summary),
+        "gates": asdict(gates),
+        "windows": [asdict(window) for window in windows],
+        "resolved_backtest_config": audit["backtest_config"],
+        "cost_audit": cost_audit,
+        "global_trend_filter_audit": filter_audit,
+        "buy_threshold_binding_audit": threshold_binding,
+        "effective_start": effective_start,
+        "effective_end": effective_end,
+    }
+
+
+def _render_report(
+    *,
+    rows: list[dict[str, object]],
+    coverage: dict[str, str | bool],
+    output_path: Path,
+) -> str:
+    _, verdict = _decision_verdict(rows)
+
+    lines: list[str] = []
+    lines.append("# Overlay Threshold × Frequency Sweep — 2026-06-18")
+    lines.append("")
+    lines.append(
+        "**Spec:** [overlay-threshold-frequency-sweep-v0.md]"
+        "(../specs/overlay-threshold-frequency-sweep-v0.md)"
+    )
+    lines.append(
+        "**Lane:** `sol-1h-trend-pullback-overlay-live` — SOLUSDT 1h, corrected costs, "
+        "global trend filter ON (production mirror)."
+    )
+    lines.append("")
+    lines.append("## Data coverage")
+    lines.append("")
+    lines.append(f"- Requested span: {coverage['requested_start']} → {coverage['requested_end']}")
+    lines.append(f"- DB coverage: {coverage['data_start'][:10]} → {coverage['data_end'][:10]}")
+    lines.append(
+        f"- **Effective span used:** {coverage['effective_start']} → {coverage['effective_end']}"
+    )
+    if coverage.get("clamped_start") or coverage.get("clamped_end"):
+        lines.append(f"- Clamped: start={coverage['clamped_start']}, end={coverage['clamped_end']}")
+    lines.append("")
+    lines.append("## Frontier (corrected costs, filter ON)")
+    lines.append("")
+    lines.append(
+        "| buy_threshold | trades | trades/mo | wfo_return% | Sharpe | max_DD% | "
+        "profit_conc% | p_loss% | passes |"
+    )
+    lines.append("|---:|---:|---:|---:|---:|---:|---:|---:|---:|")
+    for row in sorted(rows, key=lambda item: float(item["buy_threshold"])):
+        p_loss = row.get("bootstrap_p_loss_pct")
+        p_loss_cell = "—" if p_loss is None else f"{float(p_loss):.1f}"
+        passes = "PASS" if bool(row["passes_gates"]) else "FAIL"
+        lines.append(
+            f"| {float(row['buy_threshold']):.2f} | {int(row['wfo_total_trades'])} | "
+            f"{float(row['trades_per_month']):.2f} | {float(row['wfo_total_return_pct']):.2f} | "
+            f"{float(row['wfo_mean_sharpe']):.2f} | {float(row['max_drawdown_pct']):.2f} | "
+            f"{float(row['profit_concentration_pct']):.1f} | {p_loss_cell} | {passes} |"
+        )
+    lines.append("")
+    lines.append("## Decision")
+    lines.append("")
+    lines.append(verdict)
+    lines.append("")
+    lines.append(
+        f"_Pre-registered frequency floor: trades_per_month ≥ "
+        f"{FORWARD_VALIDATABLE_TRADES_PER_MONTH:.0f}._"
+    )
+    lines.append("")
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    content = "\n".join(lines)
+    output_path.write_text(content, encoding="utf-8")
+    return content
+
+
+async def main() -> None:
+    args = parse_args()
+    configure_logger("INFO")
+    logger = get_logger("overlay_threshold_sweep")
+
+    thresholds = _select_thresholds(args.thresholds)
+    output_dir = args.output_dir
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    settings = load_settings(LANE.base_config)
+    db_config = _db_config_from_settings(settings)
+    if not db_config.get("password"):
+        import os
+
+        db_config["password"] = os.getenv("POSTGRES_PASSWORD", "change_me")
+    logger.info("DB target: %s:%s", db_config["host"], db_config["port"])
+    await init_pool(db_config)
+
+    all_results: list[dict[str, object]] = []
+    summary_rows: list[dict[str, object]] = []
+    coverage: dict[str, str] = {}
+
+    try:
+        data_start, data_end = await _resolve_data_range(LANE.symbol, LANE.timeframe)
+        effective_start, effective_end, coverage = _clamp_date_range(
+            requested_start=LANE.requested_start,
+            requested_end=LANE.requested_end,
+            data_start=data_start,
+            data_end=data_end,
+        )
+        logger.info(
+            "Effective backtest span: %s → %s (requested %s → %s)",
+            effective_start,
+            effective_end,
+            LANE.requested_start,
+            LANE.requested_end,
+        )
+
+        gates = _gate_config_from_profile(LANE.gate_profile)
+        for threshold in thresholds:
+            resolved_config = _resolve_threshold_config(
+                lane=LANE,
+                threshold=threshold,
+                output_dir=output_dir,
+            )
+            logger.info("Running buy_threshold=%s", _threshold_label(threshold))
+            payload = await _run_threshold(
+                lane=LANE,
+                threshold=threshold,
+                resolved_config=resolved_config,
+                effective_start=effective_start,
+                effective_end=effective_end,
+                cost_profile=COST_PROFILE,
+                db_config=db_config,
+                gates=gates,
+            )
+            payload["coverage"] = coverage
+            artifact = output_dir / f"{_threshold_label(threshold)}.json"
+            with artifact.open("w", encoding="utf-8") as handle:
+                json.dump(payload, handle, indent=2)
+            row = _summary_row(threshold=threshold, payload=payload, test_months=LANE.test_months)
+            print(f"\n=== buy_threshold={_threshold_label(threshold)} ===")
+            print(json.dumps(payload["cost_audit"], indent=2))
+            print(json.dumps(payload["buy_threshold_binding_audit"], indent=2))
+            print(
+                f"trades={row['wfo_total_trades']} trades/mo={float(row['trades_per_month']):.2f} "
+                f"return={float(row['wfo_total_return_pct']):.2f}% "
+                f"sharpe={float(row['wfo_mean_sharpe']):.2f} "
+                f"passes={row['passes_gates']}"
+            )
+            all_results.append(payload)
+            summary_rows.append(row)
+    finally:
+        await close_pool()
+
+    combined_path = output_dir / "combined_results.json"
+    with combined_path.open("w", encoding="utf-8") as handle:
+        json.dump(all_results, handle, indent=2)
+
+    report = _render_report(rows=summary_rows, coverage=coverage, output_path=args.write_report)
+    print(f"\nReport written: {args.write_report}")
+    print(report.split("## Decision")[-1].strip())
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/src/backtest/cost_overrides.py
+++ b/src/backtest/cost_overrides.py
@@ -25,7 +25,7 @@ TIMEFRAME_HOURS: dict[str, float] = {
 }
 
 FundingCadence = Literal["per_bar", "scaled_8h"]
-CostPassName = Literal["legacy", "realistic"]
+CostPassName = Literal["legacy", "realistic", "corrected"]
 
 LEGACY_FEE_RATE = 0.001
 LEGACY_SLIPPAGE_PCT = 0.001
@@ -102,6 +102,17 @@ def legacy_cost_profile(*, apply_global_trend_filter: bool = True) -> CostProfil
 def realistic_cost_profile(*, apply_global_trend_filter: bool = False) -> CostProfile:
     return CostProfile(
         name="realistic",
+        fee_rate=REALISTIC_FEE_RATE,
+        slippage_pct=REALISTIC_SLIPPAGE_PCT,
+        apply_global_trend_filter=apply_global_trend_filter,
+        funding_cadence="scaled_8h",
+    )
+
+
+def corrected_main_cost_profile(*, apply_global_trend_filter: bool) -> CostProfile:
+    """Main-branch defaults post #94 — only trend filter is swept."""
+    return CostProfile(
+        name="corrected",
         fee_rate=REALISTIC_FEE_RATE,
         slippage_pct=REALISTIC_SLIPPAGE_PCT,
         apply_global_trend_filter=apply_global_trend_filter,

--- a/tests/test_closed_family_cost_rescreen.py
+++ b/tests/test_closed_family_cost_rescreen.py
@@ -1,0 +1,66 @@
+"""Tests for closed-family cost-corrected re-screen harness."""
+
+from __future__ import annotations
+
+from scripts.run_closed_family_cost_rescreen import (
+    FILTER_CELLS,
+    FROZEN_LANES,
+    _pick_best_cell,
+)
+
+
+def test_frozen_lane_set_covers_mean_reversion_family() -> None:
+    lane_ids = {lane.lane_id for lane in FROZEN_LANES}
+    assert "sol-4h-rsi-reversal" in lane_ids
+    assert "avax-4h-bollinger-strategy" in lane_ids
+    assert "avax-4h-mean-reversion" in lane_ids
+    assert "eth-4h-range-reversion-bounded" in lane_ids
+
+
+def test_mean_reversion_lane_documented_skip() -> None:
+    lane = next(item for item in FROZEN_LANES if item.lane_id == "avax-4h-mean-reversion")
+    assert lane.skipped is True
+    assert "pair_close_price" in lane.skip_reason
+
+
+def test_filter_cells_use_corrected_costs_only() -> None:
+    assert len(FILTER_CELLS) == 2
+    combos = {
+        (cell.cost_profile.name, cell.cost_profile.apply_global_trend_filter)
+        for cell in FILTER_CELLS
+    }
+    assert combos == {("corrected", False), ("corrected", True)}
+    for cell in FILTER_CELLS:
+        assert cell.cost_profile.fee_rate == 0.0004
+        assert cell.cost_profile.slippage_pct == 0.0002
+        assert cell.cost_profile.funding_cadence == "scaled_8h"
+
+
+def test_pick_best_cell_prefers_pass_then_sharpe() -> None:
+    rows = {
+        "cell_a": {
+            "passes_gates": False,
+            "wfo_sharpe": 0.10,
+            "wfo_return_pct": 1.0,
+            "wfo_trades": 20,
+            "max_drawdown_pct": 5.0,
+            "profit_concentration": 40.0,
+            "verdict": "FAIL",
+        },
+        "cell_b": {
+            "passes_gates": True,
+            "wfo_sharpe": 0.55,
+            "wfo_return_pct": 2.0,
+            "wfo_trades": 25,
+            "max_drawdown_pct": 6.0,
+            "profit_concentration": 35.0,
+            "verdict": "PASS",
+        },
+    }
+    assert _pick_best_cell(rows) == "cell_b"
+
+
+def test_all_runnable_lanes_use_standard_gate() -> None:
+    for lane in FROZEN_LANES:
+        if not lane.skipped:
+            assert lane.gate_profile == "standard"

--- a/tests/test_overlay_threshold_sweep.py
+++ b/tests/test_overlay_threshold_sweep.py
@@ -1,0 +1,146 @@
+"""Tests for overlay buy_threshold frequency sweep harness."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from scripts.run_overlay_threshold_sweep import (
+    COST_PROFILE,
+    FORWARD_VALIDATABLE_TRADES_PER_MONTH,
+    LANE,
+    THRESHOLD_GRID,
+    _clamp_date_range,
+    _decision_verdict,
+    _resolve_threshold_config,
+    _select_thresholds,
+    _summary_row,
+    _threshold_binding_audit,
+    _threshold_label,
+)
+
+
+def test_threshold_grid_matches_spec() -> None:
+    assert THRESHOLD_GRID == (0.50, 0.60, 0.70, 0.80, 0.90, 1.00, 1.07, 1.27)
+
+
+def test_lane_uses_overlay_live_config() -> None:
+    assert LANE.base_config.name == "settings.sol_1h_trend_pullback_overlay_live.yaml"
+    assert LANE.symbol == "SOLUSDT"
+    assert LANE.timeframe == "1h"
+    assert LANE.train_months == 6
+    assert LANE.test_months == 3
+    assert LANE.bootstrap == 500
+    assert LANE.gate_profile == "standard"
+
+
+def test_cost_profile_mirrors_production_filter_on() -> None:
+    assert COST_PROFILE.fee_rate == 0.0004
+    assert COST_PROFILE.slippage_pct == 0.0002
+    assert COST_PROFILE.funding_cadence == "scaled_8h"
+    assert COST_PROFILE.apply_global_trend_filter is True
+
+
+def test_resolve_threshold_config_sets_all_four_keys(tmp_path: Path) -> None:
+    resolved = _resolve_threshold_config(lane=LANE, threshold=0.70, output_dir=tmp_path)
+    assert resolved.exists()
+    binding = _threshold_binding_audit(resolved, symbol=LANE.symbol, threshold=0.70)
+    assert len(binding) == 4
+    with resolved.open("r", encoding="utf-8") as handle:
+        raw = yaml.safe_load(handle)
+    assert raw["strategy"]["aggregator"]["buy_threshold"] == 0.70
+    assert raw["strategy"]["per_symbol_aggregator_config"]["SOLUSDT"]["buy_threshold"] == 0.70
+
+
+def test_select_thresholds_rejects_unknown() -> None:
+    with pytest.raises(SystemExit):
+        _select_thresholds([0.75])
+
+
+def test_clamp_date_range_reports_shortfall() -> None:
+    start, end, coverage = _clamp_date_range(
+        requested_start="2024-01-01",
+        requested_end="2026-06-01",
+        data_start="2024-01-09T07:00:00+00:00",
+        data_end="2026-02-23T19:00:00+00:00",
+    )
+    assert start == "2024-01-09"
+    assert end == "2026-02-23"
+    assert coverage["clamped_start"] is True
+    assert coverage["clamped_end"] is True
+
+
+def test_summary_row_computes_trades_per_month() -> None:
+    payload = {
+        "summary": {
+            "wfo_windows": 4,
+            "wfo_total_trades": 24,
+            "wfo_total_return_pct": 5.0,
+            "wfo_mean_sharpe": 0.6,
+            "max_drawdown_pct": 8.0,
+            "profit_concentration_pct": 40.0,
+            "bootstrap_p_loss_pct": 12.0,
+            "passes_gates": True,
+            "failure_reasons": [],
+        }
+    }
+    row = _summary_row(threshold=0.80, payload=payload, test_months=3)
+    assert row["trades_per_month"] == 2.0
+    assert row["wfo_total_trades"] == 24
+
+
+def test_decision_verdict_rescuable() -> None:
+    rows = [
+        {
+            "buy_threshold": 0.50,
+            "trades_per_month": 3.0,
+            "wfo_mean_sharpe": 0.4,
+            "passes_gates": True,
+        },
+        {
+            "buy_threshold": 0.80,
+            "trades_per_month": 2.5,
+            "wfo_mean_sharpe": 0.9,
+            "passes_gates": True,
+        },
+    ]
+    label, verdict = _decision_verdict(rows)
+    assert label == "rescuable"
+    assert _threshold_label(0.50) in verdict
+    assert _threshold_label(0.80) in verdict
+
+
+def test_decision_verdict_frequency_only() -> None:
+    rows = [
+        {
+            "buy_threshold": 0.50,
+            "trades_per_month": 3.0,
+            "wfo_mean_sharpe": 0.4,
+            "passes_gates": False,
+        },
+        {
+            "buy_threshold": 1.27,
+            "trades_per_month": 0.1,
+            "wfo_mean_sharpe": 1.2,
+            "passes_gates": True,
+        },
+    ]
+    label, _ = _decision_verdict(rows)
+    assert label == "frequency_only"
+
+
+def test_decision_verdict_upstream_starvation() -> None:
+    rows = [
+        {
+            "buy_threshold": threshold,
+            "trades_per_month": 0.5,
+            "wfo_mean_sharpe": 0.1,
+            "passes_gates": False,
+        }
+        for threshold in THRESHOLD_GRID
+    ]
+    label, verdict = _decision_verdict(rows)
+    assert label == "upstream"
+    assert str(int(FORWARD_VALIDATABLE_TRADES_PER_MONTH)) in verdict


### PR DESCRIPTION
## Summary

Implements `scripts/run_overlay_threshold_sweep.py` per `docs/specs/overlay-threshold-frequency-sweep-v0.md` — sweeps `buy_threshold` on the frozen `sol-1h-trend-pullback-overlay-live` lane at corrected main costs (fee 0.04%/side, slippage 0.02%/side, `scaled_8h` funding, global trend filter ON).

## Sweep results (SOLUSDT 1h, 2024-01-09→2026-02-23 effective span)

| buy_threshold | trades/mo | wfo_return% | Sharpe | passes |
|---:|---:|---:|---:|---:|
| 0.50 | 17.56 | -75.37 | -0.90 | FAIL |
| 0.60 | 13.44 | -50.73 | -0.49 | FAIL |
| 0.70 | 7.78 | -26.08 | -0.33 | FAIL |
| 0.80 | 5.67 | -17.45 | -0.40 | FAIL |
| 0.90 | 4.56 | 3.42 | 0.36 | FAIL |
| 1.00 | 3.00 | -21.58 | -0.36 | FAIL |
| 1.07 | 1.22 | 53.47 | 1.00 | FAIL |
| 1.27 | 0.67 | 19.42 | 1.05 | FAIL |

## Decision (pre-registered)

**OVERLAY NOT A VIABLE FORWARD VEHICLE** — tradeable frequency (≥2 trades/month) appears only where the standard gate fails. Lowering `buy_threshold` unlocks frequency but destroys edge at corrected costs; production thresholds (1.07/1.27) preserve Sharpe but starve live fills.

## Artifacts

- Script: `scripts/run_overlay_threshold_sweep.py` (`--threshold` filter supported)
- Report: `docs/reports/overlay-threshold-sweep-2026-06-18.md`
- JSON: `research/overlay-threshold-sweep/{0.50..1.27}.json` + `combined_results.json`
- Resolved configs: `research/overlay-threshold-sweep/resolved/`

## Verification

- `uv run pytest -v` — 1038 passed
- Each run asserts cost audit (0.0004/0.0002/scaled_8h/filter ON) and all four `buy_threshold*` keys bind to swept value
- Backtest only — no live config change

Co-Authored-By: Grok <noreply@x.ai>