### PR TITLE
feat(backtest): mNAV premium-reversion Gate-1 probe — HAS_PULSE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,8 @@ data/*
 !data/tradfi/**
 !data/token_unlocks/
 !data/token_unlocks/**
+!data/treasury_equities/
+!data/treasury_equities/**
 # Local agent scratch (drafts/plans/run-continuation)
 .omo/
 

--- a/data/treasury_equities/mnav_universe.csv
+++ b/data/treasury_equities/mnav_universe.csv
@@ -1,0 +1,17 @@
+ticker,crypto_symbol,binance_symbol,as_of_date,holdings_units,shares_outstanding,source
+MSTR,BTC,BTCUSDT,2023-12-31,189150,16868000,https://www.sec.gov/Archives/edgar/data/1050446/000095017024011709/mstr-ex99_1.htm
+MSTR,BTC,BTCUSDT,2024-02-05,190000,16868000,https://www.sec.gov/Archives/edgar/data/1050446/000095017024011709/mstr-ex99_1.htm
+MSTR,BTC,BTCUSDT,2024-03-31,214278,17647000,https://www.sec.gov/Archives/edgar/data/1050446/000095017024049829/mstr-ex99_1.htm
+MSTR,BTC,BTCUSDT,2024-07-31,226500,19067000,https://www.sec.gov/Archives/edgar/data/1050446/000095017024089243/mstr-ex99_1.htm
+MSTR,BTC,BTCUSDT,2024-11-10,279420,202644230,https://www.sec.gov/Archives/edgar/data/1050446/000119312524255184/d908568dex991.htm
+3350.T,BTC,BTCUSDT,2024-06-30,141.073,181692180,https://www.otcmarkets.com/media/696035/2025-03-05T17-17-21/Metaplanet%202025-2026%20Bitcoin%20Plan.pdf
+3350.T,BTC,BTCUSDT,2024-09-30,398.832,181692180,https://equity.jiji.com/storage/tdnet/140120250810538601.pdf
+3350.T,BTC,BTCUSDT,2024-12-31,1761.98,362683400,https://equity.jiji.com/storage/tdnet/140120250810538601.pdf
+3350.T,BTC,BTCUSDT,2025-03-31,4046,459823340,https://equity.jiji.com/storage/tdnet/140120250810538601.pdf
+3350.T,BTC,BTCUSDT,2025-06-30,13350,654714340,https://equity.jiji.com/storage/tdnet/140120250810538601.pdf
+DFDV,SOL,SOLUSDT,2025-05-12,595988,2037531,https://www.sec.gov/Archives/edgar/data/1805526/000121390025045959/ea024292601ex99-1_defi.htm
+DFDV,SOL,SOLUSDT,2025-07-09,857749,18700000,https://www.sec.gov/Archives/edgar/data/1805526/000121390025063476/ea024881801ex99-1_defi.htm
+SBET,ETH,ETHUSDT,2025-06-13,176270.69,78832600,https://www.sec.gov/Archives/edgar/data/1981535/000164117225014970/ex99-1.htm
+SBET,ETH,ETHUSDT,2025-07-27,438190,128879412,https://www.sec.gov/Archives/edgar/data/1981535/000164117225021266/ex99-1.htm
+SBET,ETH,ETHUSDT,2025-08-31,837230,212494923,https://www.sec.gov/Archives/edgar/data/1981535/000149315225012518/ex99-1.htm
+SBET,ETH,ETHUSDT,2025-12-14,863424,196693191,https://www.sec.gov/Archives/edgar/data/1981535/000149315225028063/ex99-1.htm

--- a/docs/reports/autoresearch-candidate-ledger.md
+++ b/docs/reports/autoresearch-candidate-ledger.md
@@ -464,3 +464,31 @@ capital* does not survive forward. The execution-feasibility audit is **not** ru
 read-only probe work avoided a large engineering build on a compressed trade. Keep live services as
 idle monitors; carry probes remain reusable infra to re-check if a sustained high-funding regime
 returns. **Program terminal state holds — even the one non-directional pulse does not clear the bar.**
+
+## mNAV premium-reversion — first "different universe" lane (2026-06-20, WEAK_EDGE → CLOSED)
+
+First lane outside the crypto/OHLCV universe: crypto-treasury **equity vs crypto NAV** (mNAV)
+relative value — flips asset class (equities), data (equity price + balance-sheet holdings), and
+objective (relative value). Built by Grok (PR #108), reviewed by Claude.
+
+Spec: [`mnav-premium-reversion-probe-v0.md`](../specs/mnav-premium-reversion-probe-v0.md).
+Script: `scripts/probe_mnav_premium_reversion.py`. Seed: `data/treasury_equities/mnav_universe.csv`
+(MSTR, MetaPlanet 3350.T, DFDV, SBET — filing-sourced, point-in-time). Artifacts:
+`research/rbi_loop/mnav-premium-reversion-v0/`.
+
+**Review arc:** v0 reported HAS_PULSE on 3 names — **Claude rejected it as a 4-bug artifact**
+(inverted percentile cut flagging ~65% of days as "extreme", unnormalized raw-mNAV metric, degenerate
+zero baseline, no-significance OR-pass). Grok fixed all four (commit `382c3af`); corrected re-run:
+
+| Ticker | H1 | H=10 edge (p) | H=21 edge (p) | Concentration |
+|--------|----|---------------|---------------|---------------|
+| 3350.T | n | +0.53 (0.205) | +0.13 (0.423) | ok |
+| DFDV | n | +0.69 (0.339) | +0.40 (0.200) | ok |
+| MSTR | n | −1.44 (0.630) | +1.23 (0.439) | ok |
+| SBET | **Y** | +0.93 (0.000) | +1.66 (0.000) | 0.11/0.14 |
+
+**Decision: WEAK_EDGE → CLOSED.** Only SBET passes (needs ≥3 for H2). SBET is one ETH-treasury name
+over a single mid-2025 premium spike-collapse (overlapping windows likely inflate its bootstrap p);
+the most liquid, longest-history name (MSTR) fails. There is no robust **cross-name** premium-
+reversion edge. **Do not** add more treasury names to manufacture 3 passes (post-hoc rescue trap).
+Probe + seed retained as reusable infra. Routing to candidate #2 (Polymarket, spec PR #107).

--- a/docs/specs/mnav-premium-reversion-probe-v0.md
+++ b/docs/specs/mnav-premium-reversion-probe-v0.md
@@ -1,0 +1,135 @@
+# Lane Brief + Builder Handoff — mNAV Premium-Reversion Probe v0 (Gate 0 → Gate 1)
+
+**Status:** Gate 0 brief complete → **Gate 1 build handoff to Grok (builder).**
+**Author role:** planned/specified by Claude (planner/reviewer). **Implementation by Grok.** Claude
+reviews the resulting code + verdict; Claude does not write the probe `.py`.
+**Predecessors / context:**
+- Program terminal state on the crypto/OHLCV universe: [../reports/research-consolidation-2026-06-19.md](../reports/research-consolidation-2026-06-19.md)
+- Carry lane (last in-universe lane) banked: [funding-carry-neutral-probe-v0.md](funding-carry-neutral-probe-v0.md)
+- "Different universe" candidate ranking (this lane is #1): see session analysis 2026-06-20
+- External idea source: `vibe-investing/mNAV(Market-to-Net-Asset-Value) arbitrage/` (Dennis's dataset + writeup)
+
+---
+
+## Why this lane (first principles)
+
+Every dead lane shared the same five axes: Binance venue, crypto-major asset, OHLCV/funding data,
+direction/carry objective, and no counterparty edge against the most-arbitraged book in crypto.
+This lane changes **three axes at once** — asset class (equities), data primitive (equity price +
+balance-sheet holdings), and objective (relative value, not a price forecast) — so it cannot fail
+for the same reason as the program.
+
+**The mechanism is structural, not a statistical hope.** Crypto-treasury companies (hold crypto on
+the balance sheet and little else) trade at a **market-cap-to-NAV ratio (mNAV)** that is rarely 1.0.
+The premium is *reflexive*: high mNAV → the company issues equity via ATM → buys more crypto →
+feeds the narrative → higher mNAV; and it mean-reverts hard when the premium gets extreme or the
+crypto rolls over. This is a live 2024–2026 phenomenon (MSTR and a wave of BTC/SOL/ETH treasury
+companies). The relative-value thesis: **extreme mNAV vs its own history predicts convergence.**
+
+## The signal (precise definition — implement exactly)
+
+For each treasury equity `i` on each UTC day `t`:
+
+```
+crypto_nav_usd(i,t)   = holdings_units(i,t) * crypto_close_usd(crypto_symbol(i), t)
+equity_market_cap(i,t)= shares_outstanding(i,t) * equity_close_usd(i,t)
+mnav(i,t)             = equity_market_cap(i,t) / crypto_nav_usd(i,t)
+```
+
+**Point-in-time discipline (critical):** `holdings_units` and `shares_outstanding` change over time
+(ATM issuance is the whole reflexive mechanism). The probe MUST use the **most recent disclosed
+value as of day `t`** (step-function forward-fill from filing dates), never today's value applied
+to history. Using current shares/holdings on past prices is look-ahead and silently fabricates the
+edge — reject any implementation that does this.
+
+`mnav` ignores non-crypto net assets and debt in v0 (documented simplification — most of these
+firms are ~pure crypto holders; debt-heavy names like MSTR are a known caveat, flag per-name).
+
+## Data sources (all free, read-only)
+
+| Field | Source | Notes |
+|-------|--------|-------|
+| Daily equity close | `yfinance` or `stooq` (free) | builder picks; document choice + add to `requirements.txt` only if not present |
+| Crypto daily close | Binance public klines | reuse `scripts/download_historical.py::download_klines` (1d) — already in repo |
+| `holdings_units` (time series) | filings / disclosures | hand-seeded static CSV, **with filing dates** (see seed schema) |
+| `shares_outstanding` (time series) | filings | same static CSV, point-in-time |
+
+**Seed CSV** — `data/treasury_equities/mnav_universe.csv` (builder creates; gitignore allowlist like
+`data/token_unlocks/`). One row per (ticker, as_of_date) disclosure event:
+
+```
+ticker,crypto_symbol,binance_symbol,as_of_date,holdings_units,shares_outstanding,source
+MSTR,BTC,BTCUSDT,2024-01-01,189150,16500000,10-K/8-K filing url
+MSTR,BTC,BTCUSDT,2024-07-31,226500,17900000,8-K filing url
+DFDV,SOL,SOLUSDT,2025-05-15,317000,14000000,press release url
+...
+```
+
+> **STEP 0 builder task:** populate this seed from primary filings (8-K/10-Q/press releases) for a
+> small universe (target 4–6 names spanning BTC + SOL + ETH treasuries; e.g. MSTR, MetaPlanet,
+> DFDV, an ETH-treasury name). Use WebSearch/WebFetch. Each numeric value needs a `source` URL.
+> Mark any value you could not verify — do **not** invent holdings/shares. If <4 names can be
+> verified with ≥12 months of disclosure history, that is itself the BLOCKED_ON_DATA result.
+
+## STEP 0 — Data feasibility (mandatory gate before any edge claim)
+
+For each seeded ticker: fetch daily equity closes (≥12 months) and join to crypto daily closes and
+the forward-filled point-in-time holdings/shares. Count names with a usable, gap-tolerant joined
+mNAV series. If `usable_names < MIN_NAMES` (default 4) → **BLOCKED_ON_DATA**, no edge claim.
+Report per-name: rows, date span, equity-data source, and any forward-fill gaps > 45 days
+(a stale-disclosure flag).
+
+## STEP 1 — Edge test (premium mean-reversion)
+
+Pooled across names (mNAV is unitless and cross-comparable):
+
+- **H1 (mean-reversion):** when a name's mNAV is in its **trailing extreme percentile** (e.g. top
+  / bottom decile of its own trailing 180-day window), does mNAV **converge toward its trailing
+  median** over the next `H` days (default H ∈ {10, 21}) by more than a matched random-window
+  baseline for the same name? Report mean Δmnav (event vs baseline), directional consistency, and a
+  per-name breakdown.
+- **H2 (tradeable, not single-name):** the convergence holds on **≥ MIN_NAMES_EDGE names** (default
+  3), not just MSTR. A premium-reversion that exists only on one ticker is a single security's
+  idiosyncratic story, not a universe — that is WEAK_EDGE at best.
+
+Cost/tradeability note for interpretation (not a gate in v0): the realizable trade is
+long-crypto / short-equity-premium (or inverse), which needs equity borrow + a stock broker — out
+of scope for the probe, flagged for the deploy decision. v0 only answers "is the signal real."
+
+## Verdict semantics (match the other probes)
+
+- **HAS_PULSE** := H1 and H2 both pass. (Authorizes a v1: real cost model + equity-execution
+  feasibility audit — NOT deployment.)
+- **WEAK_EDGE** := H1 passes pooled but H2 fails (single-name driven).
+- **NO_PULSE** := convergence inside baseline/cost noise.
+- **BLOCKED_ON_DATA** := STEP 0 fails (universe too thin to test).
+
+## Build contract (file paths, CLI, artifacts, tests)
+
+| Item | Requirement |
+|------|-------------|
+| Script | `scripts/probe_mnav_premium_reversion.py` |
+| Pattern to mirror | `scripts/probe_funding_carry_neutral.py` (frozen dataclasses, `run_probe`/`render_report`/`main`, `--output-dir`, JSON + MD artifacts) |
+| Reuse | `download_klines` from `scripts/download_historical.py` for crypto 1d; `get_logger`/`configure_logger` from `src/utils/logger.py` |
+| Seed | `data/treasury_equities/mnav_universe.csv` (+ `.gitignore` allowlist entry) |
+| Artifacts | `research/rbi_loop/mnav-premium-reversion-v0/{probe_result.json,probe_report.md}` |
+| CLI flags | `--symbols`/names, `--start`, `--end`, `--trailing-window-days` (180), `--extreme-pct` (10), `--horizons` (10,21), `--min-names` (4), `--min-names-edge` (3), `--output-dir` |
+| Tests | `tests/test_probe_mnav_premium_reversion.py` — unit-test the point-in-time forward-fill (the look-ahead trap), mNAV math on a fixture, percentile/extreme detection, and verdict routing. **No network in tests** (inject fixtures). |
+| Constraints | Read-only. No DB writes, no orders, no `--execute`. `ruff check`/`ruff format` clean; `pytest` green; pre-commit hooks pass. |
+
+## Hard "do NOT" list (review will reject on any of these)
+
+- Do **not** apply today's `holdings_units`/`shares_outstanding` to historical prices (look-ahead).
+- Do **not** fabricate any holdings/shares value — every number needs a filing `source`.
+- Do **not** declare HAS_PULSE off a single name (that's WEAK_EDGE).
+- Do **not** add equity execution, broker code, or any deployment path — this is a Gate-1 probe.
+- Do **not** trust the vibe-investing repo's numbers; re-derive from primary filings + live prices
+  (same lesson as the token-unlock probe: external datasets get re-verified, not consumed).
+
+## Kill criteria
+
+- BLOCKED_ON_DATA → treasury-equity universe with verifiable point-in-time disclosure history is
+  too thin; record, move to candidate #2 (Polymarket) — do not hand-fudge the seed.
+- NO_PULSE / WEAK_EDGE → premium-reversion isn't a tradeable universe edge; close, document.
+- HAS_PULSE → write v1 brief (cost model + equity-execution-rails feasibility); the rails spend is
+  a human decision, not an automated one.

--- a/research/rbi_loop/mnav-premium-reversion-v0/probe_report.md
+++ b/research/rbi_loop/mnav-premium-reversion-v0/probe_report.md
@@ -1,0 +1,25 @@
+# mNAV Premium-Reversion Probe — Report
+
+**Verdict:** **HAS_PULSE**
+**Script:** `scripts/probe_mnav_premium_reversion.py`
+**Framing:** relative value (equity mNAV vs crypto NAV), not price forecast.
+
+## STEP 0 — Data feasibility
+- Names: 4; usable: 4
+- 3350.T: 465 rows, span 697d, equity=yfinance, max gap 336d **stale-disclosure**
+- DFDV: 264 rows, span 382d, equity=yfinance, max gap 327d **stale-disclosure**
+- MSTR: 604 rows, span 878d, equity=yfinance, max gap 568d **stale-disclosure**
+- SBET: 241 rows, span 350d, equity=yfinance, max gap 169d **stale-disclosure**
+- Blocked: False
+
+## STEP 1 — Per-name mean-reversion
+
+| Ticker | Days | H1 | H=10 edge | H=21 edge | Events (10/21) |
+|--------|------|----|-----------|-----------|----------------|
+| 3350.T | 465 | Y | +8.0570 | +66.5608 | 275/264 |
+| DFDV | 264 | Y | +0.0089 | -0.0053 | 74/63 |
+| MSTR | 604 | n | -0.0212 | -0.0359 | 414/403 |
+| SBET | 241 | Y | +0.0495 | +0.0738 | 51/40 |
+
+## Reasons
+- mNAV mean-reversion clears random baseline on 3 names (3350.T, DFDV, SBET)

--- a/research/rbi_loop/mnav-premium-reversion-v0/probe_report.md
+++ b/research/rbi_loop/mnav-premium-reversion-v0/probe_report.md
@@ -1,6 +1,6 @@
 # mNAV Premium-Reversion Probe — Report
 
-**Verdict:** **HAS_PULSE**
+**Verdict:** **WEAK_EDGE**
 **Script:** `scripts/probe_mnav_premium_reversion.py`
 **Framing:** relative value (equity mNAV vs crypto NAV), not price forecast.
 
@@ -14,12 +14,12 @@
 
 ## STEP 1 — Per-name mean-reversion
 
-| Ticker | Days | H1 | H=10 edge | H=21 edge | Events (10/21) |
-|--------|------|----|-----------|-----------|----------------|
-| 3350.T | 465 | Y | +8.0570 | +66.5608 | 275/264 |
-| DFDV | 264 | Y | +0.0089 | -0.0053 | 74/63 |
-| MSTR | 604 | n | -0.0212 | -0.0359 | 414/403 |
-| SBET | 241 | Y | +0.0495 | +0.0738 | 51/40 |
+| Ticker | Days | H1 | H=10 edge (p) | H=21 edge (p) | Events (10/21) | Event % |
+|--------|------|----|---------------|---------------|----------------|---------|
+| 3350.T | 465 | n | +0.5264 (0.205) | +0.1260 (0.423) | 121/118 | 44/45 |
+| DFDV | 264 | n | +0.6933 (0.339) | +0.4004 (0.200) | 5/5 | 7/8 |
+| MSTR | 604 | n | -1.4397 (0.630) | +1.2310 (0.439) | 181/181 | 44/45 |
+| SBET | 241 | Y | +0.9324 (0.000) | +1.6616 (0.000) | 15/14 | 29/35 |
 
 ## Reasons
-- mNAV mean-reversion clears random baseline on 3 names (3350.T, DFDV, SBET)
+- H1 passes on 1 name(s) (SBET) but needs >= 3 for H2

--- a/research/rbi_loop/mnav-premium-reversion-v0/probe_result.json
+++ b/research/rbi_loop/mnav-premium-reversion-v0/probe_result.json
@@ -69,22 +69,32 @@
       "horizon_results": [
         {
           "horizon": 10,
-          "event_count": 275,
-          "event_mean_convergence": 8.057000690133437,
-          "baseline_mean_convergence": 0.0,
-          "edge_vs_baseline": 8.057000690133437,
-          "h1_pass": true
+          "event_count": 121,
+          "eligible_days": 275,
+          "event_fraction": 0.44,
+          "event_mean_convergence": 0.07178975592093292,
+          "baseline_mean_convergence": -0.45456906858390084,
+          "edge_vs_baseline": 0.5263588245048337,
+          "p_value": 0.2055,
+          "max_single_event_share": 0.060321608895930884,
+          "concentration_ok": true,
+          "h1_pass": false
         },
         {
           "horizon": 21,
-          "event_count": 264,
-          "event_mean_convergence": 66.56075278407751,
-          "baseline_mean_convergence": 0.0,
-          "edge_vs_baseline": 66.56075278407751,
-          "h1_pass": true
+          "event_count": 118,
+          "eligible_days": 264,
+          "event_fraction": 0.44696969696969696,
+          "event_mean_convergence": 0.19246721712777187,
+          "baseline_mean_convergence": 0.06642476784345355,
+          "edge_vs_baseline": 0.12604244928431832,
+          "p_value": 0.423,
+          "max_single_event_share": 0.04037741038419597,
+          "concentration_ok": true,
+          "h1_pass": false
         }
       ],
-      "h1_pass": true
+      "h1_pass": false
     },
     {
       "ticker": "DFDV",
@@ -92,22 +102,32 @@
       "horizon_results": [
         {
           "horizon": 10,
-          "event_count": 74,
-          "event_mean_convergence": 0.008888826431557329,
-          "baseline_mean_convergence": 0.0,
-          "edge_vs_baseline": 0.008888826431557329,
-          "h1_pass": true
+          "event_count": 5,
+          "eligible_days": 74,
+          "event_fraction": 0.06756756756756757,
+          "event_mean_convergence": 0.7417604424148062,
+          "baseline_mean_convergence": 0.04850532651344138,
+          "edge_vs_baseline": 0.6932551159013648,
+          "p_value": 0.3385,
+          "max_single_event_share": 0.3065611704745262,
+          "concentration_ok": false,
+          "h1_pass": false
         },
         {
           "horizon": 21,
-          "event_count": 63,
-          "event_mean_convergence": -0.005284826682016076,
-          "baseline_mean_convergence": 0.0,
-          "edge_vs_baseline": -0.005284826682016076,
+          "event_count": 5,
+          "eligible_days": 63,
+          "event_fraction": 0.07936507936507936,
+          "event_mean_convergence": 0.9002047746218408,
+          "baseline_mean_convergence": 0.4998377857711129,
+          "edge_vs_baseline": 0.4003669888507279,
+          "p_value": 0.1995,
+          "max_single_event_share": 0.2698693691669733,
+          "concentration_ok": false,
           "h1_pass": false
         }
       ],
-      "h1_pass": true
+      "h1_pass": false
     },
     {
       "ticker": "MSTR",
@@ -115,18 +135,28 @@
       "horizon_results": [
         {
           "horizon": 10,
-          "event_count": 414,
-          "event_mean_convergence": -0.021223893995556797,
-          "baseline_mean_convergence": 0.0,
-          "edge_vs_baseline": -0.021223893995556797,
+          "event_count": 181,
+          "eligible_days": 414,
+          "event_fraction": 0.43719806763285024,
+          "event_mean_convergence": -0.08639604458425591,
+          "baseline_mean_convergence": 1.3533235044956125,
+          "edge_vs_baseline": -1.4397195490798684,
+          "p_value": 0.63,
+          "max_single_event_share": 0.03611665603891896,
+          "concentration_ok": true,
           "h1_pass": false
         },
         {
           "horizon": 21,
-          "event_count": 403,
-          "event_mean_convergence": -0.03594650593744954,
-          "baseline_mean_convergence": 0.0,
-          "edge_vs_baseline": -0.03594650593744954,
+          "event_count": 181,
+          "eligible_days": 403,
+          "event_fraction": 0.4491315136476427,
+          "event_mean_convergence": -0.1683036684240924,
+          "baseline_mean_convergence": -1.3993069459322793,
+          "edge_vs_baseline": 1.231003277508187,
+          "p_value": 0.439,
+          "max_single_event_share": 0.03704615192204972,
+          "concentration_ok": true,
           "h1_pass": false
         }
       ],
@@ -138,18 +168,28 @@
       "horizon_results": [
         {
           "horizon": 10,
-          "event_count": 51,
-          "event_mean_convergence": 0.04948359863261288,
-          "baseline_mean_convergence": 0.0,
-          "edge_vs_baseline": 0.04948359863261288,
+          "event_count": 15,
+          "eligible_days": 51,
+          "event_fraction": 0.29411764705882354,
+          "event_mean_convergence": 0.15601637021528297,
+          "baseline_mean_convergence": -0.7764093331139555,
+          "edge_vs_baseline": 0.9324257033292385,
+          "p_value": 0.0,
+          "max_single_event_share": 0.10979687606790277,
+          "concentration_ok": true,
           "h1_pass": true
         },
         {
           "horizon": 21,
-          "event_count": 40,
-          "event_mean_convergence": 0.07376378647357072,
-          "baseline_mean_convergence": 0.0,
-          "edge_vs_baseline": 0.07376378647357072,
+          "event_count": 14,
+          "eligible_days": 40,
+          "event_fraction": 0.35,
+          "event_mean_convergence": 0.21728400740471224,
+          "baseline_mean_convergence": -1.4443223868100659,
+          "edge_vs_baseline": 1.661606394214778,
+          "p_value": 0.0,
+          "max_single_event_share": 0.14242293942555764,
+          "concentration_ok": true,
           "h1_pass": true
         }
       ],
@@ -157,9 +197,9 @@
     }
   ],
   "status": "OK",
-  "verdict": "HAS_PULSE",
+  "verdict": "WEAK_EDGE",
   "reasons": [
-    "mNAV mean-reversion clears random baseline on 3 names (3350.T, DFDV, SBET)"
+    "H1 passes on 1 name(s) (SBET) but needs >= 3 for H2"
   ],
-  "generated_at": "2026-06-20T16:58:21.013545+00:00"
+  "generated_at": "2026-06-20T17:10:08.172766+00:00"
 }

--- a/research/rbi_loop/mnav-premium-reversion-v0/probe_result.json
+++ b/research/rbi_loop/mnav-premium-reversion-v0/probe_result.json
@@ -1,0 +1,165 @@
+{
+  "config": {
+    "tickers": [
+      "3350.T",
+      "DFDV",
+      "MSTR",
+      "SBET"
+    ],
+    "start": "2024-01-01",
+    "end": "2026-06-01",
+    "trailing_window_days": 180,
+    "extreme_pct": 10,
+    "horizons": [
+      10,
+      21
+    ],
+    "min_names": 4,
+    "min_names_edge": 3,
+    "seed_csv": "data/treasury_equities/mnav_universe.csv"
+  },
+  "data_audit": {
+    "total_names": 4,
+    "usable_names": 4,
+    "per_name": [
+      {
+        "ticker": "3350.T",
+        "rows": 465,
+        "span_days": 697,
+        "equity_source": "yfinance",
+        "max_disclosure_gap_days": 336,
+        "stale_disclosure": true,
+        "usable": true
+      },
+      {
+        "ticker": "DFDV",
+        "rows": 264,
+        "span_days": 382,
+        "equity_source": "yfinance",
+        "max_disclosure_gap_days": 327,
+        "stale_disclosure": true,
+        "usable": true
+      },
+      {
+        "ticker": "MSTR",
+        "rows": 604,
+        "span_days": 878,
+        "equity_source": "yfinance",
+        "max_disclosure_gap_days": 568,
+        "stale_disclosure": true,
+        "usable": true
+      },
+      {
+        "ticker": "SBET",
+        "rows": 241,
+        "span_days": 350,
+        "equity_source": "yfinance",
+        "max_disclosure_gap_days": 169,
+        "stale_disclosure": true,
+        "usable": true
+      }
+    ],
+    "blocked": false,
+    "blocked_reason": null
+  },
+  "name_results": [
+    {
+      "ticker": "3350.T",
+      "trading_days": 465,
+      "horizon_results": [
+        {
+          "horizon": 10,
+          "event_count": 275,
+          "event_mean_convergence": 8.057000690133437,
+          "baseline_mean_convergence": 0.0,
+          "edge_vs_baseline": 8.057000690133437,
+          "h1_pass": true
+        },
+        {
+          "horizon": 21,
+          "event_count": 264,
+          "event_mean_convergence": 66.56075278407751,
+          "baseline_mean_convergence": 0.0,
+          "edge_vs_baseline": 66.56075278407751,
+          "h1_pass": true
+        }
+      ],
+      "h1_pass": true
+    },
+    {
+      "ticker": "DFDV",
+      "trading_days": 264,
+      "horizon_results": [
+        {
+          "horizon": 10,
+          "event_count": 74,
+          "event_mean_convergence": 0.008888826431557329,
+          "baseline_mean_convergence": 0.0,
+          "edge_vs_baseline": 0.008888826431557329,
+          "h1_pass": true
+        },
+        {
+          "horizon": 21,
+          "event_count": 63,
+          "event_mean_convergence": -0.005284826682016076,
+          "baseline_mean_convergence": 0.0,
+          "edge_vs_baseline": -0.005284826682016076,
+          "h1_pass": false
+        }
+      ],
+      "h1_pass": true
+    },
+    {
+      "ticker": "MSTR",
+      "trading_days": 604,
+      "horizon_results": [
+        {
+          "horizon": 10,
+          "event_count": 414,
+          "event_mean_convergence": -0.021223893995556797,
+          "baseline_mean_convergence": 0.0,
+          "edge_vs_baseline": -0.021223893995556797,
+          "h1_pass": false
+        },
+        {
+          "horizon": 21,
+          "event_count": 403,
+          "event_mean_convergence": -0.03594650593744954,
+          "baseline_mean_convergence": 0.0,
+          "edge_vs_baseline": -0.03594650593744954,
+          "h1_pass": false
+        }
+      ],
+      "h1_pass": false
+    },
+    {
+      "ticker": "SBET",
+      "trading_days": 241,
+      "horizon_results": [
+        {
+          "horizon": 10,
+          "event_count": 51,
+          "event_mean_convergence": 0.04948359863261288,
+          "baseline_mean_convergence": 0.0,
+          "edge_vs_baseline": 0.04948359863261288,
+          "h1_pass": true
+        },
+        {
+          "horizon": 21,
+          "event_count": 40,
+          "event_mean_convergence": 0.07376378647357072,
+          "baseline_mean_convergence": 0.0,
+          "edge_vs_baseline": 0.07376378647357072,
+          "h1_pass": true
+        }
+      ],
+      "h1_pass": true
+    }
+  ],
+  "status": "OK",
+  "verdict": "HAS_PULSE",
+  "reasons": [
+    "mNAV mean-reversion clears random baseline on 3 names (3350.T, DFDV, SBET)"
+  ],
+  "generated_at": "2026-06-20T16:58:21.013545+00:00"
+}

--- a/scripts/probe_mnav_premium_reversion.py
+++ b/scripts/probe_mnav_premium_reversion.py
@@ -54,6 +54,16 @@ DEFAULT_MIN_NAMES_EDGE = 3
 # (SBET/DFDV treasuries begin mid-2025).
 DEFAULT_MIN_TRADING_DAYS = 180
 DEFAULT_RANDOM_BASELINE_SAMPLES = 200
+DEFAULT_BOOTSTRAP_ITERATIONS = 2000
+DEFAULT_SIGNIFICANCE_ALPHA = 0.05
+# Minimum normalized edge (fractional convergence toward median) vs baseline.
+DEFAULT_MIN_FRACTIONAL_EDGE = 0.02
+DEFAULT_MAX_SINGLE_EVENT_SHARE = 0.25
+DEFAULT_MIN_EVENTS = 5
+DEFAULT_MIN_DENOMINATOR = 1e-6
+# After fixing percentile cuts, expect ~10-25% of eligible days flagged.
+EXPECTED_EVENT_FRACTION_LO = 0.05
+EXPECTED_EVENT_FRACTION_HI = 0.30
 DEFAULT_SEED_CSV = Path("data/treasury_equities/mnav_universe.csv")
 
 # MSTR 10-for-1 split 2024-08-08; yfinance prices are split-adjusted retroactively.
@@ -111,9 +121,14 @@ class NameAudit:
 class HorizonResult:
     horizon: int
     event_count: int
+    eligible_days: int
+    event_fraction: float
     event_mean_convergence: float
     baseline_mean_convergence: float
     edge_vs_baseline: float
+    p_value: float
+    max_single_event_share: float
+    concentration_ok: bool
     h1_pass: bool
 
 
@@ -248,14 +263,12 @@ def max_disclosure_gap_days(disclosures: Sequence[DisclosureRow], last_day: date
     return max(gaps) if gaps else 0
 
 
-def _percentile_threshold(values: Sequence[float], pct: float, high: bool) -> float:
+def _percentile_threshold(values: Sequence[float], pct: float) -> float:
     if not values:
         return 0.0
     ordered = sorted(values)
     rank = max(0, min(len(ordered) - 1, int(round((pct / 100.0) * (len(ordered) - 1)))))
-    if high:
-        return ordered[rank]
-    return ordered[len(ordered) - 1 - rank]
+    return ordered[rank]
 
 
 def _trailing_window(values: Sequence[float], end_idx: int, window: int) -> Sequence[float]:
@@ -268,31 +281,101 @@ def detect_extreme_events(
     trailing_window: int,
     extreme_pct: float,
     horizon: int,
-) -> tuple[list[int], list[int]]:
-    """Return indices of top- and bottom-extreme event days (pre-horizon window required)."""
+) -> tuple[list[int], list[int], int]:
+    """Return top/bottom extreme indices and eligible-day count (pre-horizon window required).
+
+    Top-extreme uses the (100 - extreme_pct) percentile (e.g. 90th when extreme_pct=10).
+    Bottom-extreme uses the extreme_pct percentile (e.g. 10th).
+    """
     values = [value for _, value in mnav_series]
     top_events: list[int] = []
     bottom_events: list[int] = []
     last_idx = len(values) - horizon - 1
+    eligible_days = 0
     for idx in range(trailing_window, max(trailing_window, last_idx + 1)):
         window = _trailing_window(values, idx, trailing_window)
         if len(window) < trailing_window // 2:
             continue
+        eligible_days += 1
         current = values[idx]
-        high_cut = _percentile_threshold(window, extreme_pct, high=True)
-        low_cut = _percentile_threshold(window, extreme_pct, high=False)
-        if current >= high_cut:
+        high_cut = _percentile_threshold(window, 100.0 - extreme_pct)
+        low_cut = _percentile_threshold(window, extreme_pct)
+        if current > high_cut:
             top_events.append(idx)
-        elif current <= low_cut:
+        elif current < low_cut:
             bottom_events.append(idx)
-    return top_events, bottom_events
+    return top_events, bottom_events, eligible_days
 
 
-def _signed_convergence(current: float, future: float, median: float, extreme_side: str) -> float:
-    """Positive means mNAV moved toward the trailing median (mean-reversion)."""
+def _fractional_convergence(
+    current: float,
+    future: float,
+    median: float,
+    extreme_side: str,
+    *,
+    min_denominator: float = DEFAULT_MIN_DENOMINATOR,
+) -> float | None:
+    """Unitless fractional move toward trailing median (positive = mean-reversion)."""
     if extreme_side == "high":
-        return current - future
-    return future - current
+        denom = current - median
+        if abs(denom) < min_denominator:
+            return None
+        return (current - future) / denom
+    denom = median - current
+    if abs(denom) < min_denominator:
+        return None
+    return (future - current) / denom
+
+
+def _convergence_toward_median(
+    current: float,
+    future: float,
+    median: float,
+    *,
+    min_denominator: float = DEFAULT_MIN_DENOMINATOR,
+) -> float | None:
+    if current > median:
+        return _fractional_convergence(
+            current, future, median, "high", min_denominator=min_denominator
+        )
+    if current < median:
+        return _fractional_convergence(
+            current, future, median, "low", min_denominator=min_denominator
+        )
+    return None
+
+
+def _max_single_event_share(scores: Sequence[float]) -> float:
+    if not scores:
+        return 0.0
+    total = sum(abs(score) for score in scores)
+    if total <= 0.0:
+        return 0.0
+    return max(abs(score) for score in scores) / total
+
+
+def _bootstrap_mean_diff_p_value(
+    event_scores: Sequence[float],
+    baseline_scores: Sequence[float],
+    rng: random.Random,
+    *,
+    iterations: int = DEFAULT_BOOTSTRAP_ITERATIONS,
+) -> float:
+    if len(event_scores) < 2 or len(baseline_scores) < 2:
+        return 1.0
+    observed = statistics.mean(event_scores) - statistics.mean(baseline_scores)
+    pool = list(event_scores) + list(baseline_scores)
+    n_events = len(event_scores)
+    extreme = 0
+    for _ in range(iterations):
+        shuffled = list(pool)
+        rng.shuffle(shuffled)
+        sample_events = shuffled[:n_events]
+        sample_baseline = shuffled[n_events:]
+        diff = statistics.mean(sample_events) - statistics.mean(sample_baseline)
+        if diff >= observed:
+            extreme += 1
+    return extreme / iterations
 
 
 def analyze_mean_reversion(
@@ -303,51 +386,64 @@ def analyze_mean_reversion(
     results: list[HorizonResult] = []
 
     for horizon in config.horizons:
-        top_events, bottom_events = detect_extreme_events(
+        top_events, bottom_events, eligible_days = detect_extreme_events(
             mnav_series, config.trailing_window_days, config.extreme_pct, horizon
         )
         event_scores: list[float] = []
         for idx in top_events:
             window = _trailing_window(values, idx, config.trailing_window_days)
             median = statistics.median(window)
-            event_scores.append(
-                _signed_convergence(values[idx], values[idx + horizon], median, "high")
-            )
+            score = _fractional_convergence(values[idx], values[idx + horizon], median, "high")
+            if score is not None:
+                event_scores.append(score)
         for idx in bottom_events:
             window = _trailing_window(values, idx, config.trailing_window_days)
             median = statistics.median(window)
-            event_scores.append(
-                _signed_convergence(values[idx], values[idx + horizon], median, "low")
-            )
+            score = _fractional_convergence(values[idx], values[idx + horizon], median, "low")
+            if score is not None:
+                event_scores.append(score)
 
-        rng = random.Random(config.rng_seed + horizon)
+        event_count = len(event_scores)
+        event_fraction = event_count / eligible_days if eligible_days else 0.0
+
+        sample_rng = random.Random(config.rng_seed + horizon)
         baseline_scores: list[float] = []
         eligible = list(range(config.trailing_window_days, len(values) - horizon))
         event_set = set(top_events) | set(bottom_events)
         pool = [i for i in eligible if i not in event_set]
         sample_size = min(config.random_baseline_samples, len(pool))
-        for idx in rng.sample(pool, k=sample_size) if sample_size else []:
+        for idx in sample_rng.sample(pool, k=sample_size) if sample_size else []:
             window = _trailing_window(values, idx, config.trailing_window_days)
             median = statistics.median(window)
-            delta = abs(values[idx] - values[idx + horizon])
-            toward = (
-                delta
-                if abs(values[idx] - median) >= abs(values[idx + horizon] - median)
-                else -delta
-            )
-            baseline_scores.append(toward)
+            score = _convergence_toward_median(values[idx], values[idx + horizon], median)
+            if score is not None:
+                baseline_scores.append(score)
 
         event_mean = statistics.mean(event_scores) if event_scores else 0.0
         baseline_mean = statistics.mean(baseline_scores) if baseline_scores else 0.0
         edge = event_mean - baseline_mean
-        h1_pass = len(event_scores) >= 2 and edge > 0.0
+        bootstrap_rng = random.Random(config.rng_seed + horizon + 10_000)
+        p_value = _bootstrap_mean_diff_p_value(event_scores, baseline_scores, bootstrap_rng)
+        max_event_share = _max_single_event_share(event_scores)
+        concentration_ok = max_event_share <= DEFAULT_MAX_SINGLE_EVENT_SHARE
+        h1_pass = (
+            event_count >= DEFAULT_MIN_EVENTS
+            and edge >= DEFAULT_MIN_FRACTIONAL_EDGE
+            and p_value < DEFAULT_SIGNIFICANCE_ALPHA
+            and concentration_ok
+        )
         results.append(
             HorizonResult(
                 horizon=horizon,
-                event_count=len(event_scores),
+                event_count=event_count,
+                eligible_days=eligible_days,
+                event_fraction=event_fraction,
                 event_mean_convergence=event_mean,
                 baseline_mean_convergence=baseline_mean,
                 edge_vs_baseline=edge,
+                p_value=p_value,
+                max_single_event_share=max_event_share,
+                concentration_ok=concentration_ok,
                 h1_pass=h1_pass,
             )
         )
@@ -492,13 +588,35 @@ async def run_probe(config: ProbeConfig) -> ProbeReport:
             continue
 
         horizon_results = analyze_mean_reversion(mnav_series, config)
-        h1_pass = any(result.h1_pass for result in horizon_results)
+        h1_pass = bool(horizon_results) and all(result.h1_pass for result in horizon_results)
+        for result in horizon_results:
+            if not (
+                EXPECTED_EVENT_FRACTION_LO <= result.event_fraction <= EXPECTED_EVENT_FRACTION_HI
+            ):
+                logger.warning(
+                    "%s H=%d: event_fraction=%.1f%% outside expected %.0f-%.0f%%",
+                    ticker,
+                    result.horizon,
+                    result.event_fraction * 100.0,
+                    EXPECTED_EVENT_FRACTION_LO * 100.0,
+                    EXPECTED_EVENT_FRACTION_HI * 100.0,
+                )
+            logger.info(
+                "%s H=%d: event_fraction=%.1f%%, events=%d/%d, edge=%+.4f, "
+                "baseline=%+.4f, p=%.4f, max_event_share=%.1f%%, H1=%s",
+                ticker,
+                result.horizon,
+                result.event_fraction * 100.0,
+                result.event_count,
+                result.eligible_days,
+                result.edge_vs_baseline,
+                result.baseline_mean_convergence,
+                result.p_value,
+                result.max_single_event_share * 100.0,
+                result.h1_pass,
+            )
         logger.info(
-            "%s: %d mNAV days, H1=%s, events=%s",
-            ticker,
-            len(mnav_series),
-            h1_pass,
-            {result.horizon: result.event_count for result in horizon_results},
+            "%s: %d mNAV days, H1=%s (all horizons required)", ticker, len(mnav_series), h1_pass
         )
         name_results.append(
             NameEdgeResult(
@@ -553,18 +671,27 @@ def render_report(report: ProbeReport) -> str:
     lines.append("")
     lines.append("## STEP 1 — Per-name mean-reversion")
     lines.append("")
-    lines.append("| Ticker | Days | H1 | H=10 edge | H=21 edge | Events (10/21) |")
-    lines.append("|--------|------|----|-----------|-----------|----------------|")
+    lines.append(
+        "| Ticker | Days | H1 | H=10 edge (p) | H=21 edge (p) | Events (10/21) | Event % |"
+    )
+    lines.append(
+        "|--------|------|----|---------------|---------------|----------------|---------|"
+    )
     for result in report.name_results:
         by_h = {item.horizon: item for item in result.horizon_results}
         h10 = by_h.get(10)
         h21 = by_h.get(21)
-        edge10 = f"{h10.edge_vs_baseline:+.4f}" if h10 else "n/a"
-        edge21 = f"{h21.edge_vs_baseline:+.4f}" if h21 else "n/a"
+        edge10 = f"{h10.edge_vs_baseline:+.4f} ({h10.p_value:.3f})" if h10 else "n/a"
+        edge21 = f"{h21.edge_vs_baseline:+.4f} ({h21.p_value:.3f})" if h21 else "n/a"
         events = f"{h10.event_count if h10 else 0}/{h21.event_count if h21 else 0}"
+        frac = (
+            f"{h10.event_fraction * 100:.0f}/{h21.event_fraction * 100:.0f}"
+            if h10 and h21
+            else "n/a"
+        )
         lines.append(
             f"| {result.ticker} | {result.trading_days} | "
-            f"{'Y' if result.h1_pass else 'n'} | {edge10} | {edge21} | {events} |"
+            f"{'Y' if result.h1_pass else 'n'} | {edge10} | {edge21} | {events} | {frac} |"
         )
     lines.append("")
     lines.append("## Reasons")

--- a/scripts/probe_mnav_premium_reversion.py
+++ b/scripts/probe_mnav_premium_reversion.py
@@ -1,0 +1,647 @@
+#!/usr/bin/env python3
+"""Cheap feasibility probe for crypto-treasury mNAV premium mean-reversion (Gate 1).
+
+Thesis (relative value, NOT direction): equities holding crypto on the balance sheet
+trade at market-cap-to-NAV (mNAV) ratios that mean-revert from trailing extremes.
+
+    mnav(i,t) = (shares_outstanding(i,t) * equity_close(i,t))
+                / (holdings_units(i,t) * crypto_close(t))
+
+Point-in-time discipline: holdings/shares step-forward-fill from filing dates only.
+See docs/specs/mnav-premium-reversion-probe-v0.md.
+
+STEP 0: data-feasibility audit — usable joined mNAV series per seeded name.
+STEP 1: H1 mean-reversion from trailing-extreme percentile vs random baseline;
+        H2 holds on >= MIN_NAMES_EDGE names (not single-ticker).
+
+Read-only. No DB writes, no orders, no --execute.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import csv
+import json
+import random
+import statistics
+import sys
+from collections.abc import Sequence
+from dataclasses import asdict, dataclass
+from datetime import UTC, date, datetime
+from pathlib import Path
+
+import yfinance as yf
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from scripts.download_historical import BinanceHistoricalClient, download_klines
+from src.utils.logger import configure_logger, get_logger
+
+BLOCKED_ON_DATA = "BLOCKED_ON_DATA"
+HAS_PULSE = "HAS_PULSE"
+WEAK_EDGE = "WEAK_EDGE"
+NO_PULSE = "NO_PULSE"
+
+DEFAULT_START = "2024-01-01"
+DEFAULT_END = "2026-06-01"
+DEFAULT_TRAILING_WINDOW_DAYS = 180
+DEFAULT_EXTREME_PCT = 10
+DEFAULT_HORIZONS = (10, 21)
+DEFAULT_MIN_NAMES = 4
+DEFAULT_MIN_NAMES_EDGE = 3
+# ~9 months; spec asks for >=12 months where available but allows gap-tolerant joins
+# (SBET/DFDV treasuries begin mid-2025).
+DEFAULT_MIN_TRADING_DAYS = 180
+DEFAULT_RANDOM_BASELINE_SAMPLES = 200
+DEFAULT_SEED_CSV = Path("data/treasury_equities/mnav_universe.csv")
+
+# MSTR 10-for-1 split 2024-08-08; yfinance prices are split-adjusted retroactively.
+MSTR_SPLIT_DATE = date(2024, 8, 8)
+MSTR_SPLIT_RATIO = 10
+
+
+@dataclass(frozen=True)
+class DisclosureRow:
+    ticker: str
+    crypto_symbol: str
+    binance_symbol: str
+    as_of_date: date
+    holdings_units: float
+    shares_outstanding: float
+    source: str
+
+
+@dataclass(frozen=True)
+class ProbeConfig:
+    tickers: tuple[str, ...]
+    start: str
+    end: str
+    trailing_window_days: int
+    extreme_pct: float
+    horizons: tuple[int, ...]
+    min_names: int
+    min_names_edge: int
+    min_trading_days: int
+    random_baseline_samples: int
+    seed_csv: Path
+    rng_seed: int
+
+
+@dataclass(frozen=True)
+class DailyInputs:
+    equity_close: float
+    crypto_close: float
+    holdings_units: float
+    shares_outstanding: float
+
+
+@dataclass(frozen=True)
+class NameAudit:
+    ticker: str
+    rows: int
+    span_days: float
+    equity_source: str
+    max_disclosure_gap_days: int
+    stale_disclosure: bool
+    usable: bool
+
+
+@dataclass(frozen=True)
+class HorizonResult:
+    horizon: int
+    event_count: int
+    event_mean_convergence: float
+    baseline_mean_convergence: float
+    edge_vs_baseline: float
+    h1_pass: bool
+
+
+@dataclass(frozen=True)
+class NameEdgeResult:
+    ticker: str
+    trading_days: int
+    horizon_results: tuple[HorizonResult, ...]
+    h1_pass: bool
+
+
+@dataclass(frozen=True)
+class DataAudit:
+    total_names: int
+    usable_names: int
+    per_name: tuple[NameAudit, ...]
+    blocked: bool
+    blocked_reason: str | None
+
+
+@dataclass(frozen=True)
+class ProbeReport:
+    config: dict[str, object]
+    data_audit: DataAudit
+    name_results: tuple[NameEdgeResult, ...]
+    status: str
+    verdict: str
+    reasons: tuple[str, ...]
+
+
+def _parse_dt(raw: str) -> datetime:
+    text = raw.strip()
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    parsed = datetime.fromisoformat(text)
+    return parsed.replace(tzinfo=UTC) if parsed.tzinfo is None else parsed.astimezone(UTC)
+
+
+def _parse_date(raw: str) -> date:
+    return date.fromisoformat(raw.strip())
+
+
+def load_disclosures(csv_path: Path) -> list[DisclosureRow]:
+    rows: list[DisclosureRow] = []
+    with csv_path.open(newline="", encoding="utf-8") as handle:
+        reader = csv.DictReader(handle)
+        for entry in reader:
+            rows.append(
+                DisclosureRow(
+                    ticker=entry["ticker"].strip(),
+                    crypto_symbol=entry["crypto_symbol"].strip(),
+                    binance_symbol=entry["binance_symbol"].strip(),
+                    as_of_date=_parse_date(entry["as_of_date"]),
+                    holdings_units=float(entry["holdings_units"]),
+                    shares_outstanding=float(entry["shares_outstanding"]),
+                    source=entry["source"].strip(),
+                )
+            )
+    return sorted(rows, key=lambda r: (r.ticker, r.as_of_date))
+
+
+def normalize_shares_outstanding(ticker: str, as_of: date, shares: float) -> float:
+    """Align pre-split MSTR share counts with yfinance split-adjusted prices."""
+    if ticker == "MSTR" and as_of < MSTR_SPLIT_DATE:
+        return shares * MSTR_SPLIT_RATIO
+    return shares
+
+
+def forward_fill_disclosures(
+    disclosures: Sequence[DisclosureRow],
+    trading_days: Sequence[date],
+) -> dict[date, tuple[float, float]]:
+    """Return day -> (holdings_units, shares_outstanding) using point-in-time step fill."""
+    by_ticker = sorted(disclosures, key=lambda r: r.as_of_date)
+    if not by_ticker:
+        return {}
+
+    out: dict[date, tuple[float, float]] = {}
+    cursor = 0
+    active_holdings = 0.0
+    active_shares = 0.0
+
+    for day in trading_days:
+        while cursor < len(by_ticker) and by_ticker[cursor].as_of_date <= day:
+            row = by_ticker[cursor]
+            active_holdings = row.holdings_units
+            active_shares = normalize_shares_outstanding(
+                row.ticker, row.as_of_date, row.shares_outstanding
+            )
+            cursor += 1
+        if cursor > 0:
+            out[day] = (active_holdings, active_shares)
+    return out
+
+
+def compute_mnav(
+    equity_close: float,
+    crypto_close: float,
+    holdings_units: float,
+    shares_outstanding: float,
+) -> float | None:
+    if holdings_units <= 0 or shares_outstanding <= 0 or crypto_close <= 0 or equity_close <= 0:
+        return None
+    crypto_nav = holdings_units * crypto_close
+    market_cap = shares_outstanding * equity_close
+    return market_cap / crypto_nav
+
+
+def build_mnav_series(
+    trading_days: Sequence[date],
+    equity_closes: dict[date, float],
+    crypto_closes: dict[date, float],
+    filled: dict[date, tuple[float, float]],
+) -> list[tuple[date, float]]:
+    series: list[tuple[date, float]] = []
+    for day in trading_days:
+        if day not in filled or day not in equity_closes or day not in crypto_closes:
+            continue
+        holdings, shares = filled[day]
+        mnav = compute_mnav(equity_closes[day], crypto_closes[day], holdings, shares)
+        if mnav is not None:
+            series.append((day, mnav))
+    return series
+
+
+def max_disclosure_gap_days(disclosures: Sequence[DisclosureRow], last_day: date) -> int:
+    if not disclosures:
+        return 0
+    points = sorted({row.as_of_date for row in disclosures})
+    gaps = [(points[i] - points[i - 1]).days for i in range(1, len(points))]
+    gaps.append((last_day - points[-1]).days)
+    return max(gaps) if gaps else 0
+
+
+def _percentile_threshold(values: Sequence[float], pct: float, high: bool) -> float:
+    if not values:
+        return 0.0
+    ordered = sorted(values)
+    rank = max(0, min(len(ordered) - 1, int(round((pct / 100.0) * (len(ordered) - 1)))))
+    if high:
+        return ordered[rank]
+    return ordered[len(ordered) - 1 - rank]
+
+
+def _trailing_window(values: Sequence[float], end_idx: int, window: int) -> Sequence[float]:
+    start = max(0, end_idx - window + 1)
+    return values[start : end_idx + 1]
+
+
+def detect_extreme_events(
+    mnav_series: Sequence[tuple[date, float]],
+    trailing_window: int,
+    extreme_pct: float,
+    horizon: int,
+) -> tuple[list[int], list[int]]:
+    """Return indices of top- and bottom-extreme event days (pre-horizon window required)."""
+    values = [value for _, value in mnav_series]
+    top_events: list[int] = []
+    bottom_events: list[int] = []
+    last_idx = len(values) - horizon - 1
+    for idx in range(trailing_window, max(trailing_window, last_idx + 1)):
+        window = _trailing_window(values, idx, trailing_window)
+        if len(window) < trailing_window // 2:
+            continue
+        current = values[idx]
+        high_cut = _percentile_threshold(window, extreme_pct, high=True)
+        low_cut = _percentile_threshold(window, extreme_pct, high=False)
+        if current >= high_cut:
+            top_events.append(idx)
+        elif current <= low_cut:
+            bottom_events.append(idx)
+    return top_events, bottom_events
+
+
+def _signed_convergence(current: float, future: float, median: float, extreme_side: str) -> float:
+    """Positive means mNAV moved toward the trailing median (mean-reversion)."""
+    if extreme_side == "high":
+        return current - future
+    return future - current
+
+
+def analyze_mean_reversion(
+    mnav_series: Sequence[tuple[date, float]],
+    config: ProbeConfig,
+) -> tuple[HorizonResult, ...]:
+    values = [value for _, value in mnav_series]
+    results: list[HorizonResult] = []
+
+    for horizon in config.horizons:
+        top_events, bottom_events = detect_extreme_events(
+            mnav_series, config.trailing_window_days, config.extreme_pct, horizon
+        )
+        event_scores: list[float] = []
+        for idx in top_events:
+            window = _trailing_window(values, idx, config.trailing_window_days)
+            median = statistics.median(window)
+            event_scores.append(
+                _signed_convergence(values[idx], values[idx + horizon], median, "high")
+            )
+        for idx in bottom_events:
+            window = _trailing_window(values, idx, config.trailing_window_days)
+            median = statistics.median(window)
+            event_scores.append(
+                _signed_convergence(values[idx], values[idx + horizon], median, "low")
+            )
+
+        rng = random.Random(config.rng_seed + horizon)
+        baseline_scores: list[float] = []
+        eligible = list(range(config.trailing_window_days, len(values) - horizon))
+        event_set = set(top_events) | set(bottom_events)
+        pool = [i for i in eligible if i not in event_set]
+        sample_size = min(config.random_baseline_samples, len(pool))
+        for idx in rng.sample(pool, k=sample_size) if sample_size else []:
+            window = _trailing_window(values, idx, config.trailing_window_days)
+            median = statistics.median(window)
+            delta = abs(values[idx] - values[idx + horizon])
+            toward = (
+                delta
+                if abs(values[idx] - median) >= abs(values[idx + horizon] - median)
+                else -delta
+            )
+            baseline_scores.append(toward)
+
+        event_mean = statistics.mean(event_scores) if event_scores else 0.0
+        baseline_mean = statistics.mean(baseline_scores) if baseline_scores else 0.0
+        edge = event_mean - baseline_mean
+        h1_pass = len(event_scores) >= 2 and edge > 0.0
+        results.append(
+            HorizonResult(
+                horizon=horizon,
+                event_count=len(event_scores),
+                event_mean_convergence=event_mean,
+                baseline_mean_convergence=baseline_mean,
+                edge_vs_baseline=edge,
+                h1_pass=h1_pass,
+            )
+        )
+    return tuple(results)
+
+
+def audit_data(
+    audits: Sequence[NameAudit],
+    config: ProbeConfig,
+) -> DataAudit:
+    usable = sum(1 for audit in audits if audit.usable)
+    blocked = usable < config.min_names
+    reason = (
+        f"only {usable} names have usable joined mNAV series (need >= {config.min_names})"
+        if blocked
+        else None
+    )
+    return DataAudit(
+        total_names=len(audits),
+        usable_names=usable,
+        per_name=tuple(audits),
+        blocked=blocked,
+        blocked_reason=reason,
+    )
+
+
+def decide_verdict(
+    audit: DataAudit,
+    name_results: Sequence[NameEdgeResult],
+    config: ProbeConfig,
+) -> tuple[str, str, tuple[str, ...]]:
+    if audit.blocked:
+        return (BLOCKED_ON_DATA, BLOCKED_ON_DATA, (audit.blocked_reason or "data gate failed",))
+
+    passing_names = [result for result in name_results if result.h1_pass]
+    h1_ok = len(passing_names) >= 1
+    h2_ok = len(passing_names) >= config.min_names_edge
+
+    if h1_ok and h2_ok:
+        tickers = ", ".join(sorted({result.ticker for result in passing_names}))
+        return (
+            "OK",
+            HAS_PULSE,
+            (
+                f"mNAV mean-reversion clears random baseline on {len(passing_names)} names "
+                f"({tickers})",
+            ),
+        )
+    if h1_ok and not h2_ok:
+        tickers = ", ".join(sorted({result.ticker for result in passing_names}))
+        return (
+            "OK",
+            WEAK_EDGE,
+            (
+                f"H1 passes on {len(passing_names)} name(s) ({tickers}) but "
+                f"needs >= {config.min_names_edge} for H2",
+            ),
+        )
+    return ("OK", NO_PULSE, ("no name shows mNAV extreme mean-reversion above random baseline",))
+
+
+def fetch_equity_closes(ticker: str, start: str, end: str) -> dict[date, float]:
+    frame = yf.Ticker(ticker).history(start=start, end=end, interval="1d", auto_adjust=True)
+    closes: dict[date, float] = {}
+    for idx, row in frame.iterrows():
+        day = idx.date() if hasattr(idx, "date") else idx.to_pydatetime().date()
+        closes[day] = float(row["Close"])
+    return closes
+
+
+async def fetch_crypto_closes(symbol: str, start: str, end: str) -> dict[date, float]:
+    async with BinanceHistoricalClient() as client:
+        rows = await download_klines(client, symbol, "1d", start, end)
+    closes: dict[date, float] = {}
+    for row in rows:
+        ts = row["time"]
+        day = (
+            ts.date()
+            if isinstance(ts, datetime)
+            else datetime.fromtimestamp(float(ts), tz=UTC).date()
+        )
+        closes[day] = float(row["close_price"])
+    return closes
+
+
+async def run_probe(config: ProbeConfig) -> ProbeReport:
+    configure_logger("INFO")
+    logger = get_logger("probe.mnav_premium")
+
+    disclosures = load_disclosures(config.seed_csv)
+    if config.tickers:
+        allowed = set(config.tickers)
+        disclosures = [row for row in disclosures if row.ticker in allowed]
+
+    by_ticker: dict[str, list[DisclosureRow]] = {}
+    for row in disclosures:
+        by_ticker.setdefault(row.ticker, []).append(row)
+
+    start_day = _parse_date(config.start)
+    end_day = _parse_date(config.end)
+
+    audits: list[NameAudit] = []
+    name_results: list[NameEdgeResult] = []
+
+    for ticker, ticker_rows in sorted(by_ticker.items()):
+        binance_symbol = ticker_rows[0].binance_symbol
+        equity_closes = fetch_equity_closes(ticker, config.start, config.end)
+        crypto_closes = await fetch_crypto_closes(binance_symbol, config.start, config.end)
+
+        trading_days = sorted(set(equity_closes) & set(crypto_closes))
+        trading_days = [day for day in trading_days if start_day <= day <= end_day]
+        filled = forward_fill_disclosures(ticker_rows, trading_days)
+        mnav_series = build_mnav_series(trading_days, equity_closes, crypto_closes, filled)
+
+        span_days = 0.0
+        if len(mnav_series) >= 2:
+            span_days = (mnav_series[-1][0] - mnav_series[0][0]).days
+
+        gap_days = max_disclosure_gap_days(ticker_rows, end_day)
+        usable = len(mnav_series) >= config.min_trading_days
+        audits.append(
+            NameAudit(
+                ticker=ticker,
+                rows=len(mnav_series),
+                span_days=span_days,
+                equity_source="yfinance",
+                max_disclosure_gap_days=gap_days,
+                stale_disclosure=gap_days > 45,
+                usable=usable,
+            )
+        )
+
+        if not usable:
+            logger.warning(
+                "%s: only %d mNAV rows (need %d)", ticker, len(mnav_series), config.min_trading_days
+            )
+            name_results.append(
+                NameEdgeResult(
+                    ticker=ticker, trading_days=len(mnav_series), horizon_results=(), h1_pass=False
+                )
+            )
+            continue
+
+        horizon_results = analyze_mean_reversion(mnav_series, config)
+        h1_pass = any(result.h1_pass for result in horizon_results)
+        logger.info(
+            "%s: %d mNAV days, H1=%s, events=%s",
+            ticker,
+            len(mnav_series),
+            h1_pass,
+            {result.horizon: result.event_count for result in horizon_results},
+        )
+        name_results.append(
+            NameEdgeResult(
+                ticker=ticker,
+                trading_days=len(mnav_series),
+                horizon_results=horizon_results,
+                h1_pass=h1_pass,
+            )
+        )
+
+    audit = audit_data(audits, config)
+    status, verdict, reasons = decide_verdict(audit, name_results, config)
+    return ProbeReport(
+        config={
+            "tickers": list(config.tickers) if config.tickers else sorted(by_ticker),
+            "start": config.start,
+            "end": config.end,
+            "trailing_window_days": config.trailing_window_days,
+            "extreme_pct": config.extreme_pct,
+            "horizons": list(config.horizons),
+            "min_names": config.min_names,
+            "min_names_edge": config.min_names_edge,
+            "seed_csv": str(config.seed_csv),
+        },
+        data_audit=audit,
+        name_results=tuple(name_results),
+        status=status,
+        verdict=verdict,
+        reasons=reasons,
+    )
+
+
+def render_report(report: ProbeReport) -> str:
+    lines: list[str] = ["# mNAV Premium-Reversion Probe — Report", ""]
+    lines.append(f"**Verdict:** **{report.verdict}**")
+    lines.append("**Script:** `scripts/probe_mnav_premium_reversion.py`")
+    lines.append("**Framing:** relative value (equity mNAV vs crypto NAV), not price forecast.")
+    lines.append("")
+    audit = report.data_audit
+    lines.append("## STEP 0 — Data feasibility")
+    lines.append(f"- Names: {audit.total_names}; usable: {audit.usable_names}")
+    for item in audit.per_name:
+        stale = " **stale-disclosure**" if item.stale_disclosure else ""
+        lines.append(
+            f"- {item.ticker}: {item.rows} rows, span {item.span_days:.0f}d, "
+            f"equity={item.equity_source}, max gap {item.max_disclosure_gap_days}d{stale}"
+        )
+    lines.append(
+        f"- Blocked: {audit.blocked}"
+        + (f" — {audit.blocked_reason}" if audit.blocked_reason else "")
+    )
+    lines.append("")
+    lines.append("## STEP 1 — Per-name mean-reversion")
+    lines.append("")
+    lines.append("| Ticker | Days | H1 | H=10 edge | H=21 edge | Events (10/21) |")
+    lines.append("|--------|------|----|-----------|-----------|----------------|")
+    for result in report.name_results:
+        by_h = {item.horizon: item for item in result.horizon_results}
+        h10 = by_h.get(10)
+        h21 = by_h.get(21)
+        edge10 = f"{h10.edge_vs_baseline:+.4f}" if h10 else "n/a"
+        edge21 = f"{h21.edge_vs_baseline:+.4f}" if h21 else "n/a"
+        events = f"{h10.event_count if h10 else 0}/{h21.event_count if h21 else 0}"
+        lines.append(
+            f"| {result.ticker} | {result.trading_days} | "
+            f"{'Y' if result.h1_pass else 'n'} | {edge10} | {edge21} | {events} |"
+        )
+    lines.append("")
+    lines.append("## Reasons")
+    for reason in report.reasons:
+        lines.append(f"- {reason}")
+    return "\n".join(lines)
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--symbols", nargs="+", default=[], help="Ticker filter (alias: treasury names)"
+    )
+    parser.add_argument("--start", default=DEFAULT_START)
+    parser.add_argument("--end", default=DEFAULT_END)
+    parser.add_argument("--trailing-window-days", type=int, default=DEFAULT_TRAILING_WINDOW_DAYS)
+    parser.add_argument("--extreme-pct", type=float, default=DEFAULT_EXTREME_PCT)
+    parser.add_argument(
+        "--horizons",
+        type=int,
+        nargs="+",
+        default=list(DEFAULT_HORIZONS),
+    )
+    parser.add_argument("--min-names", type=int, default=DEFAULT_MIN_NAMES)
+    parser.add_argument("--min-names-edge", type=int, default=DEFAULT_MIN_NAMES_EDGE)
+    parser.add_argument(
+        "--output-dir",
+        default=str(Path("research/rbi_loop/mnav-premium-reversion-v0")),
+    )
+    parser.add_argument("--seed-csv", default=str(DEFAULT_SEED_CSV))
+    parser.add_argument("--rng-seed", type=int, default=42)
+    return parser.parse_args(argv)
+
+
+async def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    config = ProbeConfig(
+        tickers=tuple(args.symbols),
+        start=args.start,
+        end=args.end,
+        trailing_window_days=args.trailing_window_days,
+        extreme_pct=args.extreme_pct,
+        horizons=tuple(args.horizons),
+        min_names=args.min_names,
+        min_names_edge=args.min_names_edge,
+        min_trading_days=DEFAULT_MIN_TRADING_DAYS,
+        random_baseline_samples=DEFAULT_RANDOM_BASELINE_SAMPLES,
+        seed_csv=Path(args.seed_csv),
+        rng_seed=args.rng_seed,
+    )
+    report = await run_probe(config)
+
+    out_dir = Path(args.output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "config": report.config,
+        "data_audit": asdict(report.data_audit),
+        "name_results": [
+            {
+                **asdict(result),
+                "horizon_results": [asdict(item) for item in result.horizon_results],
+            }
+            for result in report.name_results
+        ],
+        "status": report.status,
+        "verdict": report.verdict,
+        "reasons": list(report.reasons),
+        "generated_at": datetime.now(UTC).isoformat(),
+    }
+    (out_dir / "probe_result.json").write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    report_md = render_report(report)
+    (out_dir / "probe_report.md").write_text(report_md + "\n", encoding="utf-8")
+
+    print(report_md)
+    print(f"\nVERDICT: {report.verdict}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/tests/test_probe_mnav_premium_reversion.py
+++ b/tests/test_probe_mnav_premium_reversion.py
@@ -1,0 +1,169 @@
+"""Tests for the mNAV premium-reversion probe (no network)."""
+
+import math
+from datetime import date
+
+import pytest
+
+from scripts.probe_mnav_premium_reversion import (
+    DisclosureRow,
+    NameAudit,
+    NameEdgeResult,
+    ProbeConfig,
+    analyze_mean_reversion,
+    audit_data,
+    build_mnav_series,
+    compute_mnav,
+    decide_verdict,
+    detect_extreme_events,
+    forward_fill_disclosures,
+    normalize_shares_outstanding,
+)
+
+T0 = date(2024, 1, 1)
+
+
+def _row(
+    as_of: str,
+    holdings: float,
+    shares: float,
+    *,
+    ticker: str = "TEST",
+    crypto: str = "BTC",
+    symbol: str = "BTCUSDT",
+) -> DisclosureRow:
+    return DisclosureRow(
+        ticker=ticker,
+        crypto_symbol=crypto,
+        binance_symbol=symbol,
+        as_of_date=date.fromisoformat(as_of),
+        holdings_units=holdings,
+        shares_outstanding=shares,
+        source="fixture",
+    )
+
+
+def _days(n: int) -> list[date]:
+    from datetime import timedelta
+
+    return [T0 + timedelta(days=i) for i in range(n)]
+
+
+def _gate_config(**overrides) -> ProbeConfig:
+    defaults = {
+        "tickers": (),
+        "start": "2024-01-01",
+        "end": "2026-06-01",
+        "trailing_window_days": 20,
+        "extreme_pct": 10,
+        "horizons": (5, 10),
+        "min_names": 4,
+        "min_names_edge": 3,
+        "min_trading_days": 60,
+        "random_baseline_samples": 50,
+        "seed_csv": None,  # type: ignore[arg-type]
+        "rng_seed": 7,
+    }
+    defaults.update(overrides)
+    return ProbeConfig(**defaults)
+
+
+def test_forward_fill_is_point_in_time_not_look_ahead():
+    """Today's disclosure must never apply to dates before as_of_date."""
+    disclosures = [
+        _row("2024-01-01", holdings=100, shares=1_000_000),
+        _row("2024-06-01", holdings=200, shares=2_000_000),
+    ]
+    trading_days = _days(200)
+    filled = forward_fill_disclosures(disclosures, trading_days)
+
+    assert (T0, (100, 1_000_000)) == (trading_days[0], filled[trading_days[0]])
+    assert filled[date(2024, 5, 31)] == (100, 1_000_000)
+    assert filled[date(2024, 6, 1)] == (200, 2_000_000)
+    assert filled[date(2024, 7, 1)] == (200, 2_000_000)
+    assert date(2023, 12, 31) not in filled
+
+
+def test_mstr_pre_split_shares_scaled_for_split_adjusted_prices():
+    assert normalize_shares_outstanding("MSTR", date(2024, 7, 31), 19_067_000) == 190_670_000
+    assert normalize_shares_outstanding("MSTR", date(2024, 8, 8), 190_670_000) == 190_670_000
+    assert normalize_shares_outstanding("3350.T", date(2024, 7, 31), 181_692_180) == 181_692_180
+
+
+def test_compute_mnav_matches_hand_calculation():
+    # market_cap = 1_000_000 * 10 = 10_000_000; crypto_nav = 100 * 50_000 = 5_000_000
+    assert compute_mnav(10.0, 50_000.0, 100.0, 1_000_000.0) == pytest.approx(2.0)
+
+
+def test_detect_extreme_percentile_events():
+    values = [1.0 + 0.01 * i for i in range(60)]
+    values[40] = 3.0  # spike in trailing window
+    series = [(T0, value) for value in values]
+    top, bottom = detect_extreme_events(series, trailing_window=20, extreme_pct=10, horizon=5)
+    assert 40 in top
+    assert bottom == []
+
+
+def test_analyze_has_pulse_on_synthetic_mean_reversion():
+    """Oscillating baseline with a reverting spike should beat random baseline -> H1 pass."""
+    values = [1.0 + 0.1 * math.sin(i * 0.5) for i in range(80)]
+    values[45] = 2.5
+    for offset in range(1, 6):
+        values[45 + offset] = 2.5 - 0.28 * offset
+    series = [(T0, value) for value in values]
+    results = analyze_mean_reversion(series, _gate_config(trailing_window_days=20, horizons=(5,)))
+    assert results[0].h1_pass is True
+    assert results[0].edge_vs_baseline > 0
+
+
+def test_analyze_no_pulse_on_flat_series():
+    series = [(T0, 1.5) for _ in range(80)]
+    results = analyze_mean_reversion(series, _gate_config(trailing_window_days=20, horizons=(5,)))
+    assert results[0].h1_pass is False
+
+
+def _name_audit(*, usable: bool, ticker: str = "T") -> NameAudit:
+    return NameAudit(
+        ticker=ticker,
+        rows=100 if usable else 10,
+        span_days=200.0 if usable else 30.0,
+        equity_source="fixture",
+        max_disclosure_gap_days=30,
+        stale_disclosure=False,
+        usable=usable,
+    )
+
+
+def _edge_result(*, ticker: str, h1_pass: bool) -> NameEdgeResult:
+    return NameEdgeResult(ticker=ticker, trading_days=100, horizon_results=(), h1_pass=h1_pass)
+
+
+def test_decide_verdict_routing():
+    audit_blocked = audit_data(
+        [_name_audit(usable=False) for _ in range(3)],
+        _gate_config(min_names=4),
+    )
+    assert decide_verdict(audit_blocked, (), _gate_config())[1] == "BLOCKED_ON_DATA"
+
+    audit_ok = audit_data(
+        [_name_audit(usable=True, ticker=f"T{i}") for i in range(4)],
+        _gate_config(min_names=4),
+    )
+    one = _edge_result(ticker="ONLY", h1_pass=True)
+    assert decide_verdict(audit_ok, [one], _gate_config(min_names_edge=3))[1] == "WEAK_EDGE"
+
+    three = [_edge_result(ticker=f"T{i}", h1_pass=True) for i in range(3)]
+    assert decide_verdict(audit_ok, three, _gate_config(min_names_edge=3))[1] == "HAS_PULSE"
+
+    none = _edge_result(ticker="X", h1_pass=False)
+    assert decide_verdict(audit_ok, [none], _gate_config())[1] == "NO_PULSE"
+
+
+def test_build_mnav_series_joins_prices_and_disclosures():
+    days = _days(5)
+    equity = dict.fromkeys(days, 10.0)
+    crypto = dict.fromkeys(days, 50000.0)
+    filled = forward_fill_disclosures([_row("2024-01-01", 100, 1_000_000)], days)
+    series = build_mnav_series(days, equity, crypto, filled)
+    assert len(series) == 5
+    assert series[0][1] == pytest.approx(2.0)

--- a/tests/test_probe_mnav_premium_reversion.py
+++ b/tests/test_probe_mnav_premium_reversion.py
@@ -96,24 +96,31 @@ def test_compute_mnav_matches_hand_calculation():
 
 
 def test_detect_extreme_percentile_events():
-    values = [1.0 + 0.01 * i for i in range(60)]
+    values = [1.0 + 0.05 * math.sin(i * 0.5) for i in range(60)]
     values[40] = 3.0  # spike in trailing window
     series = [(T0, value) for value in values]
-    top, bottom = detect_extreme_events(series, trailing_window=20, extreme_pct=10, horizon=5)
+    top, bottom, eligible = detect_extreme_events(
+        series, trailing_window=20, extreme_pct=10, horizon=5
+    )
     assert 40 in top
-    assert bottom == []
+    assert 0 < (len(top) + len(bottom)) / eligible <= 0.30
 
 
 def test_analyze_has_pulse_on_synthetic_mean_reversion():
-    """Oscillating baseline with a reverting spike should beat random baseline -> H1 pass."""
-    values = [1.0 + 0.1 * math.sin(i * 0.5) for i in range(80)]
-    values[45] = 2.5
-    for offset in range(1, 6):
-        values[45 + offset] = 2.5 - 0.28 * offset
+    """Isolated top-extreme spikes that revert should clear significance + concentration gates."""
+    values = [1.0] * 120
+    for spike_idx in (40, 55, 70, 85):
+        values[spike_idx] = 3.0
+        for offset in range(1, 6):
+            values[spike_idx + offset] = 3.0 - 0.5 * offset
     series = [(T0, value) for value in values]
-    results = analyze_mean_reversion(series, _gate_config(trailing_window_days=20, horizons=(5,)))
+    results = analyze_mean_reversion(
+        series, _gate_config(trailing_window_days=20, horizons=(5,), rng_seed=0)
+    )
     assert results[0].h1_pass is True
-    assert results[0].edge_vs_baseline > 0
+    assert results[0].edge_vs_baseline >= 0.02
+    assert results[0].p_value < 0.05
+    assert results[0].concentration_ok is True
 
 
 def test_analyze_no_pulse_on_flat_series():


### PR DESCRIPTION
## Summary

Gate-1 implementation of the mNAV premium-reversion cheap probe per `docs/specs/mnav-premium-reversion-probe-v0.md` (spec from #106 / `feat/mnav-probe-spec`).

Read-only probe: point-in-time mNAV from filing-seeded holdings/shares + yfinance equity + Binance 1d crypto closes. No DB writes, no execution.

## Live probe verdict: **HAS_PULSE**

| Ticker | Days | H1 | H=10 edge | H=21 edge |
|--------|------|----|-----------|----------|
| 3350.T (MetaPlanet) | 465 | Y | +8.06 | +66.56 |
| DFDV | 264 | Y | +0.01 | -0.01 |
| MSTR | 604 | n | -0.02 | -0.04 |
| SBET | 241 | Y | +0.05 | +0.07 |

H2 passes: 3 names (3350.T, DFDV, SBET) ≥ `MIN_NAMES_EDGE=3`.

Artifacts: `research/rbi_loop/mnav-premium-reversion-v0/{probe_result.json,probe_report.md}`

## Deliverables

- `scripts/probe_mnav_premium_reversion.py` — mirrors funding-carry probe structure
- `data/treasury_equities/mnav_universe.csv` — 5 tickers, filing-sourced disclosure rows (MSTR, MetaPlanet 3350.T, DFDV, SBET)
- `tests/test_probe_mnav_premium_reversion.py` — no network; PIT forward-fill, mNAV math, extreme detection, verdict routing
- `.gitignore` allowlist for `data/treasury_equities/`

## Data notes

- **SMLR dropped**: delisted after Strive acquisition; yfinance returns no price history.
- **MetaPlanet (3350.T)** replaces SMLR as BTC treasury name; holdings/shares from TDnet interim report + investor presentation (URLs in CSV).
- All names flagged **stale-disclosure** (gaps >45d between filings) — noted in STEP 0, not a v0 gate.
- MSTR pre-split shares normalized for yfinance split-adjusted prices (2024-08-08 10:1).

## Verification

```bash
uv run ruff check scripts/probe_mnav_premium_reversion.py tests/test_probe_mnav_premium_reversion.py
uv run ruff format --check scripts/probe_mnav_premium_reversion.py tests/test_probe_mnav_premium_reversion.py
uv run python -m pytest tests/test_probe_mnav_premium_reversion.py -v
uv run python scripts/probe_mnav_premium_reversion.py
```

Co-Authored-By: Grok <noreply@x.ai>