### PR TITLE
chore(config): gitignore synthetic sentiment sweep logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,7 @@ research/last_result.json
 research/archive/
 research/candidates/
 research/resolved/
+research/**/synthetic-sentiment-*.jsonl
 
 # Generated reports (reproducible)
 docs/reports/config-search-*.csv


### PR DESCRIPTION
## Summary
- Ignore runtime-generated `synthetic-sentiment-*.jsonl` files from `run_sentiment_vol_filter_sweep.py`
- Keeps local sweep artifacts without polluting `git status` (~2MB JSONL)

## Context
Post-consolidation git hygiene (#99–#102). The tracked per-arm JSONs and YAMLs in `research/sentiment-vol-filter-sweep/` remain committed; only the generated log is excluded.

## Test plan
- [x] `git status` no longer shows `research/sentiment-vol-filter-sweep/synthetic-sentiment-72.jsonl` as untracked
- [x] `uv run pytest -q` green