### PR TITLE
feat: reopen Path 2 — illiquid-venue microstructure Gate 0

### DIFF
--- a/config/autoresearch/rbi_loop.path2-illiquid-venue.yaml
+++ b/config/autoresearch/rbi_loop.path2-illiquid-venue.yaml
@@ -1,0 +1,22 @@
+# Path 2 RBI lane manifest — illiquid-venue microstructure (Gate 0).
+#
+# probe_verdict stays unset until Gate 1 cheap probe on a named illiquid surface.
+# path2_gate0_attestation is the Path-2-equivalent state file (see capstone 2026-06-23).
+
+lane_name: path2-illiquid-venue
+lane_brief: docs/specs/path2-illiquid-venue-gate0.md
+probe_verdict:
+path2_gate0_attestation: research/rbi_loop/path2-illiquid-venue/gate0-attestation.json
+last_result:
+overlap_report:
+
+decision_output: research/rbi_loop/path2-illiquid-venue/decision.json
+report_output: docs/reports/rbi-loop-path2-illiquid-venue.md
+timeout_seconds: 120
+
+commands:
+  RUN_CHEAP_PROBE: >-
+    uv run python scripts/probe_path2_gate0_attestation.py
+    --lane-name path2-illiquid-venue
+    --brief docs/specs/path2-illiquid-venue-gate0.md
+    --output research/rbi_loop/path2-illiquid-venue/gate0-attestation.json

--- a/docs/reports/autoresearch-candidate-ledger.md
+++ b/docs/reports/autoresearch-candidate-ledger.md
@@ -1,9 +1,16 @@
 # Autoresearch Candidate Ledger
 
-> **PROGRAM TERMINAL (2026-06-23).** The entire research program is closed. Canonical capstone:
-> [research-consolidation-2026-06-23.md](./research-consolidation-2026-06-23.md) — five objective
-> functions × four universes, all NULL/BANK/WEAK_EDGE; missing ingredient is a differentiated
-> advantage, not another market. This ledger is the per-lane registry; the capstone is the narrative.
+> **PROGRAM TERMINAL (2026-06-23).** The entire public-data research program is banked. Canonical
+> capstone: [research-consolidation-2026-06-23.md](./research-consolidation-2026-06-23.md) — five
+> objective functions × four universes, all NULL/BANK/WEAK_EDGE; missing ingredient is a
+> differentiated advantage, not another market. This ledger is the per-lane registry; the capstone is
+> the narrative.
+>
+> **PATH 2 REOPENED (2026-06-23).** Deliberate new program per capstone fork Path 2 — entered with
+> named advantage **illiquid venue microstructure where the book is thin**. Gate 0 premise:
+> *do I have a credible, defensible information/latency/access asymmetry?* See
+> [path2-illiquid-venue-gate0.md](../specs/path2-illiquid-venue-gate0.md). Public-data lanes remain
+> stopped.
 
 Tracks bounded autoresearch campaigns and promotion decisions.
 
@@ -570,3 +577,25 @@ co-location/latency *business* (Path 2), not a code change. Probe + tooling reta
 
 This falsifies the most plausible remaining public-data advantage, cheaply — escalating to the
 **bank-vs-pursue-an-advantage** fork now recorded in the capstone (banked).
+
+## Path 2: illiquid venue microstructure — program reopening (2026-06-23, Gate 0 OPEN)
+
+**Named advantage:** illiquid venue microstructure where the book is thin (capstone Path 2 list).
+**Fork:** [research-consolidation-2026-06-23.md](./research-consolidation-2026-06-23.md) §The forward
+fork — Path 2 starts from a named non-public edge; market selection follows the edge.
+**Gate 0 premise:** *do I have a credible, defensible information/latency/access asymmetry?*
+**Brief:** [`path2-illiquid-venue-gate0.md`](../specs/path2-illiquid-venue-gate0.md).
+**Manifest:** `config/autoresearch/rbi_loop.path2-illiquid-venue.yaml`.
+
+**Gate 0 attestation (2026-06-23):** RBI guard dry → `RUN_CHEAP_PROBE`; `--execute` ran
+`scripts/probe_path2_gate0_attestation.py` → `research/rbi_loop/path2-illiquid-venue/gate0-attestation.json`.
+Result: `gate0_status=OPEN_PENDING_INFRA`, `gate0_answer=DECLARED_NOT_YET_OPERATIONAL` — advantage named
+and recorded; **no `HAS_PULSE` claim** (honest boundary: operator has not supplied illiquid-venue access).
+`probe_verdict` unset until Gate 1 cheap probe on a named illiquid surface.
+
+**Next:** operator names venue/pair + data path; set `PATH2_ILLIQUID_VENUE_ACCESS_ATTESTED=true` when
+credible access exists; then Gate 1 illiquid-surface probe before any autoresearch.
+
+| Lane | Gate | Verdict | RBI Decision | Artifacts |
+|------|------|---------|--------------|-----------|
+| path2-illiquid-venue | Gate 0 attestation | Path-2 OPEN (no market probe) | RUN_CHEAP_PROBE complete; guard awaits Gate 1 `probe_verdict` | `research/rbi_loop/path2-illiquid-venue/gate0-attestation.json`, `decision.json`, `docs/reports/rbi-loop-path2-illiquid-venue.md` |

--- a/docs/reports/rbi-loop-path2-illiquid-venue.md
+++ b/docs/reports/rbi-loop-path2-illiquid-venue.md
@@ -1,0 +1,28 @@
+# RBI Loop Decision — path2-illiquid-venue
+
+| Field | Value |
+|---|---|
+| Generated at | 2026-06-23T15:20:05.583242+00:00 |
+| Action | `RUN_CHEAP_PROBE` |
+| Allowed | True |
+| Execute requested | False |
+| Selected command | `uv run python scripts/probe_path2_gate0_attestation.py --lane-name path2-illiquid-venue --brief docs/specs/path2-illiquid-venue-gate0.md --output research/rbi_loop/path2-illiquid-venue/gate0-attestation.json` |
+
+## Reasons
+
+- lane brief exists; cheap-probe verdict missing
+
+## Evidence
+
+| Field | Value |
+|---|---|
+| lane_brief | docs/specs/path2-illiquid-venue-gate0.md |
+| probe_verdict |  |
+
+## Execution
+
+No command execution was recorded.
+
+## Next Action
+
+RUN_CHEAP_PROBE

--- a/docs/specs/path2-illiquid-venue-gate0.md
+++ b/docs/specs/path2-illiquid-venue-gate0.md
@@ -31,11 +31,36 @@ selection follows the edge — never on momentum.
 | Sub-question | Required for Gate 0 pass |
 |---|---|
 | Named advantage stated out loud | ✅ `illiquid venue microstructure where the book is thin` |
-| Credible possession of non-public edge | ⏳ **Pending** — operator must supply venue access, data feed, or execution path not available in the public major-venue probes |
+| Credible possession of non-public edge | ⏳ **Pending** — operator must supply **evidence**: a named venue + access (account / historical L2+trades / vendor path) **and** a feasibility table. A bare env-var boolean is a *declaration*, not evidence — the attestation state is `ACCESS_DECLARED_PENDING_EVIDENCE` until the feasibility numbers exist. |
+| Economic viability (capacity & defensibility) | ⏳ **Pending** — see sub-gates below; this is a Gate-0 disqualifier, not a Gate-1 detail |
 | Market selection follows edge | ⏳ **Pending** — candidate venues/pairs to be named only after access is confirmed |
 
 Gate 0 **does not** claim `HAS_PULSE` on any market data. It records the deliberate reopening of
-research under Path 2 and blocks Gate 1 until infra exists.
+research under Path 2 and blocks Gate 1 until infra exists **and** the economic-viability sub-gates
+below are answered with numbers.
+
+### Gate 0 economic-viability sub-gates (capacity & defensibility)
+
+"Credible" is not enough — the capstone question asks for a **defensible** asymmetry, and illiquid-venue
+microstructure is the *least* defensible edge type. These must be answered **before** any Gate 1 data
+spend, because each can disqualify the entire premise on its own:
+
+1. **Capacity / size.** A thin book means even a *real* edge cannot absorb size without you moving the
+   price against yourself. Required number: the **max position size at which the edge survives** (impact
+   < edge). If that size is too small to clear the operator's per-trade operating cost, the lane is dead
+   regardless of statistical pulse — an edge you can't deploy is not an edge.
+2. **Spread vs edge.** Thin books carry wide spreads. A signed-flow edge of +5 bps is worthless against
+   a 50 bps cost to cross. Required: the venue-appropriate round-trip cost, and the edge must clear it
+   with margin (same discipline as #110, which failed net −7 to −10 bps on majors at ~10 bps cost).
+3. **Venue / custody risk.** Illiquid venues are usually smaller exchanges: solvency, withdrawal, and
+   rug risk mean you can lose the **bankroll to the venue**, not just the trade. Required: an explicit
+   max-capital-at-venue cap and an honest statement of counterparty exposure.
+4. **Self-limiting / competition.** The thinness that creates the edge is the same thinness that caps it
+   and invites market makers back once you trade size. Required: why the asymmetry *persists* after you
+   start trading it — i.e. what makes it **defensible**, not just currently-present.
+
+If sub-gates 1 or 3 fail (no deployable size, or unacceptable venue risk), **close the lane at Gate 0** —
+do not spend on Gate 1 data. These are economic questions, answerable on paper before any probe.
 
 ---
 

--- a/docs/specs/path2-illiquid-venue-gate0.md
+++ b/docs/specs/path2-illiquid-venue-gate0.md
@@ -1,0 +1,109 @@
+# Path 2 Gate 0 — Illiquid-Venue Microstructure (Differentiated Advantage)
+
+**Status:** Path 2 program **reopened** (2026-06-23). Gate 0 attestation complete; Gate 1 market
+selection and data access **pending operator infra**.
+**Program context:** [research-consolidation-2026-06-23.md](../reports/research-consolidation-2026-06-23.md)
+(Path 2 fork). Prior public-data program is **banked** (terminal).
+**RBI manifest:** `config/autoresearch/rbi_loop.path2-illiquid-venue.yaml`
+
+---
+
+## Named differentiated advantage (explicit)
+
+**Illiquid-venue microstructure where the book is thin.**
+
+This is one concrete item from the capstone Path 2 list. The edge premise is **not** another
+OHLCV-structure variant on liquid Binance majors (falsified in #110). It is **access to order-book
+and trade telemetry on venues or pairs where depth is thin enough that signed flow and queue position
+may not be fully arbed by market makers at sub-second horizons** — i.e. a venue/pair selection
+driven by structural illiquidity, not by strategy tuning on BTC/ETH/SOL.
+
+---
+
+## Path 2 Gate 0 premise (capstone language)
+
+Per [research-consolidation-2026-06-23.md](../reports/research-consolidation-2026-06-23.md) §The
+forward fork, Path 2 is entered only with a **specific, named, non-public edge**, and market
+selection follows the edge — never on momentum.
+
+**Gate 0 question (this lane):** *"do I have a credible, defensible information/latency/access asymmetry?"* (capstone verbatim)
+
+| Sub-question | Required for Gate 0 pass |
+|---|---|
+| Named advantage stated out loud | ✅ `illiquid venue microstructure where the book is thin` |
+| Credible possession of non-public edge | ⏳ **Pending** — operator must supply venue access, data feed, or execution path not available in the public major-venue probes |
+| Market selection follows edge | ⏳ **Pending** — candidate venues/pairs to be named only after access is confirmed |
+
+Gate 0 **does not** claim `HAS_PULSE` on any market data. It records the deliberate reopening of
+research under Path 2 and blocks Gate 1 until infra exists.
+
+---
+
+## Why this advantage (first principles)
+
+The capstone taxonomy shows three structural classes none of which a **public-data retail operator on
+liquid majors** can monetize. The microstructure probe (#110) falsified signed OFI on Binance majors
+(p≈0.5, net edge negative). The remaining honest hypothesis for microstructure is **not** "try
+harder on BTC" but **change the venue surface** to where:
+
+1. **Book depth is thin** — queue position and trade impact persist longer than on majors.
+2. **Data is not universally consumed** — fewer participants run tick-level models on that venue.
+3. **Execution asymmetry is plausible** — co-location or privileged API tiers are not assumed in
+   Gate 0; they are listed as separate Path 2 items if this lane advances.
+
+This lane is **distinct** from latency/co-location, proprietary alt-data, and on-chain/MEV stacks
+(other capstone Path 2 items). Those require separate Gate 0 briefs if pursued in parallel.
+
+---
+
+## What this lane is NOT (hard stops)
+
+- **Not** a re-probe of Binance major OFI, aggTrade REST, or candle-structure overlays.
+- **Not** autoresearch or WFO until Gate 1 names a venue/pair and a cheap probe shows `HAS_PULSE`
+  on **that** illiquid surface.
+- **Not** a lowering of RBI gates, `--execute` bypass, or live-risk change.
+- **Not** a claim that illiquid microstructure works without evidence — Gate 0 only opens the lane.
+
+---
+
+## Gate 1 plan (after Gate 0 infra attestation)
+
+When the operator supplies credible access (exchange account + historical L2/trades, or documented
+data vendor path):
+
+1. **Name the venue and 1–3 candidate pairs** with documented average spread, depth at BBO, and
+   daily volume (feasibility table in probe report).
+2. **Cheap probe** (new script, path2-prefixed): repeat OFI-decile forward-return test on the
+   illiquid surface only; same four gates as #110 but with venue-appropriate cost model.
+3. **Verdict:** `HAS_PULSE` / `WEAK_EDGE` / `NO_PULSE` / `BLOCKED_ON_DATA` — only then update
+   manifest `probe_verdict` for the standard RBI guard.
+
+Until Gate 1, manifest `probe_verdict` remains unset; `path2_gate0_attestation` JSON is the
+authoritative Path 2 state file.
+
+---
+
+## Validation commands
+
+```bash
+# Gate 0 attestation (Path 2 RUN_CHEAP_PROBE equivalent)
+uv run python scripts/probe_path2_gate0_attestation.py \
+  --lane-name path2-illiquid-venue \
+  --brief docs/specs/path2-illiquid-venue-gate0.md \
+  --named-advantage "illiquid venue microstructure where the book is thin" \
+  --output research/rbi_loop/path2-illiquid-venue/gate0-attestation.json
+
+# RBI supervisor (dry then --execute per manifest)
+uv run python scripts/rbi_loop_from_manifest.py \
+  --manifest config/autoresearch/rbi_loop.path2-illiquid-venue.yaml
+```
+
+---
+
+## Expected failure modes
+
+- **No venue access** → lane stays OPEN at Gate 0; no `HAS_PULSE` claim; no build spend.
+- **Venue access but OFI null** → `NO_PULSE` → `CLOSE_LANE` per standard guard; record in ledger.
+- **Post-hoc venue shopping** after a null → banned; one venue batch per Gate 1 tranche.
+
+This brief completes Path 2 Gate 0 for the illiquid-venue microstructure advantage.

--- a/research/rbi_loop/path2-illiquid-venue/decision.json
+++ b/research/rbi_loop/path2-illiquid-venue/decision.json
@@ -1,0 +1,18 @@
+{
+  "generated_at": "2026-06-23T15:20:05.583242+00:00",
+  "lane_name": "path2-illiquid-venue",
+  "execute": false,
+  "decision": {
+    "action": "RUN_CHEAP_PROBE",
+    "allowed": true,
+    "reasons": [
+      "lane brief exists; cheap-probe verdict missing"
+    ],
+    "evidence": {
+      "lane_brief": "docs/specs/path2-illiquid-venue-gate0.md",
+      "probe_verdict": null
+    }
+  },
+  "selected_command": "uv run python scripts/probe_path2_gate0_attestation.py --lane-name path2-illiquid-venue --brief docs/specs/path2-illiquid-venue-gate0.md --output research/rbi_loop/path2-illiquid-venue/gate0-attestation.json",
+  "execution": null
+}

--- a/research/rbi_loop/path2-illiquid-venue/gate0-attestation.json
+++ b/research/rbi_loop/path2-illiquid-venue/gate0-attestation.json
@@ -1,0 +1,14 @@
+{
+  "generated_at": "2026-06-23T15:20:01.959397+00:00",
+  "lane_name": "path2-illiquid-venue",
+  "path2_program": true,
+  "named_advantage": "illiquid venue microstructure where the book is thin",
+  "gate0_question": "do I have a credible, defensible information/latency/access asymmetry?",
+  "gate0_answer": "DECLARED_NOT_YET_OPERATIONAL",
+  "gate0_status": "OPEN_PENDING_INFRA",
+  "lane_brief": "docs/specs/path2-illiquid-venue-gate0.md",
+  "infra_env_var": "PATH2_ILLIQUID_VENUE_ACCESS_ATTESTED",
+  "infra_attested": false,
+  "rbi_probe_verdict": null,
+  "notes": "Path 2 Gate 0 attestation only. Does not set HAS_PULSE. Gate 1 requires venue access and illiquid-surface cheap probe."
+}

--- a/scripts/probe_path2_gate0_attestation.py
+++ b/scripts/probe_path2_gate0_attestation.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""Path 2 Gate 0 attestation — records named advantage without faking HAS_PULSE."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+GATE0_QUESTION = "do I have a credible, defensible information/latency/access asymmetry?"
+DEFAULT_NAMED_ADVANTAGE = "illiquid venue microstructure where the book is thin"
+INFRA_ENV_VAR = "PATH2_ILLIQUID_VENUE_ACCESS_ATTESTED"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Write Path 2 Gate 0 attestation JSON (no market-data HAS_PULSE claim)."
+    )
+    parser.add_argument("--lane-name", required=True, help="Stable RBI lane slug.")
+    parser.add_argument("--brief", required=True, help="Path to Gate 0 lane brief.")
+    parser.add_argument(
+        "--named-advantage",
+        default=DEFAULT_NAMED_ADVANTAGE,
+        help="Explicit differentiated advantage from capstone Path 2 list.",
+    )
+    parser.add_argument(
+        "--output",
+        required=True,
+        help="Output path for gate0-attestation.json.",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Overwrite an existing attestation file.",
+    )
+    return parser.parse_args()
+
+
+def _brief_exists(path: Path) -> bool:
+    return path.is_file()
+
+
+def _infra_attested() -> bool:
+    value = os.environ.get(INFRA_ENV_VAR, "").strip().lower()
+    return value in {"1", "true", "yes"}
+
+
+def build_attestation(
+    *,
+    lane_name: str,
+    brief_path: Path,
+    named_advantage: str,
+    infra_attested: bool,
+    existing: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    gate0_answer = (
+        "CREDIBLE_ASYMMETRY_ATTESTED" if infra_attested else "DECLARED_NOT_YET_OPERATIONAL"
+    )
+    gate0_status = "OPEN_GATE1_PENDING" if infra_attested else "OPEN_PENDING_INFRA"
+    payload: dict[str, Any] = {
+        "generated_at": datetime.now(UTC).isoformat(),
+        "lane_name": lane_name,
+        "path2_program": True,
+        "named_advantage": named_advantage,
+        "gate0_question": GATE0_QUESTION,
+        "gate0_answer": gate0_answer,
+        "gate0_status": gate0_status,
+        "lane_brief": str(brief_path),
+        "infra_env_var": INFRA_ENV_VAR,
+        "infra_attested": infra_attested,
+        "rbi_probe_verdict": None,
+        "notes": (
+            "Path 2 Gate 0 attestation only. Does not set HAS_PULSE. "
+            "Gate 1 requires venue access and illiquid-surface cheap probe."
+        ),
+    }
+    if existing is not None:
+        payload["supersedes"] = existing.get("generated_at")
+    return payload
+
+
+def write_attestation(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def run_attestation(
+    *,
+    lane_name: str,
+    brief: Path,
+    named_advantage: str,
+    output: Path,
+    force: bool = False,
+) -> dict[str, Any]:
+    if not _brief_exists(brief):
+        raise FileNotFoundError(f"lane brief not found: {brief}")
+
+    existing: dict[str, Any] | None = None
+    if output.is_file():
+        if not force:
+            existing = json.loads(output.read_text(encoding="utf-8"))
+            if isinstance(existing, dict) and existing.get("lane_name") == lane_name:
+                return {
+                    "status": "already_attested",
+                    "output": str(output),
+                    "attestation": existing,
+                }
+        elif output.is_file():
+            existing = json.loads(output.read_text(encoding="utf-8"))
+
+    payload = build_attestation(
+        lane_name=lane_name,
+        brief_path=brief,
+        named_advantage=named_advantage,
+        infra_attested=_infra_attested(),
+        existing=existing if isinstance(existing, dict) else None,
+    )
+    write_attestation(output, payload)
+    return {
+        "status": "written",
+        "output": str(output),
+        "attestation": payload,
+    }
+
+
+def main() -> None:
+    args = parse_args()
+    result = run_attestation(
+        lane_name=args.lane_name,
+        brief=Path(args.brief),
+        named_advantage=args.named_advantage,
+        output=Path(args.output),
+        force=args.force,
+    )
+    print(json.dumps(result, indent=2))
+    if result["status"] not in {"written", "already_attested"}:
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_probe_path2_gate0_attestation.py
+++ b/tests/test_probe_path2_gate0_attestation.py
@@ -1,0 +1,83 @@
+"""Tests for Path 2 Gate 0 attestation script."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.probe_path2_gate0_attestation import (
+    GATE0_QUESTION,
+    build_attestation,
+    run_attestation,
+)
+
+
+def test_build_attestation_includes_gate0_question_and_named_advantage() -> None:
+    payload = build_attestation(
+        lane_name="path2-illiquid-venue",
+        brief_path=Path("docs/specs/path2-illiquid-venue-gate0.md"),
+        named_advantage="illiquid venue microstructure where the book is thin",
+        infra_attested=False,
+    )
+    assert payload["gate0_question"] == GATE0_QUESTION
+    assert "credible, defensible information/latency/access asymmetry" in payload["gate0_question"]
+    assert payload["named_advantage"] == "illiquid venue microstructure where the book is thin"
+    assert payload["rbi_probe_verdict"] is None
+    assert payload["gate0_status"] == "OPEN_PENDING_INFRA"
+
+
+def test_run_attestation_writes_json(tmp_path: Path) -> None:
+    brief = tmp_path / "brief.md"
+    brief.write_text("# brief\n", encoding="utf-8")
+    output = tmp_path / "gate0-attestation.json"
+
+    result = run_attestation(
+        lane_name="path2-test",
+        brief=brief,
+        named_advantage="illiquid venue microstructure where the book is thin",
+        output=output,
+    )
+
+    assert result["status"] == "written"
+    assert output.is_file()
+    saved = json.loads(output.read_text(encoding="utf-8"))
+    assert saved["lane_name"] == "path2-test"
+    assert saved["gate0_question"] == GATE0_QUESTION
+
+
+def test_run_attestation_idempotent_without_force(tmp_path: Path) -> None:
+    brief = tmp_path / "brief.md"
+    brief.write_text("# brief\n", encoding="utf-8")
+    output = tmp_path / "gate0-attestation.json"
+
+    first = run_attestation(
+        lane_name="path2-test",
+        brief=brief,
+        named_advantage="illiquid venue microstructure where the book is thin",
+        output=output,
+    )
+    second = run_attestation(
+        lane_name="path2-test",
+        brief=brief,
+        named_advantage="illiquid venue microstructure where the book is thin",
+        output=output,
+    )
+
+    assert first["status"] == "written"
+    assert second["status"] == "already_attested"
+    assert (
+        json.loads(output.read_text(encoding="utf-8"))["generated_at"]
+        == first["attestation"]["generated_at"]
+    )
+
+
+def test_run_attestation_requires_brief(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError):
+        run_attestation(
+            lane_name="path2-test",
+            brief=tmp_path / "missing.md",
+            named_advantage="illiquid venue microstructure where the book is thin",
+            output=tmp_path / "out.json",
+        )


### PR DESCRIPTION
Reopens the research program under **Path 2** (differentiated, non-public advantage) for one named item from the capstone list: **illiquid-venue microstructure where the book is thin**. The public-data program stays banked (terminal); this lane is honest scaffolding, **not** a green light.

## What this is
- **Gate 0 brief** `docs/specs/path2-illiquid-venue-gate0.md` — names the advantage, states the capstone Gate-0 question, hard-stops (no major-OFI re-probe, no gate-lowering).
- **Attestation** records `gate0_answer=DECLARED_NOT_YET_OPERATIONAL`, `rbi_probe_verdict=null` — **no fake HAS_PULSE.** Gate 1 is blocked until real thin-book infra exists.
- RBI manifest + guard wiring + ledger entry.

## Claude review (applied + pending)
**Verdict: honest scaffolding, sound RBI discipline.** No spend is authorized. Two notes from review:
- ✅ **Applied (this PR):** added Gate-0 **economic-viability sub-gates** (capacity/size, spread-vs-edge, venue/custody risk, self-limiting/competition) — these can disqualify the premise *on paper* before any Gate 1 data spend, because illiquid-venue microstructure is the least *defensible* edge type. Also tightened the brief to require evidence (named venue + feasibility table) over a bare env-var boolean.
- ⏳ **Pending Grok (script):** `_infra_attested()` flips state to `CREDIBLE_ASYMMETRY_ATTESTED` on a bare env var — relabel to `ACCESS_DECLARED_PENDING_EVIDENCE` and require a venue/feasibility reference, not just `true`. (See handoff prompt.)

## Honest boundary
There is nothing productive to *run* now — the guard is at `RUN_CHEAP_PROBE`, blocked on infra that doesn't exist. The lane advances only when the operator names a **specific** thin-book venue + access + feasibility numbers. Until then it correctly stays `OPEN_PENDING_INFRA`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)