### PR TITLE
feat(backtest): funding carry — v0 HAS_PULSE → v1 durability BANK

### DIFF
--- a/docs/reports/autoresearch-candidate-ledger.md
+++ b/docs/reports/autoresearch-candidate-ledger.md
@@ -419,17 +419,32 @@ This is the **fourth independent null** across families that all share one objec
 crypto price direction (OHLCV structure, higher-TF trend, macro calendar, token unlock). Next
 deliberate bet deliberately changes the **objective**, not the lane — see the carry brief below.
 
-## Delta-neutral funding carry — next deliberate lane (2026-06-20, Gate 0 brief)
+## Delta-neutral funding carry — first non-null (2026-06-20, HAS_PULSE at Gate 1)
 
-**Status:** Gate 0 brief written; cheap probe not yet built. The one structurally-different
-primitive never actually tested: all three prior funding/basis probes measured forward *price*
-returns (directional). Carry-as-yield (long spot + short perp, collect funding, market-neutral)
-tests a **different objective function** and dissolves the trade-frequency constraint that killed
-both live vehicles.
+**Status:** Gate 1 RUN — **HAS_PULSE**. The one structurally-different primitive never previously
+tested: all three prior funding/basis probes measured forward *price* returns (directional).
+Carry-as-yield (long spot + short perp, collect funding, market-neutral) tests a **different
+objective function** and dissolves the trade-frequency constraint that killed both live vehicles.
 
 Brief: [`funding-carry-neutral-probe-v0.md`](../specs/funding-carry-neutral-probe-v0.md).
-Data: `migrations/008_add_funding_rates_table.sql` (funding history in prod).
+Script: `scripts/probe_funding_carry_neutral.py` (read-only, public Binance futures funding API).
+Artifacts: `research/rbi_loop/funding-carry-neutral-v0/`.
 
-**Pre-committed stop rule:** if the carry probe also nulls (net funding < holding costs, or
-negative-funding frequency erases the carry), that is the **fifth** null across **two** objectives
-— bank the terminal state with conviction. This is the final deliberate bet, not a new campaign.
+| Symbol | Net ann carry % (−2% drag) | Neg-funding % | Cum net % | Gates |
+|--------|----------------------------|---------------|-----------|-------|
+| BTCUSDT | +5.22 | 15.8 | +12.45 | H1+H2 ✅ |
+| ETHUSDT | +5.49 | 15.6 | +13.10 | H1+H2 ✅ |
+| SOLUSDT | +3.25 | 30.0 | +7.70 | H1+H2 ✅ |
+
+**Read (do not oversell):** this is the **known crypto carry premium** re-confirmed on independent
+data (2.4y of 8h funding), *not* discovered alpha. Value = first lane to survive Gate 1, and it did
+so by being market-neutral yield not a forecast. ~5% net delta-neutral APY on deployed capital —
+must be judged against the **opportunity cost of capital** (stablecoin/T-bill yield is comparable),
+not against zero. The probe measured only the funding stream; it did **not** model leg
+mark-to-market, rebalancing, liquidation/margin risk, or capital efficiency.
+
+**Decision: advance to an execution-feasibility audit, NOT deployment.** HAS_PULSE authorizes only
+a paired spot+perp delta-neutral execution audit (analogue of `short-side-parity-audit-v0.md`) —
+the engine has no paired-position lifecycle and futures execution is LONG-only MVP. No campaign,
+config, paper agent, or live risk before that audit passes. The pre-committed stop rule does **not**
+fire — this is the non-null path it was waiting for.

--- a/docs/reports/autoresearch-candidate-ledger.md
+++ b/docs/reports/autoresearch-candidate-ledger.md
@@ -443,8 +443,24 @@ must be judged against the **opportunity cost of capital** (stablecoin/T-bill yi
 not against zero. The probe measured only the funding stream; it did **not** model leg
 mark-to-market, rebalancing, liquidation/margin risk, or capital efficiency.
 
-**Decision: advance to an execution-feasibility audit, NOT deployment.** HAS_PULSE authorizes only
-a paired spot+perp delta-neutral execution audit (analogue of `short-side-parity-audit-v0.md`) —
-the engine has no paired-position lifecycle and futures execution is LONG-only MVP. No campaign,
-config, paper agent, or live risk before that audit passes. The pre-committed stop rule does **not**
-fire — this is the non-null path it was waiting for.
+**v1 durability refinement (2026-06-20) — BANK.** Before any build, a cheap read-only refinement
+(`scripts/probe_funding_carry_durability.py`) re-asked v0 as the decision number — yield on
+**capital** not notional, **excess over 4.5% risk-free**, a **forward/OOS split**, and **margin
+stress**:
+
+| Symbol | Net/capital % | Excess vs RF % | Fwd excess % | Train→Fwd carry | Worst +72h |
+|--------|---------------|----------------|--------------|-----------------|------------|
+| BTC | +4.17 | −0.33 | −3.27 | +7.81% → +1.54% | 23.2% |
+| ETH | +3.85 | −0.65 | −3.69 | +8.54% → +1.16% | 42.6% |
+| SOL | +2.29 | −2.21 | −6.39 | +7.44% → −2.68% | 41.9% |
+
+Three cuts each kill it: on capital the ~5% → ~4%; **excess over risk-free is negative on all
+three**; and carry **compressed ~80% forward** (negative for SOL) — it is being arbitraged away in
+real time. Margin stress (40%+ buffer needed on ETH/SOL) makes it worse.
+
+**Decision: BANK — the build is NOT justified.** v0's "5% market-neutral" was the known carry
+premium on notional in a bull-funding window; its *tradeable excess over the opportunity cost of
+capital* does not survive forward. The execution-feasibility audit is **not** run. A few hours of
+read-only probe work avoided a large engineering build on a compressed trade. Keep live services as
+idle monitors; carry probes remain reusable infra to re-check if a sustained high-funding regime
+returns. **Program terminal state holds — even the one non-directional pulse does not clear the bar.**

--- a/docs/specs/funding-carry-neutral-probe-v0.md
+++ b/docs/specs/funding-carry-neutral-probe-v0.md
@@ -1,8 +1,8 @@
 # Lane Brief — Delta-Neutral Funding Carry Probe v0 (Gate 0)
 
-**Status:** Gate 1 RUN — **HAS_PULSE** (2026-06-20). First non-null in the program; it's a *known
-carry premium*, not discovered alpha. Next gate is **execution feasibility**, not deployment. See
-"## v0 result" below.
+**Status:** Gate 1 v0 **HAS_PULSE** → v1 durability refinement **BANK** (2026-06-20). The raw-notional
+carry exists but its *excess over risk-free* does not survive a capital base + forward split. No
+build. See "## v0 result" and "## v1 durability result" below.
 **Author role:** planned by Claude (planner/reviewer); cheap probe to be built and run before any
 campaign, config, or live risk.
 **Predecessors / context:**
@@ -158,3 +158,43 @@ delta-neutral position safely (analogous to `short-side-parity-audit-v0.md`) —
 has no spot+perp paired-position lifecycle and futures execution is LONG-only MVP. No campaign,
 config, paper agent, or live risk until that audit passes. The pre-committed stop rule does **not**
 fire — this is the non-null path it was waiting for.
+
+> **Superseded by the v1 durability refinement below (2026-06-20): BANK.** The execution audit was
+> **not** run — v1 showed the carry's excess over risk-free does not survive a capital base + forward
+> split, so the build is not justified.
+
+## v1 durability result (2026-06-20) — BANK
+
+Before spending engineering on the execution audit, a cheap read-only refinement
+(`scripts/probe_funding_carry_durability.py`) re-asked the v0 HAS_PULSE as the *decision* number:
+yield on **capital** (not notional), **excess over a 4.5% risk-free benchmark**, a **forward/OOS
+split** (train 2024-01→2025-06 vs forward 2025-06→2026-06), and a **margin-stress** check (worst
+72h adverse up-move sets the perp buffer, feeding back into the capital base).
+
+| Symbol | Net/notional % | Cap factor | Net/**capital** % | **Excess vs RF** % | **Fwd excess** % | Worst +72h | Train→Fwd carry |
+|--------|----------------|------------|-------------------|--------------------|------------------|------------|-----------------|
+| BTC | +5.22 | 1.25 | +4.17 | **−0.33** | **−3.27** | 23.2% | +7.81% → +1.54% |
+| ETH | +5.49 | 1.43 | +3.85 | **−0.65** | **−3.69** | 42.6% | +8.54% → +1.16% |
+| SOL | +3.25 | 1.42 | +2.29 | **−2.21** | **−6.39** | 41.9% | +7.44% → **−2.68%** |
+
+**Verdict: BANK.** Three independent cuts each kill it:
+1. **On capital, not notional:** the ~5% becomes ~4% (margin buffer ties up extra capital).
+2. **Vs risk-free:** excess over a 4.5% T-bill/stablecoin alternative is **negative on all three**.
+   The carry does not beat parking the capital risk-free, before even counting tail risk.
+3. **Forward:** carry compressed ~80% from the 2024 bull (train ~8%) into 2025-26 (forward ~1.2%,
+   and **negative for SOL**). Forward excess over risk-free is −3% to −6%. It is being arbitraged
+   away in real time (consistent with the Ethena-style delta-neutral product boom).
+
+Margin stress confirms the tail: worst 72h up-moves of 23–43% mean the short leg needs a ~40%+ buffer
+on ETH/SOL, not 25% — pushing the capital factor up and yield-on-capital down further.
+
+**This is the value of running v1 before building.** v0's "5% market-neutral" was the known carry
+premium measured on notional in a bull-funding window. Put on capital, benchmarked against
+risk-free, and looked at forward, the tradeable **excess is gone**. A few hours of read-only probe
+work avoided a large paired-execution engineering build on a trade that is already compressed.
+
+**Decision: BANK (Option A), now with evidence.** Do not run the execution-feasibility audit. The
+program's terminal state holds: even its one non-directional pulse does not clear the opportunity
+cost of capital on a forward basis. Keep live services as idle monitors. The carry probes remain
+reusable infra — if a future regime (sustained high-funding bull) might re-open the excess, re-run
+this v1 to check; do not assume.

--- a/docs/specs/funding-carry-neutral-probe-v0.md
+++ b/docs/specs/funding-carry-neutral-probe-v0.md
@@ -1,7 +1,8 @@
 # Lane Brief — Delta-Neutral Funding Carry Probe v0 (Gate 0)
 
-**Status:** Gate 0 (brief). Cheap probe not yet built. This is the **final deliberate bet** under
-a pre-committed stop rule, not the start of a new campaign.
+**Status:** Gate 1 RUN — **HAS_PULSE** (2026-06-20). First non-null in the program; it's a *known
+carry premium*, not discovered alpha. Next gate is **execution feasibility**, not deployment. See
+"## v0 result" below.
 **Author role:** planned by Claude (planner/reviewer); cheap probe to be built and run before any
 campaign, config, or live risk.
 **Predecessors / context:**
@@ -122,3 +123,38 @@ no orders, no `--execute` path. Same Gate-1 verdict semantics as every prior pro
 - NO_PULSE → carry does not clear costs; lane closed, invoke the stop rule above.
 - WEAK_EDGE → positive mean but frequently negative / capacity-bound; do not deploy without the
   execution audit proving it's harvestable net of real two-leg costs.
+
+## v0 result (2026-06-20) — HAS_PULSE
+
+Probe ran against the public Binance futures funding history (2646 8h ticks/symbol ≈ 2.4 years,
+2024-01 → 2026-06). All three majors clear both gates:
+
+| Symbol | Ann carry % | Net ann % (−2% drag) | Neg-funding % | Max neg run | Cum net % | H1 | H2 |
+|--------|-------------|----------------------|---------------|-------------|-----------|----|----|
+| BTCUSDT | +7.22 | **+5.22** | 15.8 | 18 ticks (~6d) | +12.45 | ✅ | ✅ |
+| ETHUSDT | +7.49 | **+5.49** | 15.6 | 16 ticks (~5d) | +13.10 | ✅ | ✅ |
+| SOLUSDT | +5.25 | **+3.25** | 30.0 | 21 ticks (~7d) | +7.70 | ✅ | ✅ |
+
+**Verdict: HAS_PULSE.** Net annualized carry clears the 3% hurdle on all three; negative-funding
+fraction is bounded (16% BTC/ETH, 30% SOL) and cumulative net carry is positive over the window.
+
+**What this is — and is NOT.** This is the **known crypto carry premium** (perp longs persistently
+pay funding), re-confirmed on independent data — *not* a discovered alpha. The value is that it's
+the first lane to survive Gate 1, and it did so by being **market-neutral yield, not a price
+forecast** — exactly the objective change the four nulls argued for. Read it as "~5% net APY,
+delta-neutral, on deployed capital," which must be judged against the **opportunity cost of that
+capital** (stablecoin/T-bill yield is in the same ballpark), not against zero.
+
+**Why the probe alone cannot authorize deployment (it is a screen, not a backtest).** It measured
+*only the funding stream*. It did **not** model: (a) mark-to-market of the spot+perp legs and
+rebalancing/slippage (the −2% drag is a crude proxy, not a model); (b) liquidation/margin risk on
+the short perp during up-spikes; (c) capital efficiency (the spot leg ties up full notional);
+(d) the SOL tail (30% negative funding, ~7-day paying runs). A real backtest needs paired spot+perp
+prices marked at each funding tick.
+
+**Decision: advance to the execution-feasibility audit, not deployment.** Per this brief's sequence,
+HAS_PULSE authorizes **only** a separate audit of whether the system can hold and rebalance a paired
+delta-neutral position safely (analogous to `short-side-parity-audit-v0.md`) — the engine currently
+has no spot+perp paired-position lifecycle and futures execution is LONG-only MVP. No campaign,
+config, paper agent, or live risk until that audit passes. The pre-committed stop rule does **not**
+fire — this is the non-null path it was waiting for.

--- a/research/rbi_loop/funding-carry-neutral-v0/durability_report.md
+++ b/research/rbi_loop/funding-carry-neutral-v0/durability_report.md
@@ -1,0 +1,24 @@
+# Funding Carry Durability Probe v1 — Report
+
+**Verdict:** **BANK**
+**Script:** `scripts/probe_funding_carry_durability.py`
+**Question:** is the carry's *excess over risk-free* real, forward-durable, and
+survivable — i.e. does it justify a paired spot+perp execution build?
+
+- Symbols usable: 3/3; ticks {'BTCUSDT': 2646, 'ETHUSDT': 2646, 'SOLUSDT': 2646}
+- Risk-free benchmark: 4.5%; cost drag 2.0%/yr; min excess gate 1.0%
+
+| Symbol | Net/notional % | Cap factor | Net/capital % | Excess vs RF % | Fwd excess % | Worst +move | Carry DD % | G1 | G2 | G3 |
+|--------|----------------|------------|---------------|----------------|--------------|-------------|------------|----|----|----|
+| BTCUSDT | +5.22 | 1.25 | +4.17 | -0.33 | -3.27 | 23.2% | 0.94 | n | n | Y |
+| ETHUSDT | +5.49 | 1.43 | +3.85 | -0.65 | -3.69 | 42.6% | 1.14 | n | n | Y |
+| SOLUSDT | +3.25 | 1.42 | +2.29 | -2.21 | -6.39 | 41.9% | 3.91 | n | n | Y |
+
+Periods (net annualized carry on notional):
+- BTCUSDT: train +7.81% → forward +1.54% (neg 15.8%, max neg run 18)
+- ETHUSDT: train +8.54% → forward +1.16% (neg 15.6%, max neg run 16)
+- SOLUSDT: train +7.44% → forward -2.68% (neg 30.0%, max neg run 21)
+
+## Reasons
+- excess>risk-free+1.0% on 0/3; forward-excess>0 on 0/3; drawdown ok on 3/3
+- excess over risk-free does not survive capital base / forward split

--- a/research/rbi_loop/funding-carry-neutral-v0/durability_result.json
+++ b/research/rbi_loop/funding-carry-neutral-v0/durability_result.json
@@ -1,0 +1,163 @@
+{
+  "config": {
+    "symbols": [
+      "BTCUSDT",
+      "ETHUSDT",
+      "SOLUSDT"
+    ],
+    "start": "2024-01-01T00:00:00",
+    "split": "2025-06-01T00:00:00",
+    "end": "2026-06-01T00:00:00",
+    "risk_free_pct": 4.5,
+    "annual_cost_drag_pct": 2.0,
+    "base_margin_buffer_frac": 0.25,
+    "min_excess_pct": 1.0,
+    "max_carry_drawdown_pct": 6.0
+  },
+  "data_audit": {
+    "total_symbols": 3,
+    "usable_symbols": 3,
+    "per_symbol_ticks": {
+      "BTCUSDT": 2646,
+      "ETHUSDT": 2646,
+      "SOLUSDT": 2646
+    },
+    "blocked": false,
+    "blocked_reason": null
+  },
+  "symbol_results": [
+    {
+      "symbol": "BTCUSDT",
+      "full": {
+        "label": "full",
+        "ticks": 2646,
+        "span_days": 881.6666667129629,
+        "gross_annualized_pct": 7.21689049319728,
+        "net_annualized_pct": 5.21689049319728,
+        "neg_fraction_pct": 15.835222978080122,
+        "max_consecutive_negative": 18,
+        "max_carry_drawdown_pct": 0.9370988173515968
+      },
+      "train": {
+        "label": "train",
+        "ticks": 1551,
+        "span_days": 516.6666666666666,
+        "gross_annualized_pct": 9.812547040618956,
+        "net_annualized_pct": 7.812547040618956,
+        "neg_fraction_pct": 10.31592520954223,
+        "max_consecutive_negative": 18,
+        "max_carry_drawdown_pct": 0.2819400502283127
+      },
+      "forward": {
+        "label": "forward",
+        "ticks": 1095,
+        "span_days": 364.66666670138886,
+        "gross_annualized_pct": 3.540303,
+        "net_annualized_pct": 1.5403030000000002,
+        "neg_fraction_pct": 23.652968036529682,
+        "max_consecutive_negative": 14,
+        "max_carry_drawdown_pct": 0.9370988173515999
+      },
+      "worst_adverse_up_pct": 23.186548603141777,
+      "implied_buffer_frac": 0.25,
+      "capital_factor": 1.25,
+      "net_yield_on_capital_pct": 4.173512394557823,
+      "excess_over_risk_free_pct": -0.3264876054421766,
+      "forward_excess_over_risk_free_pct": -3.2677576,
+      "g1_excess_pass": false,
+      "g2_forward_durable_pass": false,
+      "g3_drawdown_pass": true
+    },
+    {
+      "symbol": "ETHUSDT",
+      "full": {
+        "label": "full",
+        "ticks": 2646,
+        "span_days": 881.6666667129629,
+        "gross_annualized_pct": 7.485651746031746,
+        "net_annualized_pct": 5.485651746031746,
+        "neg_fraction_pct": 15.570672713529857,
+        "max_consecutive_negative": 16,
+        "max_carry_drawdown_pct": 1.1417892374429268
+      },
+      "train": {
+        "label": "train",
+        "ticks": 1551,
+        "span_days": 516.6666666666666,
+        "gross_annualized_pct": 10.53902764990329,
+        "net_annualized_pct": 8.53902764990329,
+        "neg_fraction_pct": 8.961960025789812,
+        "max_consecutive_negative": 12,
+        "max_carry_drawdown_pct": 0.1082865251141536
+      },
+      "forward": {
+        "label": "forward",
+        "ticks": 1095,
+        "span_days": 364.66666670138886,
+        "gross_annualized_pct": 3.1607330000000005,
+        "net_annualized_pct": 1.1607330000000005,
+        "neg_fraction_pct": 24.93150684931507,
+        "max_consecutive_negative": 16,
+        "max_carry_drawdown_pct": 1.1417892374429237
+      },
+      "worst_adverse_up_pct": 42.63241879289497,
+      "implied_buffer_frac": 0.42632418792894966,
+      "capital_factor": 1.4263241879289497,
+      "net_yield_on_capital_pct": 3.8460062533167996,
+      "excess_over_risk_free_pct": -0.6539937466832004,
+      "forward_excess_over_risk_free_pct": -3.6862067475099,
+      "g1_excess_pass": false,
+      "g2_forward_durable_pass": false,
+      "g3_drawdown_pass": true
+    },
+    {
+      "symbol": "SOLUSDT",
+      "full": {
+        "label": "full",
+        "ticks": 2646,
+        "span_days": 881.6666667129629,
+        "gross_annualized_pct": 5.252290408163265,
+        "net_annualized_pct": 3.2522904081632653,
+        "neg_fraction_pct": 30.007558578987148,
+        "max_consecutive_negative": 21,
+        "max_carry_drawdown_pct": 3.9091462648402366
+      },
+      "train": {
+        "label": "train",
+        "ticks": 1551,
+        "span_days": 516.6666666666666,
+        "gross_annualized_pct": 9.437470357833657,
+        "net_annualized_pct": 7.437470357833657,
+        "neg_fraction_pct": 21.598968407479045,
+        "max_consecutive_negative": 12,
+        "max_carry_drawdown_pct": 1.3567853196347173
+      },
+      "forward": {
+        "label": "forward",
+        "ticks": 1095,
+        "span_days": 364.66666670138886,
+        "gross_annualized_pct": -0.6757589999999999,
+        "net_annualized_pct": -2.6757589999999998,
+        "neg_fraction_pct": 41.917808219178085,
+        "max_consecutive_negative": 21,
+        "max_carry_drawdown_pct": 3.5805539497716845
+      },
+      "worst_adverse_up_pct": 41.929045456813526,
+      "implied_buffer_frac": 0.41929045456813524,
+      "capital_factor": 1.4192904545681353,
+      "net_yield_on_capital_pct": 2.291490369497961,
+      "excess_over_risk_free_pct": -2.208509630502039,
+      "forward_excess_over_risk_free_pct": -6.385279360111095,
+      "g1_excess_pass": false,
+      "g2_forward_durable_pass": false,
+      "g3_drawdown_pass": true
+    }
+  ],
+  "status": "OK",
+  "verdict": "BANK",
+  "reasons": [
+    "excess>risk-free+1.0% on 0/3; forward-excess>0 on 0/3; drawdown ok on 3/3",
+    "excess over risk-free does not survive capital base / forward split"
+  ],
+  "generated_at": "2026-06-20T16:07:13.085993+00:00"
+}

--- a/research/rbi_loop/funding-carry-neutral-v0/probe_report.md
+++ b/research/rbi_loop/funding-carry-neutral-v0/probe_report.md
@@ -1,0 +1,21 @@
+# Delta-Neutral Funding Carry Probe — Report
+
+**Verdict:** **HAS_PULSE**
+**Script:** `scripts/probe_funding_carry_neutral.py`
+**Framing:** market-neutral yield (long spot + short perp), not direction.
+
+## STEP 0 — Data feasibility
+- Symbols: 3; usable: 3
+- Ticks per symbol: {'BTCUSDT': 2646, 'ETHUSDT': 2646, 'SOLUSDT': 2646}
+- Blocked: False
+
+## STEP 1 — Per-symbol carry
+
+| Symbol | Ticks | Ann carry % | Net ann % | Neg % | Max neg run | Cum net % | H1 | H2 |
+|--------|-------|-------------|-----------|-------|-------------|-----------|----|----|
+| BTCUSDT | 2646 | +7.22 | +5.22 | 15.8 | 18 | +12.45 | Y | Y |
+| ETHUSDT | 2646 | +7.49 | +5.49 | 15.6 | 16 | +13.10 | Y | Y |
+| SOLUSDT | 2646 | +5.25 | +3.25 | 30.0 | 21 | +7.70 | Y | Y |
+
+## Reasons
+- net annualized carry clears 3.0% on 3 symbols and is harvestable (neg-fraction bounded, cumulative net > 0) on 3

--- a/research/rbi_loop/funding-carry-neutral-v0/probe_result.json
+++ b/research/rbi_loop/funding-carry-neutral-v0/probe_result.json
@@ -1,0 +1,75 @@
+{
+  "config": {
+    "symbols": [
+      "BTCUSDT",
+      "ETHUSDT",
+      "SOLUSDT"
+    ],
+    "start": "2024-01-01T00:00:00",
+    "end": "2026-06-01T00:00:00",
+    "min_net_carry_pct": 3.0,
+    "annual_cost_drag_pct": 2.0,
+    "max_neg_fraction_pct": 45.0
+  },
+  "data_audit": {
+    "total_symbols": 3,
+    "usable_symbols": 3,
+    "per_symbol_ticks": {
+      "BTCUSDT": 2646,
+      "ETHUSDT": 2646,
+      "SOLUSDT": 2646
+    },
+    "blocked": false,
+    "blocked_reason": null
+  },
+  "symbol_results": [
+    {
+      "symbol": "BTCUSDT",
+      "ticks": 2646,
+      "span_days": 881.6666667129629,
+      "mean_rate_per_8h": 6.590767573696145e-05,
+      "annualized_carry_pct": 7.21689049319728,
+      "net_annualized_carry_pct": 5.21689049319728,
+      "neg_fraction_pct": 15.835222978080122,
+      "max_consecutive_negative": 18,
+      "cumulative_gross_carry_pct": 17.439170999999906,
+      "cumulative_net_carry_pct": 12.448120771435725,
+      "h1_hurdle_pass": true,
+      "h2_harvestable_pass": true
+    },
+    {
+      "symbol": "ETHUSDT",
+      "ticks": 2646,
+      "span_days": 881.6666667129629,
+      "mean_rate_per_8h": 6.83621164021164e-05,
+      "annualized_carry_pct": 7.485651746031746,
+      "net_annualized_carry_pct": 5.485651746031746,
+      "neg_fraction_pct": 15.570672713529857,
+      "max_consecutive_negative": 16,
+      "cumulative_gross_carry_pct": 18.088615999999778,
+      "cumulative_net_carry_pct": 13.097565771435598,
+      "h1_hurdle_pass": true,
+      "h2_harvestable_pass": true
+    },
+    {
+      "symbol": "SOLUSDT",
+      "ticks": 2646,
+      "span_days": 881.6666667129629,
+      "mean_rate_per_8h": 4.7966122448979593e-05,
+      "annualized_carry_pct": 5.252290408163265,
+      "net_annualized_carry_pct": 3.2522904081632653,
+      "neg_fraction_pct": 30.007558578987148,
+      "max_consecutive_negative": 21,
+      "cumulative_gross_carry_pct": 12.691835999999753,
+      "cumulative_net_carry_pct": 7.700785771435573,
+      "h1_hurdle_pass": true,
+      "h2_harvestable_pass": true
+    }
+  ],
+  "status": "OK",
+  "verdict": "HAS_PULSE",
+  "reasons": [
+    "net annualized carry clears 3.0% on 3 symbols and is harvestable (neg-fraction bounded, cumulative net > 0) on 3"
+  ],
+  "generated_at": "2026-06-20T15:53:51.545310+00:00"
+}

--- a/scripts/probe_funding_carry_durability.py
+++ b/scripts/probe_funding_carry_durability.py
@@ -1,0 +1,449 @@
+#!/usr/bin/env python3
+"""Carry durability probe v1 — refine the v0 HAS_PULSE into a bank-or-build decision (read-only).
+
+v0 (`probe_funding_carry_neutral.py`) showed funding carry exists on the raw notional stream.
+That is NOT the decision number. This v1 answers the four questions that actually decide whether
+to spend engineering on a paired spot+perp execution build:
+
+  1. Yield on CAPITAL, not notional — cash-and-carry ties up spot (N) plus perp margin buffer,
+     so capital ≈ N × (1 + buffer). Carry on notional overstates the return on deployed capital.
+  2. Excess over RISK-FREE — the capital could earn ~T-bill/stablecoin yield with zero engineering
+     and zero tail risk. The carry only justifies a build by its *excess* over that, not vs zero.
+  3. Forward / OOS split — carry is the most-arbitraged crypto trade; the 2024-26 sample is fat
+     with bull funding. Does a forward sub-period still clear the hurdle, or has it compressed?
+  4. Worst-window drawdown + margin stress — the deepest negative-funding bleed, and the worst
+     adverse perp up-move (the short leg's unrealized loss), which sets the margin buffer the
+     capital base must carry — feeding back into (1).
+
+Verdict: PROCEED_TO_BUILD / MARGINAL / BANK / BLOCKED_ON_DATA. This probe does NOT authorize a
+build by itself; PROCEED_TO_BUILD means "the execution-feasibility audit is now justified."
+
+Read-only. Public Binance futures funding + spot klines. No key, no DB writes, no execution.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import statistics
+import sys
+from collections.abc import Sequence
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+
+import aiohttp
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from scripts.download_historical import BinanceHistoricalClient, download_klines
+from scripts.probe_funding_carry_neutral import (
+    FUNDINGS_PER_YEAR,
+    FundingTick,
+    _parse_dt,
+    fetch_funding_history,
+)
+from src.utils.logger import configure_logger, get_logger
+
+BLOCKED_ON_DATA = "BLOCKED_ON_DATA"
+PROCEED_TO_BUILD = "PROCEED_TO_BUILD"
+MARGINAL = "MARGINAL"
+BANK = "BANK"
+
+DEFAULT_SYMBOLS = ("BTCUSDT", "ETHUSDT", "SOLUSDT")
+DEFAULT_START = "2024-01-01T00:00:00"
+DEFAULT_SPLIT = "2025-06-01T00:00:00"  # ~17mo train / ~12mo forward
+DEFAULT_END = "2026-06-01T00:00:00"
+
+MIN_FUNDING_TICKS = 800
+MIN_SYMBOLS = 2
+RISK_FREE_PCT = 4.5  # T-bill / stablecoin opportunity cost of the deployed capital
+ANNUAL_COST_DRAG_PCT = 2.0  # rebalancing/basis/slippage proxy (same as v0)
+ONE_TIME_FEE_PCT = 0.16
+BASE_MARGIN_BUFFER_FRAC = 0.25  # minimum perp margin buffer as a fraction of notional
+MARGIN_STRESS_HOURS = 72  # window for the worst adverse perp up-move
+# Gates
+MIN_EXCESS_PCT = 1.0  # full-period excess over risk-free must clear this (on capital)
+MAX_CARRY_DRAWDOWN_PCT = 6.0  # deepest drawdown of the cumulative net-carry curve
+
+
+@dataclass(frozen=True)
+class PeriodCarry:
+    label: str
+    ticks: int
+    span_days: float
+    gross_annualized_pct: float
+    net_annualized_pct: float
+    neg_fraction_pct: float
+    max_consecutive_negative: int
+    max_carry_drawdown_pct: float
+
+
+@dataclass(frozen=True)
+class SymbolDurability:
+    symbol: str
+    full: PeriodCarry
+    train: PeriodCarry
+    forward: PeriodCarry
+    worst_adverse_up_pct: float  # worst MARGIN_STRESS_HOURS perp up-move
+    implied_buffer_frac: float  # max(base buffer, worst adverse move)
+    capital_factor: float  # 1 + implied buffer
+    net_yield_on_capital_pct: float  # full-period net annualized / capital factor
+    excess_over_risk_free_pct: float
+    forward_excess_over_risk_free_pct: float
+    g1_excess_pass: bool
+    g2_forward_durable_pass: bool
+    g3_drawdown_pass: bool
+
+
+@dataclass(frozen=True)
+class DataAudit:
+    total_symbols: int
+    usable_symbols: int
+    per_symbol_ticks: dict[str, int]
+    blocked: bool
+    blocked_reason: str | None
+
+
+@dataclass(frozen=True)
+class ProbeReport:
+    config: dict[str, object]
+    data_audit: DataAudit
+    symbol_results: tuple[SymbolDurability, ...]
+    status: str
+    verdict: str
+    reasons: tuple[str, ...]
+
+
+def _max_consecutive_negative(rates: Sequence[float]) -> int:
+    best = run = 0
+    for rate in rates:
+        run = run + 1 if rate < 0 else 0
+        best = max(best, run)
+    return best
+
+
+def _max_drawdown_pct(rates: Sequence[float], *, per_tick_drag: float) -> float:
+    """Deepest drawdown (in %) of the cumulative net-carry equity curve."""
+    equity = 0.0
+    peak = 0.0
+    max_dd = 0.0
+    for rate in rates:
+        equity += (rate * 100.0) - per_tick_drag
+        peak = max(peak, equity)
+        max_dd = max(max_dd, peak - equity)
+    return max_dd
+
+
+def _period_carry(label: str, ticks: Sequence[FundingTick], *, drag: float) -> PeriodCarry:
+    rates = [t.rate for t in ticks]
+    n = len(rates)
+    span_days = (ticks[-1].time - ticks[0].time).total_seconds() / 86400.0 if n >= 2 else 0.0
+    mean_rate = statistics.mean(rates) if rates else 0.0
+    gross_ann = mean_rate * FUNDINGS_PER_YEAR * 100.0
+    per_tick_drag = drag / FUNDINGS_PER_YEAR
+    return PeriodCarry(
+        label=label,
+        ticks=n,
+        span_days=span_days,
+        gross_annualized_pct=gross_ann,
+        net_annualized_pct=gross_ann - drag,
+        neg_fraction_pct=(sum(1 for r in rates if r < 0) / n * 100.0) if n else 0.0,
+        max_consecutive_negative=_max_consecutive_negative(rates),
+        max_carry_drawdown_pct=_max_drawdown_pct(rates, per_tick_drag=per_tick_drag),
+    )
+
+
+def _worst_adverse_up_pct(closes: Sequence[float], horizon_bars: int) -> float:
+    """Largest forward up-move over any horizon window (the short leg's max unrealized loss)."""
+    worst = 0.0
+    for i in range(len(closes) - horizon_bars):
+        entry = closes[i]
+        if entry <= 0:
+            continue
+        move = (closes[i + horizon_bars] / entry - 1.0) * 100.0
+        worst = max(worst, move)
+    return worst
+
+
+def build_symbol_durability(
+    symbol: str,
+    ticks: Sequence[FundingTick],
+    closes: Sequence[float],
+    *,
+    split: datetime,
+    config: ProbeConfig,
+) -> SymbolDurability:
+    full = _period_carry("full", ticks, drag=config.annual_cost_drag_pct)
+    train_ticks = [t for t in ticks if t.time < split]
+    fwd_ticks = [t for t in ticks if t.time >= split]
+    train = _period_carry("train", train_ticks, drag=config.annual_cost_drag_pct)
+    forward = _period_carry("forward", fwd_ticks, drag=config.annual_cost_drag_pct)
+
+    worst_up = _worst_adverse_up_pct(closes, config.margin_stress_hours) if closes else 0.0
+    implied_buffer = max(config.base_margin_buffer_frac, worst_up / 100.0)
+    capital_factor = 1.0 + implied_buffer
+    net_yield_on_capital = full.net_annualized_pct / capital_factor
+    excess = net_yield_on_capital - config.risk_free_pct
+    fwd_yield_on_capital = forward.net_annualized_pct / capital_factor
+    fwd_excess = fwd_yield_on_capital - config.risk_free_pct
+
+    return SymbolDurability(
+        symbol=symbol,
+        full=full,
+        train=train,
+        forward=forward,
+        worst_adverse_up_pct=worst_up,
+        implied_buffer_frac=implied_buffer,
+        capital_factor=capital_factor,
+        net_yield_on_capital_pct=net_yield_on_capital,
+        excess_over_risk_free_pct=excess,
+        forward_excess_over_risk_free_pct=fwd_excess,
+        g1_excess_pass=excess > config.min_excess_pct,
+        g2_forward_durable_pass=fwd_excess > 0.0,
+        g3_drawdown_pass=full.max_carry_drawdown_pct <= config.max_carry_drawdown_pct,
+    )
+
+
+@dataclass(frozen=True)
+class ProbeConfig:
+    symbols: tuple[str, ...]
+    start: str
+    split: str
+    end: str
+    min_funding_ticks: int
+    min_symbols: int
+    risk_free_pct: float
+    annual_cost_drag_pct: float
+    one_time_fee_pct: float
+    base_margin_buffer_frac: float
+    margin_stress_hours: int
+    min_excess_pct: float
+    max_carry_drawdown_pct: float
+
+
+def audit_data(results: Sequence[SymbolDurability], config: ProbeConfig) -> DataAudit:
+    per_symbol = {r.symbol: r.full.ticks for r in results}
+    usable = sum(1 for r in results if r.full.ticks >= config.min_funding_ticks)
+    blocked = usable < config.min_symbols
+    return DataAudit(
+        total_symbols=len(results),
+        usable_symbols=usable,
+        per_symbol_ticks=per_symbol,
+        blocked=blocked,
+        blocked_reason=(
+            f"only {usable} symbols have >= {config.min_funding_ticks} ticks" if blocked else None
+        ),
+    )
+
+
+def decide_verdict(
+    audit: DataAudit, results: Sequence[SymbolDurability], config: ProbeConfig
+) -> tuple[str, str, tuple[str, ...]]:
+    if audit.blocked:
+        return (BLOCKED_ON_DATA, BLOCKED_ON_DATA, (audit.blocked_reason or "data gate failed",))
+
+    usable = [r for r in results if r.full.ticks >= config.min_funding_ticks]
+    g1 = sum(1 for r in usable if r.g1_excess_pass)
+    g2 = sum(1 for r in usable if r.g2_forward_durable_pass)
+    g3 = sum(1 for r in usable if r.g3_drawdown_pass)
+    reasons: list[str] = [
+        f"excess>risk-free+{config.min_excess_pct}% on {g1}/{len(usable)}; "
+        f"forward-excess>0 on {g2}/{len(usable)}; drawdown ok on {g3}/{len(usable)}",
+    ]
+    need = config.min_symbols
+    if g1 >= need and g2 >= need and g3 >= need:
+        return ("OK", PROCEED_TO_BUILD, tuple(reasons))
+    if g1 >= need and (g2 >= need or g3 >= need):
+        reasons.append("excess real but forward-compression or worst-window flags one gate")
+        return ("OK", MARGINAL, tuple(reasons))
+    reasons.append("excess over risk-free does not survive capital base / forward split")
+    return ("OK", BANK, tuple(reasons))
+
+
+async def _load_symbol(
+    session: aiohttp.ClientSession,
+    client: BinanceHistoricalClient,
+    symbol: str,
+    config: ProbeConfig,
+) -> SymbolDurability:
+    start, end = _parse_dt(config.start), _parse_dt(config.end)
+    ticks = await fetch_funding_history(session, symbol, start, end)
+    price_rows = await download_klines(client, symbol, "1h", config.start, config.end)
+    closes = [float(r["close_price"]) for r in price_rows if float(r["close_price"]) > 0]
+    if not ticks:
+        empty = PeriodCarry("full", 0, 0.0, 0.0, 0.0, 0.0, 0, 0.0)
+        return SymbolDurability(
+            symbol,
+            empty,
+            empty,
+            empty,
+            0.0,
+            config.base_margin_buffer_frac,
+            1 + config.base_margin_buffer_frac,
+            0.0,
+            -config.risk_free_pct,
+            -config.risk_free_pct,
+            False,
+            False,
+            False,
+        )
+    return build_symbol_durability(
+        symbol, ticks, closes, split=_parse_dt(config.split), config=config
+    )
+
+
+async def run_probe(config: ProbeConfig) -> ProbeReport:
+    configure_logger("INFO")
+    logger = get_logger("probe.funding_carry_durability")
+    results: list[SymbolDurability] = []
+    async with (
+        aiohttp.ClientSession(
+            timeout=aiohttp.ClientTimeout(total=30, connect=10),
+            headers={"Accept": "application/json"},
+        ) as session,
+        BinanceHistoricalClient() as client,
+    ):
+        for symbol in config.symbols:
+            res = await _load_symbol(session, client, symbol, config)
+            logger.info(
+                "%s: net/capital %.2f%% excess %.2f%% (fwd %.2f%%) worst+%.1f%%/%dh dd %.2f%%",
+                symbol,
+                res.net_yield_on_capital_pct,
+                res.excess_over_risk_free_pct,
+                res.forward_excess_over_risk_free_pct,
+                res.worst_adverse_up_pct,
+                config.margin_stress_hours,
+                res.full.max_carry_drawdown_pct,
+            )
+            results.append(res)
+
+    audit = audit_data(results, config)
+    status, verdict, reasons = decide_verdict(audit, results, config)
+    return ProbeReport(
+        config={
+            "symbols": list(config.symbols),
+            "start": config.start,
+            "split": config.split,
+            "end": config.end,
+            "risk_free_pct": config.risk_free_pct,
+            "annual_cost_drag_pct": config.annual_cost_drag_pct,
+            "base_margin_buffer_frac": config.base_margin_buffer_frac,
+            "min_excess_pct": config.min_excess_pct,
+            "max_carry_drawdown_pct": config.max_carry_drawdown_pct,
+        },
+        data_audit=audit,
+        symbol_results=tuple(results),
+        status=status,
+        verdict=verdict,
+        reasons=reasons,
+    )
+
+
+def render_report(report: ProbeReport) -> str:
+    lines = ["# Funding Carry Durability Probe v1 — Report", ""]
+    lines.append(f"**Verdict:** **{report.verdict}**")
+    lines.append("**Script:** `scripts/probe_funding_carry_durability.py`")
+    lines.append("**Question:** is the carry's *excess over risk-free* real, forward-durable, and")
+    lines.append("survivable — i.e. does it justify a paired spot+perp execution build?")
+    lines.append("")
+    a = report.data_audit
+    lines.append(
+        f"- Symbols usable: {a.usable_symbols}/{a.total_symbols}; ticks {a.per_symbol_ticks}"
+    )
+    lines.append(
+        f"- Risk-free benchmark: {report.config['risk_free_pct']}%; "
+        f"cost drag {report.config['annual_cost_drag_pct']}%/yr; "
+        f"min excess gate {report.config['min_excess_pct']}%"
+    )
+    lines.append("")
+    lines.append(
+        "| Symbol | Net/notional % | Cap factor | Net/capital % | Excess vs RF % | Fwd excess % | Worst +move | Carry DD % | G1 | G2 | G3 |"
+    )
+    lines.append(
+        "|--------|----------------|------------|---------------|----------------|--------------|-------------|------------|----|----|----|"
+    )
+    for r in report.symbol_results:
+        lines.append(
+            f"| {r.symbol} | {r.full.net_annualized_pct:+.2f} | {r.capital_factor:.2f} | "
+            f"{r.net_yield_on_capital_pct:+.2f} | {r.excess_over_risk_free_pct:+.2f} | "
+            f"{r.forward_excess_over_risk_free_pct:+.2f} | {r.worst_adverse_up_pct:.1f}% | "
+            f"{r.full.max_carry_drawdown_pct:.2f} | {'Y' if r.g1_excess_pass else 'n'} | "
+            f"{'Y' if r.g2_forward_durable_pass else 'n'} | {'Y' if r.g3_drawdown_pass else 'n'} |"
+        )
+    lines.append("")
+    lines.append("Periods (net annualized carry on notional):")
+    for r in report.symbol_results:
+        lines.append(
+            f"- {r.symbol}: train {r.train.net_annualized_pct:+.2f}% "
+            f"→ forward {r.forward.net_annualized_pct:+.2f}% "
+            f"(neg {r.full.neg_fraction_pct:.1f}%, max neg run {r.full.max_consecutive_negative})"
+        )
+    lines.append("")
+    lines.append("## Reasons")
+    for reason in report.reasons:
+        lines.append(f"- {reason}")
+    return "\n".join(lines)
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--symbols", nargs="+", default=list(DEFAULT_SYMBOLS))
+    p.add_argument("--start", default=DEFAULT_START)
+    p.add_argument("--split", default=DEFAULT_SPLIT)
+    p.add_argument("--end", default=DEFAULT_END)
+    p.add_argument("--min-funding-ticks", type=int, default=MIN_FUNDING_TICKS)
+    p.add_argument("--min-symbols", type=int, default=MIN_SYMBOLS)
+    p.add_argument("--risk-free-pct", type=float, default=RISK_FREE_PCT)
+    p.add_argument("--annual-cost-drag-pct", type=float, default=ANNUAL_COST_DRAG_PCT)
+    p.add_argument("--one-time-fee-pct", type=float, default=ONE_TIME_FEE_PCT)
+    p.add_argument("--base-margin-buffer-frac", type=float, default=BASE_MARGIN_BUFFER_FRAC)
+    p.add_argument("--margin-stress-hours", type=int, default=MARGIN_STRESS_HOURS)
+    p.add_argument("--min-excess-pct", type=float, default=MIN_EXCESS_PCT)
+    p.add_argument("--max-carry-drawdown-pct", type=float, default=MAX_CARRY_DRAWDOWN_PCT)
+    p.add_argument("--output-dir", default=str(Path("research/rbi_loop/funding-carry-neutral-v0")))
+    return p.parse_args(argv)
+
+
+async def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    config = ProbeConfig(
+        symbols=tuple(args.symbols),
+        start=args.start,
+        split=args.split,
+        end=args.end,
+        min_funding_ticks=args.min_funding_ticks,
+        min_symbols=args.min_symbols,
+        risk_free_pct=args.risk_free_pct,
+        annual_cost_drag_pct=args.annual_cost_drag_pct,
+        one_time_fee_pct=args.one_time_fee_pct,
+        base_margin_buffer_frac=args.base_margin_buffer_frac,
+        margin_stress_hours=args.margin_stress_hours,
+        min_excess_pct=args.min_excess_pct,
+        max_carry_drawdown_pct=args.max_carry_drawdown_pct,
+    )
+    report = await run_probe(config)
+
+    out_dir = Path(args.output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "config": report.config,
+        "data_audit": asdict(report.data_audit),
+        "symbol_results": [asdict(r) for r in report.symbol_results],
+        "status": report.status,
+        "verdict": report.verdict,
+        "reasons": list(report.reasons),
+        "generated_at": datetime.now(UTC).isoformat(),
+    }
+    (out_dir / "durability_result.json").write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    report_md = render_report(report)
+    (out_dir / "durability_report.md").write_text(report_md + "\n", encoding="utf-8")
+
+    print(report_md)
+    print(f"\nVERDICT: {report.verdict}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/scripts/probe_funding_carry_neutral.py
+++ b/scripts/probe_funding_carry_neutral.py
@@ -1,0 +1,418 @@
+#!/usr/bin/env python3
+"""Cheap feasibility probe for delta-neutral funding carry (Gate 1).
+
+Thesis (yield, NOT direction): a delta-neutral position — long spot + short USDT-M perp —
+collects the perp funding stream while staying market-neutral. PnL is funding received minus
+holding costs, independent of price direction. This is the first lane that changes the
+*objective function* away from forecasting price (see docs/specs/funding-carry-neutral-probe-v0.md).
+
+Sign convention (Binance): fundingRate > 0 ⇒ longs pay shorts. A delta-neutral carry holds the
+perp SHORT, so per-tick carry = +fundingRate (you receive when funding is positive, pay when
+negative). Cumulative gross carry over a continuous hold = Σ fundingRate.
+
+STEP 0 (mandatory gate): data-feasibility audit on the public Binance futures funding history.
+If too few funding ticks per symbol → BLOCKED_ON_DATA.
+
+STEP 1: per-symbol carry metrics, pooled into a verdict.
+  H1 (carry clears a hurdle): annualized mean funding, net of a conservative annual cost drag,
+      exceeds MIN_NET_CARRY_PCT on >= MIN_SYMBOLS symbols.
+  H2 (carry is harvestable, not a coin-flip): negative-funding fraction is bounded AND cumulative
+      net carry stays positive over the window on >= MIN_SYMBOLS symbols.
+  HAS_PULSE := H1 and H2.  WEAK_EDGE := exactly one.  NO_PULSE := neither.
+
+Read-only. Fetches public Binance futures funding (no API key, no DB writes, no execution).
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import statistics
+import sys
+from collections.abc import Sequence
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+
+import aiohttp
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from src.utils.logger import configure_logger, get_logger
+
+FUNDING_URL = "https://fapi.binance.com/fapi/v1/fundingRate"
+FUNDINGS_PER_DAY = 3  # Binance funds every 8h
+FUNDINGS_PER_YEAR = FUNDINGS_PER_DAY * 365
+
+BLOCKED_ON_DATA = "BLOCKED_ON_DATA"
+HAS_PULSE = "HAS_PULSE"
+WEAK_EDGE = "WEAK_EDGE"
+NO_PULSE = "NO_PULSE"
+
+DEFAULT_SYMBOLS = ("BTCUSDT", "ETHUSDT", "SOLUSDT")
+DEFAULT_START = "2024-01-01T00:00:00"
+DEFAULT_END = "2026-06-01T00:00:00"
+# ~12 months of 8h ticks ≈ 1095. Require at least ~9 months of coverage to test carry.
+MIN_FUNDING_TICKS = 800
+MIN_SYMBOLS = 2
+# Hurdle the net annualized carry must clear to justify capital + unbuilt two-leg execution.
+MIN_NET_CARRY_PCT = 3.0
+# Conservative ongoing annual drag proxy: rebalancing slippage + spot-perp basis/roll +
+# capital/borrow cost. A floor, not a model. Round-trip entry/exit fees are amortized to ~0
+# over a continuous hold and folded into the one-time fee below.
+ANNUAL_COST_DRAG_PCT = 2.0
+ONE_TIME_ROUNDTRIP_FEE_PCT = 0.16  # 4 taker fills (~0.04% each) on both legs, once
+# Carry stops being clean income if it is too often negative.
+MAX_NEG_FRACTION_PCT = 45.0
+
+
+@dataclass(frozen=True)
+class FundingTick:
+    time: datetime
+    rate: float
+
+
+@dataclass(frozen=True)
+class ProbeConfig:
+    symbols: tuple[str, ...]
+    start: str
+    end: str
+    min_funding_ticks: int
+    min_symbols: int
+    min_net_carry_pct: float
+    annual_cost_drag_pct: float
+    one_time_fee_pct: float
+    max_neg_fraction_pct: float
+
+
+@dataclass(frozen=True)
+class SymbolCarry:
+    symbol: str
+    ticks: int
+    span_days: float
+    mean_rate_per_8h: float
+    annualized_carry_pct: float
+    net_annualized_carry_pct: float
+    neg_fraction_pct: float
+    max_consecutive_negative: int
+    cumulative_gross_carry_pct: float
+    cumulative_net_carry_pct: float
+    h1_hurdle_pass: bool
+    h2_harvestable_pass: bool
+
+
+@dataclass(frozen=True)
+class DataAudit:
+    total_symbols: int
+    usable_symbols: int
+    per_symbol_ticks: dict[str, int]
+    blocked: bool
+    blocked_reason: str | None
+
+
+@dataclass(frozen=True)
+class ProbeReport:
+    config: dict[str, object]
+    data_audit: DataAudit
+    symbol_results: tuple[SymbolCarry, ...]
+    status: str
+    verdict: str
+    reasons: tuple[str, ...]
+
+
+def _parse_dt(raw: str) -> datetime:
+    text = raw.strip()
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    parsed = datetime.fromisoformat(text)
+    return parsed.replace(tzinfo=UTC) if parsed.tzinfo is None else parsed.astimezone(UTC)
+
+
+async def fetch_funding_history(
+    session: aiohttp.ClientSession, symbol: str, start: datetime, end: datetime
+) -> list[FundingTick]:
+    """Paginate the public Binance futures funding endpoint (no key required)."""
+    logger = get_logger("probe.funding_carry")
+    out: list[FundingTick] = []
+    cursor_ms = int(start.timestamp() * 1000)
+    end_ms = int(end.timestamp() * 1000)
+    while cursor_ms < end_ms:
+        params = {"symbol": symbol, "startTime": cursor_ms, "endTime": end_ms, "limit": 1000}
+        async with session.get(FUNDING_URL, params=params) as response:
+            response.raise_for_status()
+            payload = await response.json()
+        if not isinstance(payload, list) or not payload:
+            break
+        for entry in payload:
+            out.append(
+                FundingTick(
+                    time=datetime.fromtimestamp(int(entry["fundingTime"]) / 1000, tz=UTC),
+                    rate=float(entry["fundingRate"]),
+                )
+            )
+        last_ms = int(payload[-1]["fundingTime"])
+        if last_ms <= cursor_ms:
+            break
+        cursor_ms = last_ms + 1
+        logger.info("%s: %d funding ticks so far", symbol, len(out))
+        await asyncio.sleep(0.1)
+    return out
+
+
+def _max_consecutive_negative(rates: Sequence[float]) -> int:
+    best = 0
+    run = 0
+    for rate in rates:
+        if rate < 0:
+            run += 1
+            best = max(best, run)
+        else:
+            run = 0
+    return best
+
+
+def compute_symbol_carry(
+    symbol: str, ticks: Sequence[FundingTick], config: ProbeConfig
+) -> SymbolCarry:
+    rates = [tick.rate for tick in ticks]
+    n = len(rates)
+    span_days = (ticks[-1].time - ticks[0].time).total_seconds() / 86400.0 if n >= 2 else 0.0
+    mean_rate = statistics.mean(rates) if rates else 0.0
+    annualized = mean_rate * FUNDINGS_PER_YEAR * 100.0
+    net_annualized = annualized - config.annual_cost_drag_pct
+    neg_fraction = (sum(1 for r in rates if r < 0) / n * 100.0) if n else 0.0
+    cumulative_gross = sum(rates) * 100.0
+    cumulative_net = (
+        cumulative_gross
+        - config.one_time_fee_pct
+        - (config.annual_cost_drag_pct * span_days / 365.0)
+    )
+
+    h1 = net_annualized > config.min_net_carry_pct
+    h2 = neg_fraction <= config.max_neg_fraction_pct and cumulative_net > 0.0
+
+    return SymbolCarry(
+        symbol=symbol,
+        ticks=n,
+        span_days=span_days,
+        mean_rate_per_8h=mean_rate,
+        annualized_carry_pct=annualized,
+        net_annualized_carry_pct=net_annualized,
+        neg_fraction_pct=neg_fraction,
+        max_consecutive_negative=_max_consecutive_negative(rates),
+        cumulative_gross_carry_pct=cumulative_gross,
+        cumulative_net_carry_pct=cumulative_net,
+        h1_hurdle_pass=h1,
+        h2_harvestable_pass=h2,
+    )
+
+
+def audit_data(results: Sequence[SymbolCarry], config: ProbeConfig) -> DataAudit:
+    per_symbol = {r.symbol: r.ticks for r in results}
+    usable = sum(1 for r in results if r.ticks >= config.min_funding_ticks)
+    blocked = usable < config.min_symbols
+    reason = (
+        f"only {usable} symbols have >= {config.min_funding_ticks} funding ticks "
+        f"(need >= {config.min_symbols})"
+        if blocked
+        else None
+    )
+    return DataAudit(
+        total_symbols=len(results),
+        usable_symbols=usable,
+        per_symbol_ticks=per_symbol,
+        blocked=blocked,
+        blocked_reason=reason,
+    )
+
+
+def decide_verdict(
+    audit: DataAudit, results: Sequence[SymbolCarry], config: ProbeConfig
+) -> tuple[str, str, tuple[str, ...]]:
+    if audit.blocked:
+        return (BLOCKED_ON_DATA, BLOCKED_ON_DATA, (audit.blocked_reason or "data gate failed",))
+
+    usable = [r for r in results if r.ticks >= config.min_funding_ticks]
+    h1_count = sum(1 for r in usable if r.h1_hurdle_pass)
+    h2_count = sum(1 for r in usable if r.h2_harvestable_pass)
+    reasons: list[str] = []
+
+    h1_ok = h1_count >= config.min_symbols
+    h2_ok = h2_count >= config.min_symbols
+    if h1_ok and h2_ok:
+        return (
+            "OK",
+            HAS_PULSE,
+            (
+                f"net annualized carry clears {config.min_net_carry_pct}% on {h1_count} symbols "
+                f"and is harvestable (neg-fraction bounded, cumulative net > 0) on {h2_count}",
+            ),
+        )
+    if h1_ok != h2_ok:
+        which = "hurdle (H1)" if h1_ok else "harvestability (H2)"
+        reasons.append(
+            f"only {which} passed on >= {config.min_symbols} symbols "
+            f"(H1={h1_count}, H2={h2_count}) — carry exists but is not cleanly bankable"
+        )
+        return ("OK", WEAK_EDGE, tuple(reasons))
+    reasons.append(
+        f"neither gate passed on >= {config.min_symbols} symbols (H1={h1_count}, H2={h2_count})"
+    )
+    return ("OK", NO_PULSE, tuple(reasons))
+
+
+async def run_probe(config: ProbeConfig) -> ProbeReport:
+    configure_logger("INFO")
+    logger = get_logger("probe.funding_carry")
+    start = _parse_dt(config.start)
+    end = _parse_dt(config.end)
+
+    results: list[SymbolCarry] = []
+    async with aiohttp.ClientSession(
+        timeout=aiohttp.ClientTimeout(total=30, connect=10),
+        headers={"Accept": "application/json"},
+    ) as session:
+        for symbol in config.symbols:
+            try:
+                ticks = await fetch_funding_history(session, symbol, start, end)
+            except Exception as exc:  # noqa: BLE001 — tolerate per-symbol fetch failure
+                logger.warning("%s: funding fetch failed (%s)", symbol, type(exc).__name__)
+                ticks = []
+            if not ticks:
+                results.append(
+                    SymbolCarry(
+                        symbol=symbol,
+                        ticks=0,
+                        span_days=0.0,
+                        mean_rate_per_8h=0.0,
+                        annualized_carry_pct=0.0,
+                        net_annualized_carry_pct=0.0,
+                        neg_fraction_pct=0.0,
+                        max_consecutive_negative=0,
+                        cumulative_gross_carry_pct=0.0,
+                        cumulative_net_carry_pct=0.0,
+                        h1_hurdle_pass=False,
+                        h2_harvestable_pass=False,
+                    )
+                )
+                continue
+            carry = compute_symbol_carry(symbol, ticks, config)
+            logger.info(
+                "%s: %d ticks, ann carry %.2f%% (net %.2f%%), neg %.1f%%, cum net %.2f%%",
+                symbol,
+                carry.ticks,
+                carry.annualized_carry_pct,
+                carry.net_annualized_carry_pct,
+                carry.neg_fraction_pct,
+                carry.cumulative_net_carry_pct,
+            )
+            results.append(carry)
+
+    audit = audit_data(results, config)
+    status, verdict, reasons = decide_verdict(audit, results, config)
+    return ProbeReport(
+        config={
+            "symbols": list(config.symbols),
+            "start": config.start,
+            "end": config.end,
+            "min_net_carry_pct": config.min_net_carry_pct,
+            "annual_cost_drag_pct": config.annual_cost_drag_pct,
+            "max_neg_fraction_pct": config.max_neg_fraction_pct,
+        },
+        data_audit=audit,
+        symbol_results=tuple(results),
+        status=status,
+        verdict=verdict,
+        reasons=reasons,
+    )
+
+
+def render_report(report: ProbeReport) -> str:
+    lines: list[str] = ["# Delta-Neutral Funding Carry Probe — Report", ""]
+    lines.append(f"**Verdict:** **{report.verdict}**")
+    lines.append("**Script:** `scripts/probe_funding_carry_neutral.py`")
+    lines.append("**Framing:** market-neutral yield (long spot + short perp), not direction.")
+    lines.append("")
+    a = report.data_audit
+    lines.append("## STEP 0 — Data feasibility")
+    lines.append(f"- Symbols: {a.total_symbols}; usable: {a.usable_symbols}")
+    lines.append(f"- Ticks per symbol: {a.per_symbol_ticks}")
+    lines.append(f"- Blocked: {a.blocked}{f' — {a.blocked_reason}' if a.blocked_reason else ''}")
+    lines.append("")
+    lines.append("## STEP 1 — Per-symbol carry")
+    lines.append("")
+    lines.append(
+        "| Symbol | Ticks | Ann carry % | Net ann % | Neg % | Max neg run | Cum net % | H1 | H2 |"
+    )
+    lines.append(
+        "|--------|-------|-------------|-----------|-------|-------------|-----------|----|----|"
+    )
+    for r in report.symbol_results:
+        lines.append(
+            f"| {r.symbol} | {r.ticks} | {r.annualized_carry_pct:+.2f} | "
+            f"{r.net_annualized_carry_pct:+.2f} | {r.neg_fraction_pct:.1f} | "
+            f"{r.max_consecutive_negative} | {r.cumulative_net_carry_pct:+.2f} | "
+            f"{'Y' if r.h1_hurdle_pass else 'n'} | {'Y' if r.h2_harvestable_pass else 'n'} |"
+        )
+    lines.append("")
+    lines.append("## Reasons")
+    for reason in report.reasons:
+        lines.append(f"- {reason}")
+    return "\n".join(lines)
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--symbols", nargs="+", default=list(DEFAULT_SYMBOLS))
+    parser.add_argument("--start", default=DEFAULT_START)
+    parser.add_argument("--end", default=DEFAULT_END)
+    parser.add_argument("--min-funding-ticks", type=int, default=MIN_FUNDING_TICKS)
+    parser.add_argument("--min-symbols", type=int, default=MIN_SYMBOLS)
+    parser.add_argument("--min-net-carry-pct", type=float, default=MIN_NET_CARRY_PCT)
+    parser.add_argument("--annual-cost-drag-pct", type=float, default=ANNUAL_COST_DRAG_PCT)
+    parser.add_argument("--one-time-fee-pct", type=float, default=ONE_TIME_ROUNDTRIP_FEE_PCT)
+    parser.add_argument("--max-neg-fraction-pct", type=float, default=MAX_NEG_FRACTION_PCT)
+    parser.add_argument(
+        "--output-dir", default=str(Path("research/rbi_loop/funding-carry-neutral-v0"))
+    )
+    return parser.parse_args(argv)
+
+
+async def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    config = ProbeConfig(
+        symbols=tuple(args.symbols),
+        start=args.start,
+        end=args.end,
+        min_funding_ticks=args.min_funding_ticks,
+        min_symbols=args.min_symbols,
+        min_net_carry_pct=args.min_net_carry_pct,
+        annual_cost_drag_pct=args.annual_cost_drag_pct,
+        one_time_fee_pct=args.one_time_fee_pct,
+        max_neg_fraction_pct=args.max_neg_fraction_pct,
+    )
+    report = await run_probe(config)
+
+    out_dir = Path(args.output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "config": report.config,
+        "data_audit": asdict(report.data_audit),
+        "symbol_results": [asdict(r) for r in report.symbol_results],
+        "status": report.status,
+        "verdict": report.verdict,
+        "reasons": list(report.reasons),
+        "generated_at": datetime.now(UTC).isoformat(),
+    }
+    (out_dir / "probe_result.json").write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    report_md = render_report(report)
+    (out_dir / "probe_report.md").write_text(report_md + "\n", encoding="utf-8")
+
+    print(report_md)
+    print(f"\nVERDICT: {report.verdict}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))


### PR DESCRIPTION
## Summary

Builds the Gate-1 cheap probe for the carry lane drafted in #104. This is the **first lane that tests a non-directional objective** — delta-neutral funding carry (long spot + short USDT-M perp, collect funding, market-neutral): **yield, not a price forecast.**

### Verdict: HAS_PULSE — the first non-null in the program

On 2.4 years of public Binance futures funding (2646 8h ticks/symbol, no API key):

| Symbol | Net ann carry % (−2% drag) | Neg-funding % | Max neg run | Cum net % | Gates |
|--------|----------------------------|---------------|-------------|-----------|-------|
| BTCUSDT | **+5.22** | 15.8 | 18 ticks (~6d) | +12.45 | H1+H2 ✅ |
| ETHUSDT | **+5.49** | 15.6 | 16 ticks (~5d) | +13.10 | H1+H2 ✅ |
| SOLUSDT | **+3.25** | 30.0 | 21 ticks (~7d) | +7.70 | H1+H2 ✅ |

All three clear the 3% net hurdle and the harvestability gate. It survived **by abandoning directional prediction** — the objective the four prior nulls (OHLCV structure, higher-TF trend, macro calendar, token unlock) argued against.

### Read honestly (do not oversell)

- This is the **known crypto carry premium** re-confirmed on independent data, **not discovered alpha** — perp longs persistently pay funding. Read it as **~5% net delta-neutral APY on deployed capital**, judged against the **opportunity cost of capital** (stablecoin/T-bill yield is comparable), not against zero.
- The probe measured **only the funding stream.** It does **not** model leg mark-to-market, rebalancing/slippage, liquidation/margin risk on the short perp, or capital efficiency (the spot leg ties up full notional). The −2% drag is a crude proxy, not a model. The SOL tail (30% negative funding, ~7-day paying runs) is a flag.

### Decision: advance to an execution-feasibility audit, NOT deployment

HAS_PULSE authorizes **only** a paired spot+perp delta-neutral execution audit (analogue of `short-side-parity-audit-v0.md`) — the engine has no paired-position lifecycle and futures execution is LONG-only MVP. No campaign, config, paper agent, or live risk before that audit. The pre-committed stop rule does **not** fire.

## Contents
- `scripts/probe_funding_carry_neutral.py` — read-only Gate-1 probe (public Binance funding API; no key, no DB writes, no orders)
- `docs/specs/funding-carry-neutral-probe-v0.md` — brief + HAS_PULSE result
- `docs/reports/autoresearch-candidate-ledger.md` — HAS_PULSE entry + next-gate decision
- `research/rbi_loop/funding-carry-neutral-v0/` — probe artifacts

## Validation
- `ruff check` / `ruff format` clean (pre-commit hooks pass)
- `pytest`: 1051 passed, 1 skipped
- Probe executed read-only against the public Binance futures API

🤖 Generated with [Claude Code](https://claude.com/claude-code)