### PR TITLE
fix: Path 2 Gate 0 attestation — close env-var loophole (missed in #112 squash)

### DIFF
--- a/scripts/probe_path2_gate0_attestation.py
+++ b/scripts/probe_path2_gate0_attestation.py
@@ -32,6 +32,16 @@ def parse_args() -> argparse.Namespace:
         help="Output path for gate0-attestation.json.",
     )
     parser.add_argument(
+        "--venue",
+        default="",
+        help="Named illiquid venue (required with --feasibility-doc to advance Gate 0).",
+    )
+    parser.add_argument(
+        "--feasibility-doc",
+        default="",
+        help="Path to feasibility evidence file (must exist to advance Gate 0).",
+    )
+    parser.add_argument(
         "--force",
         action="store_true",
         help="Overwrite an existing attestation file.",
@@ -43,9 +53,23 @@ def _brief_exists(path: Path) -> bool:
     return path.is_file()
 
 
-def _infra_attested() -> bool:
+def _access_env_declared() -> bool:
     value = os.environ.get(INFRA_ENV_VAR, "").strip().lower()
     return value in {"1", "true", "yes"}
+
+
+def _access_declared_pending_evidence(
+    *,
+    access_env_declared: bool,
+    venue: str,
+    feasibility_doc: Path | None,
+) -> bool:
+    return (
+        access_env_declared
+        and bool(venue.strip())
+        and feasibility_doc is not None
+        and feasibility_doc.is_file()
+    )
 
 
 def build_attestation(
@@ -53,13 +77,20 @@ def build_attestation(
     lane_name: str,
     brief_path: Path,
     named_advantage: str,
-    infra_attested: bool,
+    access_env_declared: bool,
+    venue: str = "",
+    feasibility_doc: Path | None = None,
     existing: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
-    gate0_answer = (
-        "CREDIBLE_ASYMMETRY_ATTESTED" if infra_attested else "DECLARED_NOT_YET_OPERATIONAL"
+    access_pending = _access_declared_pending_evidence(
+        access_env_declared=access_env_declared,
+        venue=venue,
+        feasibility_doc=feasibility_doc,
     )
-    gate0_status = "OPEN_GATE1_PENDING" if infra_attested else "OPEN_PENDING_INFRA"
+    gate0_answer = (
+        "ACCESS_DECLARED_PENDING_EVIDENCE" if access_pending else "DECLARED_NOT_YET_OPERATIONAL"
+    )
+    gate0_status = "OPEN_GATE1_PENDING" if access_pending else "OPEN_PENDING_INFRA"
     payload: dict[str, Any] = {
         "generated_at": datetime.now(UTC).isoformat(),
         "lane_name": lane_name,
@@ -70,7 +101,9 @@ def build_attestation(
         "gate0_status": gate0_status,
         "lane_brief": str(brief_path),
         "infra_env_var": INFRA_ENV_VAR,
-        "infra_attested": infra_attested,
+        "infra_attested": access_env_declared,
+        "venue": venue.strip() or None,
+        "feasibility_doc": str(feasibility_doc) if feasibility_doc else None,
         "rbi_probe_verdict": None,
         "notes": (
             "Path 2 Gate 0 attestation only. Does not set HAS_PULSE. "
@@ -93,6 +126,8 @@ def run_attestation(
     brief: Path,
     named_advantage: str,
     output: Path,
+    venue: str = "",
+    feasibility_doc: Path | None = None,
     force: bool = False,
 ) -> dict[str, Any]:
     if not _brief_exists(brief):
@@ -115,7 +150,9 @@ def run_attestation(
         lane_name=lane_name,
         brief_path=brief,
         named_advantage=named_advantage,
-        infra_attested=_infra_attested(),
+        access_env_declared=_access_env_declared(),
+        venue=venue,
+        feasibility_doc=feasibility_doc,
         existing=existing if isinstance(existing, dict) else None,
     )
     write_attestation(output, payload)
@@ -128,11 +165,14 @@ def run_attestation(
 
 def main() -> None:
     args = parse_args()
+    feasibility_doc = Path(args.feasibility_doc) if args.feasibility_doc else None
     result = run_attestation(
         lane_name=args.lane_name,
         brief=Path(args.brief),
         named_advantage=args.named_advantage,
         output=Path(args.output),
+        venue=args.venue,
+        feasibility_doc=feasibility_doc,
         force=args.force,
     )
     print(json.dumps(result, indent=2))

--- a/tests/test_probe_path2_gate0_attestation.py
+++ b/tests/test_probe_path2_gate0_attestation.py
@@ -9,6 +9,7 @@ import pytest
 
 from scripts.probe_path2_gate0_attestation import (
     GATE0_QUESTION,
+    INFRA_ENV_VAR,
     build_attestation,
     run_attestation,
 )
@@ -19,13 +20,79 @@ def test_build_attestation_includes_gate0_question_and_named_advantage() -> None
         lane_name="path2-illiquid-venue",
         brief_path=Path("docs/specs/path2-illiquid-venue-gate0.md"),
         named_advantage="illiquid venue microstructure where the book is thin",
-        infra_attested=False,
+        access_env_declared=False,
     )
     assert payload["gate0_question"] == GATE0_QUESTION
     assert "credible, defensible information/latency/access asymmetry" in payload["gate0_question"]
     assert payload["named_advantage"] == "illiquid venue microstructure where the book is thin"
     assert payload["rbi_probe_verdict"] is None
+    assert payload["gate0_answer"] == "DECLARED_NOT_YET_OPERATIONAL"
     assert payload["gate0_status"] == "OPEN_PENDING_INFRA"
+
+
+def test_no_env_var_stays_not_operational(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(INFRA_ENV_VAR, raising=False)
+    brief = tmp_path / "brief.md"
+    brief.write_text("# brief\n", encoding="utf-8")
+
+    result = run_attestation(
+        lane_name="path2-test",
+        brief=brief,
+        named_advantage="illiquid venue microstructure where the book is thin",
+        output=tmp_path / "out.json",
+    )
+
+    attestation = result["attestation"]
+    assert attestation["gate0_answer"] == "DECLARED_NOT_YET_OPERATIONAL"
+    assert attestation["gate0_status"] == "OPEN_PENDING_INFRA"
+    assert attestation["rbi_probe_verdict"] is None
+
+
+def test_env_var_only_without_venue_or_doc_stays_pending(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv(INFRA_ENV_VAR, "true")
+    brief = tmp_path / "brief.md"
+    brief.write_text("# brief\n", encoding="utf-8")
+
+    result = run_attestation(
+        lane_name="path2-test",
+        brief=brief,
+        named_advantage="illiquid venue microstructure where the book is thin",
+        output=tmp_path / "out.json",
+    )
+
+    attestation = result["attestation"]
+    assert attestation["infra_attested"] is True
+    assert attestation["gate0_answer"] == "DECLARED_NOT_YET_OPERATIONAL"
+    assert attestation["gate0_status"] == "OPEN_PENDING_INFRA"
+    assert attestation["rbi_probe_verdict"] is None
+
+
+def test_env_var_venue_and_doc_advances_to_access_declared_pending_evidence(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv(INFRA_ENV_VAR, "true")
+    brief = tmp_path / "brief.md"
+    brief.write_text("# brief\n", encoding="utf-8")
+    feasibility = tmp_path / "feasibility.md"
+    feasibility.write_text("# feasibility\n", encoding="utf-8")
+
+    result = run_attestation(
+        lane_name="path2-test",
+        brief=brief,
+        named_advantage="illiquid venue microstructure where the book is thin",
+        output=tmp_path / "out.json",
+        venue="example-dex",
+        feasibility_doc=feasibility,
+    )
+
+    attestation = result["attestation"]
+    assert attestation["gate0_answer"] == "ACCESS_DECLARED_PENDING_EVIDENCE"
+    assert attestation["gate0_status"] == "OPEN_GATE1_PENDING"
+    assert attestation["venue"] == "example-dex"
+    assert attestation["feasibility_doc"] == str(feasibility)
+    assert attestation["rbi_probe_verdict"] is None
 
 
 def test_run_attestation_writes_json(tmp_path: Path) -> None:
@@ -45,6 +112,7 @@ def test_run_attestation_writes_json(tmp_path: Path) -> None:
     saved = json.loads(output.read_text(encoding="utf-8"))
     assert saved["lane_name"] == "path2-test"
     assert saved["gate0_question"] == GATE0_QUESTION
+    assert saved["rbi_probe_verdict"] is None
 
 
 def test_run_attestation_idempotent_without_force(tmp_path: Path) -> None:


### PR DESCRIPTION
**#112 was squash-merged from the pre-fix state**, so main shipped a brief/script mismatch: the brief references `ACCESS_DECLARED_PENDING_EVIDENCE` but the merged script still had the old `CREDIBLE_ASYMMETRY_ATTESTED` env-var-only loophole. This lands the relabel fix (Grok's `35b3a82`, reviewed and tested) that the squash dropped.

- Relabel `CREDIBLE_ASYMMETRY_ATTESTED` → `ACCESS_DECLARED_PENDING_EVIDENCE`
- Advancement requires env var **and** `--venue` **and** an existing `--feasibility-doc` (three-way AND); env-var alone stays `OPEN_PENDING_INFRA`
- `rbi_probe_verdict` stays `None` (no fake HAS_PULSE); `venue`/`feasibility_doc` recorded
- 7/7 tests pass (`uv run python -m pytest`)

After this, main's script and brief are consistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)