### PR TITLE
fix(notifications): stop phantom TP win alerts on reconciliation closes

### DIFF
--- a/src/execution/futures_executor.py
+++ b/src/execution/futures_executor.py
@@ -62,6 +62,7 @@ class CloseExecutionDetails:
     ticket_id: str | None
     fill_price: float | None = None
     realized_pnl: float | None = None
+    confirmed_fill: bool = False
 
 
 class FuturesTradingExecutor:
@@ -255,9 +256,6 @@ class FuturesTradingExecutor:
         self,
         symbol: str,
         tracked_orders: dict[str, str],
-        last_mark: float,
-        sl_price: float,
-        tp_price: float,
     ) -> CloseExecutionDetails:
         sl_order_id = tracked_orders.get("sl_order_id")
         tp_order_id = tracked_orders.get("tp_order_id")
@@ -287,36 +285,34 @@ class FuturesTradingExecutor:
 
         close_reason: str | None = None
         close_ticket: str | None = None
+        confirmed_fill = False
         if await _is_filled(sl_order_id):
             close_reason = "stop_loss"
             close_ticket = sl_order_id
+            confirmed_fill = True
         elif await _is_filled(tp_order_id):
             close_reason = "take_profit"
             close_ticket = tp_order_id
-        elif sl_price > 0 and last_mark > 0:
-            dist_sl = abs(last_mark - sl_price)
-            dist_tp = abs(last_mark - tp_price) if tp_price > 0 else float("inf")
-            if dist_sl <= dist_tp:
-                close_reason = "stop_loss"
-                close_ticket = sl_order_id
-            else:
-                close_reason = "take_profit"
-                close_ticket = tp_order_id
-        else:
-            close_ticket = sl_order_id or tp_order_id
+            confirmed_fill = True
 
-        fill_price, realized_pnl = await self._fetch_close_execution_details(symbol, close_ticket)
-        if fill_price is None or realized_pnl is None:
-            self._logger.warning(
-                "Using estimated %s close for %s because Binance fill/PnL lookup was unavailable",
-                close_reason or "exchange",
-                symbol,
+        fill_price: float | None = None
+        realized_pnl: float | None = None
+        if confirmed_fill and close_ticket:
+            fill_price, realized_pnl = await self._fetch_close_execution_details(
+                symbol, close_ticket
             )
+            if fill_price is None or realized_pnl is None:
+                self._logger.warning(
+                    "Confirmed %s fill for %s but Binance fill/PnL lookup was unavailable",
+                    close_reason or "exchange",
+                    symbol,
+                )
         return CloseExecutionDetails(
             reason=close_reason,
             ticket_id=close_ticket,
             fill_price=fill_price,
             realized_pnl=realized_pnl,
+            confirmed_fill=confirmed_fill,
         )
 
     async def run(self) -> None:
@@ -407,77 +403,91 @@ class FuturesTradingExecutor:
                     )
                     pos_state = self._positions.get(symbol, {})
                     entry_px = float(pos_state.get("entry_price", 0.0))
-                    last_mark = float(pos_state.get("mark_price", 0.0))
                     qty = float(pos_state.get("amount", 0.0))
                     tracked_orders = self._sl_tp_orders.get(symbol, {})
                     sw_prices = self._sl_tp_prices.get(symbol, {})
                     sl_px = sw_prices.get("sl_price", 0.0)
-                    tp_px = sw_prices.get("tp_price", 0.0)
                     close_details = await self._resolve_close_execution_details(
                         symbol=symbol,
                         tracked_orders=tracked_orders,
-                        last_mark=last_mark,
-                        sl_price=sl_px,
-                        tp_price=tp_px,
-                    )
-                    close_price = (
-                        close_details.fill_price if close_details.fill_price else last_mark
                     )
                     pnl: float | None = None
-                    if close_details.reason == "stop_loss" and self._config.sl_cooldown_minutes > 0:
-                        self._sl_cooldown_timestamps[symbol] = time.time()
-                        self._logger.info(
-                            "SL cooldown started for %s (close=%.4f sl=%.4f)",
-                            symbol,
-                            close_price,
-                            sl_px,
-                        )
-
-                    bars_held: int | None = None
-                    if self._portfolio_manager is not None:
-                        tracked_position = self._portfolio_manager.get_position(
-                            symbol, market="futures"
-                        )
-                        if tracked_position is not None:
-                            bars_held = self._estimate_bars_held(tracked_position.entry_time)
-
-                    realized_pnl: float | None = None
-                    if self._portfolio_manager is not None and close_price > 0:
-                        try:
-                            _, realized_pnl = await self._portfolio_manager.close_position(
-                                symbol=symbol,
-                                price=close_price,
-                                order_id=close_details.ticket_id,
-                                market="futures",
-                                closing_side="SELL",
-                                realized_pnl_override=close_details.realized_pnl,
+                    if close_details.confirmed_fill and close_details.ticket_id:
+                        close_price = close_details.fill_price
+                        if close_price is None:
+                            self._logger.warning(
+                                "Confirmed exchange close for %s but fill price unavailable — "
+                                "skipping close alert",
+                                symbol,
                             )
-                        except ValueError:
-                            pass  # position not in DB (recovered or pre-tracking)
+                        else:
+                            if (
+                                close_details.reason == "stop_loss"
+                                and self._config.sl_cooldown_minutes > 0
+                            ):
+                                self._sl_cooldown_timestamps[symbol] = time.time()
+                                self._logger.info(
+                                    "SL cooldown started for %s (close=%.4f sl=%.4f)",
+                                    symbol,
+                                    close_price,
+                                    sl_px,
+                                )
 
-                    if entry_px > 0 and qty > 0 and close_price > 0:
-                        pnl = (
-                            realized_pnl
-                            if realized_pnl is not None
-                            else (close_price - entry_px) * qty
-                        )
-                        await self._notifier.send_trade_alert(
-                            symbol=symbol,
-                            side="SELL",
-                            quantity=qty,
-                            price=close_price,
-                            pnl=pnl,
-                            market="futures",
-                            entry_price=entry_px,
-                            close_reason=close_details.reason,
-                            bars_held=bars_held,
-                            ticket_id=close_details.ticket_id,
+                            bars_held: int | None = None
+                            if self._portfolio_manager is not None:
+                                tracked_position = self._portfolio_manager.get_position(
+                                    symbol, market="futures"
+                                )
+                                if tracked_position is not None:
+                                    bars_held = self._estimate_bars_held(
+                                        tracked_position.entry_time
+                                    )
+
+                            realized_pnl: float | None = None
+                            if self._portfolio_manager is not None:
+                                try:
+                                    _, realized_pnl = await self._portfolio_manager.close_position(
+                                        symbol=symbol,
+                                        price=close_price,
+                                        order_id=close_details.ticket_id,
+                                        market="futures",
+                                        closing_side="SELL",
+                                        realized_pnl_override=close_details.realized_pnl,
+                                    )
+                                except ValueError:
+                                    realized_pnl = close_details.realized_pnl
+
+                            pnl = realized_pnl
+                            if pnl is not None and entry_px > 0 and qty > 0 and close_price > 0:
+                                await self._notifier.send_trade_alert(
+                                    symbol=symbol,
+                                    side="SELL",
+                                    quantity=qty,
+                                    price=close_price,
+                                    pnl=pnl,
+                                    market="futures",
+                                    entry_price=entry_px,
+                                    close_reason=close_details.reason,
+                                    bars_held=bars_held,
+                                    ticket_id=close_details.ticket_id,
+                                )
+                                self._record_risk_close(symbol, pnl, self._account_balance)
+                            else:
+                                self._logger.warning(
+                                    "Confirmed exchange close for %s but booked PnL unavailable — "
+                                    "skipping close alert",
+                                    symbol,
+                                )
+                    else:
+                        self._logger.info(
+                            "Position %s flat on exchange with no confirmed SL/TP fill — "
+                            "clearing tracking only",
+                            symbol,
                         )
 
                     self._sl_tp_orders.pop(symbol, None)
                     self._sl_tp_prices.pop(symbol, None)
                     self._positions.pop(symbol, None)
-                    self._record_risk_close(symbol, pnl, self._account_balance)
 
                 # Software exits: enforce SL/TP, ATR trailing, and time stops.
                 sw = self._sl_tp_prices.get(symbol)
@@ -586,27 +596,28 @@ class FuturesTradingExecutor:
                                 and self._config.sl_cooldown_minutes > 0
                             ):
                                 self._sl_cooldown_timestamps[symbol] = time.time()
-                            if close_realized_pnl is not None:
-                                pnl = close_realized_pnl
-                            else:
-                                pnl = (
-                                    (close_fill_price - sw_entry_px) * qty
-                                    if sw_entry_px > 0
-                                    else None
+                            pnl = close_realized_pnl
+                            if pnl is not None and close_order.order_id:
+                                await self._notifier.send_trade_alert(
+                                    symbol=symbol,
+                                    side="SELL",
+                                    quantity=qty,
+                                    price=close_fill_price,
+                                    pnl=pnl,
+                                    market="futures",
+                                    entry_price=sw_entry_px if sw_entry_px > 0 else None,
+                                    close_reason=sw_close_reason,
+                                    bars_held=bars_held,
+                                    ticket_id=close_order.order_id,
                                 )
-                            await self._notifier.send_trade_alert(
-                                symbol=symbol,
-                                side="SELL",
-                                quantity=qty,
-                                price=close_fill_price,
-                                pnl=pnl,
-                                market="futures",
-                                entry_price=sw_entry_px if sw_entry_px > 0 else None,
-                                close_reason=sw_close_reason,
-                                bars_held=bars_held,
-                                ticket_id=close_order.order_id,
-                            )
-                            self._record_risk_close(symbol, pnl, self._account_balance)
+                                self._record_risk_close(symbol, pnl, self._account_balance)
+                            else:
+                                self._logger.warning(
+                                    "Software %s close for %s missing booked PnL — "
+                                    "skipping close alert",
+                                    reason_str,
+                                    symbol,
+                                )
                         except Exception as close_exc:
                             self._logger.error(
                                 "Failed to close %s after software %s: %s",

--- a/src/execution/reconciliation.py
+++ b/src/execution/reconciliation.py
@@ -362,12 +362,15 @@ class ExchangeReconciler:
 
             if div.divergence_type == "phantom_db":
                 entry_px = float(div.db_state.get("entry_price", 0.0))
+                qty = float(div.db_state.get("quantity", 0.0))
+                position_side = div.db_state.get("side", "LONG")
+                closing_side = "SELL" if position_side in (None, "LONG", "BOTH") else "BUY"
                 try:
-                    await self._portfolio.close_position(
+                    _, realized_pnl = await self._portfolio.close_position(
                         symbol=symbol,
                         price=entry_px,
                         market=market,
-                        closing_side="SELL",
+                        closing_side=closing_side,
                     )
                     self._logger.warning(
                         "AUTO_FIX: force-closed phantom DB position %s %s @ %.4f",
@@ -375,6 +378,17 @@ class ExchangeReconciler:
                         symbol,
                         entry_px,
                     )
+                    if qty > 0 and entry_px > 0:
+                        await self._notifier.send_trade_alert(
+                            symbol=symbol,
+                            side=closing_side,
+                            quantity=qty,
+                            price=entry_px,
+                            pnl=realized_pnl,
+                            market=market,
+                            entry_price=entry_px,
+                            close_reason="reconciliation",
+                        )
                     fixed.append(symbol)
                 except ValueError:
                     self._logger.warning(

--- a/tests/test_futures_executor.py
+++ b/tests/test_futures_executor.py
@@ -856,9 +856,9 @@ class TestFuturesTradingExecutor:
 
         await executor._monitor_and_update()
 
-        # Tracking should be cleaned up
+        # Tracking should be cleaned up even without a confirmed exchange fill
         assert "BTCUSDT" not in executor._sl_tp_orders
-        executor._risk_manager.register_close_position.assert_called_once_with("BTCUSDT")
+        executor._risk_manager.register_close_position.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_monitor_sends_close_notification_on_sl_close(self, executor):
@@ -868,9 +868,32 @@ class TestFuturesTradingExecutor:
         mock_client.get_account_info = AsyncMock(
             return_value=MagicMock(total_margin_balance=5000.0, available_balance=5000.0)
         )
+        mock_client.get_order_status = AsyncMock(
+            return_value=_make_order(order_id="sl_1", side="SELL", price=78_100.0, status="FILLED")
+        )
+        mock_client.get_user_trades = AsyncMock(
+            return_value=[
+                FuturesUserTrade(
+                    trade_id="trade_sl",
+                    order_id="sl_1",
+                    symbol="BTCUSDT",
+                    side="SELL",
+                    price=78_100.0,
+                    quantity=0.01,
+                    realized_pnl=-20.0,
+                    commission=0.04,
+                    commission_asset="USDT",
+                    time=1_800_000_500_000,
+                )
+            ]
+        )
         executor._client = mock_client
         notifier = AsyncMock()
         executor._notifier = notifier
+        portfolio_manager = MagicMock()
+        portfolio_manager.get_position.return_value = MagicMock(entry_time=None)
+        portfolio_manager.close_position = AsyncMock(return_value=(MagicMock(), -20.0))
+        executor._portfolio_manager = portfolio_manager
 
         executor._sl_tp_orders["BTCUSDT"] = {"sl_order_id": "sl_1", "tp_order_id": "tp_1"}
         executor._positions["BTCUSDT"] = {
@@ -887,7 +910,9 @@ class TestFuturesTradingExecutor:
         call_kwargs = notifier.send_trade_alert.call_args.kwargs
         assert call_kwargs["symbol"] == "BTCUSDT"
         assert call_kwargs["close_reason"] == "stop_loss"
-        assert call_kwargs["pnl"] == pytest.approx((78000.0 - 80000.0) * 0.01)
+        assert call_kwargs["price"] == pytest.approx(78_100.0)
+        assert call_kwargs["pnl"] == pytest.approx(-20.0)
+        assert call_kwargs["ticket_id"] == "sl_1"
         assert "BTCUSDT" not in executor._sl_tp_orders
 
     @pytest.mark.asyncio
@@ -902,7 +927,22 @@ class TestFuturesTradingExecutor:
 
         triggered_algo = dataclass_replace(_make_algo_order(algo_id="sl_algo"), status="TRIGGERED")
         mock_client.get_algo_order_status = AsyncMock(return_value=triggered_algo)
-        mock_client.get_user_trades = AsyncMock(side_effect=RuntimeError("unavailable"))
+        mock_client.get_user_trades = AsyncMock(
+            return_value=[
+                FuturesUserTrade(
+                    trade_id="trade_algo",
+                    order_id="sl_algo",
+                    symbol="BTCUSDT",
+                    side="SELL",
+                    price=74_949.1,
+                    quantity=0.001,
+                    realized_pnl=-0.7689,
+                    commission=0.03747455,
+                    commission_asset="USDT",
+                    time=1_800_000_500_000,
+                )
+            ]
+        )
         executor._client = mock_client
         notifier = AsyncMock()
         executor._notifier = notifier
@@ -1019,14 +1059,18 @@ class TestFuturesTradingExecutor:
         executor._risk_manager.register_close_position.assert_called_once_with("BTCUSDT")
 
     @pytest.mark.asyncio
-    async def test_monitor_falls_back_to_mark_when_binance_fill_lookup_fails(self, executor):
-        """Exchange close still clears tracking and reports estimated PnL if fill lookup fails."""
+    async def test_monitor_skips_alert_when_fill_lookup_fails(self, executor):
+        """Confirmed fill without fill price/PnL must not emit a close alert."""
         mock_client = MagicMock()
         mock_client.get_position_risk = AsyncMock(return_value=[])
         mock_client.get_account_info = AsyncMock(
             return_value=MagicMock(total_margin_balance=5000.0, available_balance=5000.0)
         )
-        mock_client.get_order_status = AsyncMock(side_effect=RuntimeError("not found"))
+        mock_client.get_order_status = AsyncMock(
+            return_value=_make_order(
+                order_id="sl_algo", side="SELL", price=78_100.0, status="FILLED"
+            )
+        )
         mock_client.get_user_trades = AsyncMock(side_effect=RuntimeError("api unavailable"))
         executor._client = mock_client
         notifier = AsyncMock()
@@ -1047,34 +1091,55 @@ class TestFuturesTradingExecutor:
 
         await executor._monitor_and_update()
 
-        portfolio_manager.close_position.assert_awaited_once_with(
-            symbol="BTCUSDT",
-            price=78_000.0,
-            order_id="sl_algo",
-            market="futures",
-            closing_side="SELL",
-            realized_pnl_override=None,
-        )
-        notifier.send_trade_alert.assert_awaited_once()
-        assert notifier.send_trade_alert.call_args.kwargs["price"] == pytest.approx(78_000.0)
+        portfolio_manager.close_position.assert_not_awaited()
+        notifier.send_trade_alert.assert_not_awaited()
         assert "BTCUSDT" not in executor._sl_tp_orders
 
     @pytest.mark.asyncio
     async def test_monitor_sends_close_notification_on_tp_close(self, executor):
-        """send_trade_alert is called with pnl and close_reason='take_profit' on exchange TP fill."""
+        """send_trade_alert uses actual fill price/PnL on a genuine exchange TP fill."""
+        fill_price = 77_875.70
+        booked_pnl = 1.04
         mock_client = MagicMock()
         mock_client.get_position_risk = AsyncMock(return_value=[])
         mock_client.get_account_info = AsyncMock(
             return_value=MagicMock(total_margin_balance=5000.0, available_balance=5000.0)
         )
+
+        async def order_status(symbol: str, order_id: str) -> FuturesOrderInfo:
+            if order_id == "tp_1":
+                return _make_order(order_id="tp_1", side="SELL", price=fill_price, status="FILLED")
+            return _make_order(order_id=order_id, status="NEW")
+
+        mock_client.get_order_status = AsyncMock(side_effect=order_status)
+        mock_client.get_user_trades = AsyncMock(
+            return_value=[
+                FuturesUserTrade(
+                    trade_id="trade_tp",
+                    order_id="tp_1",
+                    symbol="BTCUSDT",
+                    side="SELL",
+                    price=fill_price,
+                    quantity=0.01,
+                    realized_pnl=booked_pnl,
+                    commission=0.04,
+                    commission_asset="USDT",
+                    time=1_800_000_500_000,
+                )
+            ]
+        )
         executor._client = mock_client
         notifier = AsyncMock()
         executor._notifier = notifier
+        portfolio_manager = MagicMock()
+        portfolio_manager.get_position.return_value = MagicMock(entry_time=None)
+        portfolio_manager.close_position = AsyncMock(return_value=(MagicMock(), booked_pnl))
+        executor._portfolio_manager = portfolio_manager
 
         executor._sl_tp_orders["BTCUSDT"] = {"sl_order_id": "sl_1", "tp_order_id": "tp_1"}
         executor._positions["BTCUSDT"] = {
             "entry_price": 80000.0,
-            "mark_price": 84100.0,  # close to TP, not SL
+            "mark_price": 84100.0,
             "amount": 0.01,
             "unrealized_pnl": 41.0,
         }
@@ -1086,7 +1151,39 @@ class TestFuturesTradingExecutor:
         call_kwargs = notifier.send_trade_alert.call_args.kwargs
         assert call_kwargs["symbol"] == "BTCUSDT"
         assert call_kwargs["close_reason"] == "take_profit"
-        assert call_kwargs["pnl"] == pytest.approx((84100.0 - 80000.0) * 0.01)
+        assert call_kwargs["price"] == pytest.approx(fill_price)
+        assert call_kwargs["price"] != pytest.approx(84_000.0)
+        assert call_kwargs["pnl"] == pytest.approx(booked_pnl)
+        assert call_kwargs["ticket_id"] == "tp_1"
+        assert "BTCUSDT" not in executor._sl_tp_orders
+
+    @pytest.mark.asyncio
+    async def test_monitor_phantom_flat_skips_take_profit_win_alert(self, executor):
+        """Flat exchange with no confirmed fill must not emit a fabricated TP win."""
+        mock_client = MagicMock()
+        mock_client.get_position_risk = AsyncMock(return_value=[])
+        mock_client.get_account_info = AsyncMock(
+            return_value=MagicMock(total_margin_balance=5000.0, available_balance=5000.0)
+        )
+        mock_client.get_order_status = AsyncMock(
+            return_value=_make_order(order_id="tp_1", status="NEW")
+        )
+        executor._client = mock_client
+        notifier = AsyncMock()
+        executor._notifier = notifier
+
+        executor._sl_tp_orders["BTCUSDT"] = {"sl_order_id": "sl_1", "tp_order_id": "tp_1"}
+        executor._positions["BTCUSDT"] = {
+            "entry_price": 76_832.20,
+            "mark_price": 77_875.70,
+            "amount": 0.001,
+            "unrealized_pnl": 1.04,
+        }
+        executor._sl_tp_prices["BTCUSDT"] = {"sl_price": 74_000.0, "tp_price": 77_875.70}
+
+        await executor._monitor_and_update()
+
+        notifier.send_trade_alert.assert_not_awaited()
         assert "BTCUSDT" not in executor._sl_tp_orders
 
     @pytest.mark.asyncio
@@ -1113,8 +1210,28 @@ class TestFuturesTradingExecutor:
         mock_client.place_order = AsyncMock(
             return_value=_make_order(order_id="software_close", side="SELL", reduce_only=True)
         )
+        mock_client.get_user_trades = AsyncMock(
+            return_value=[
+                FuturesUserTrade(
+                    trade_id="trade_sw",
+                    order_id="software_close",
+                    symbol="BTCUSDT",
+                    side="SELL",
+                    price=78_000.0,
+                    quantity=0.01,
+                    realized_pnl=-20.0,
+                    commission=0.04,
+                    commission_asset="USDT",
+                    time=1_800_000_500_000,
+                )
+            ]
+        )
         executor._client = mock_client
         executor._notifier = AsyncMock()
+        portfolio_manager = MagicMock()
+        portfolio_manager.get_position.return_value = MagicMock(entry_time=None)
+        portfolio_manager.close_position = AsyncMock(return_value=(MagicMock(), -20.0))
+        executor._portfolio_manager = portfolio_manager
         executor._sl_tp_prices["BTCUSDT"] = {"sl_price": 78100.0, "tp_price": 84000.0}
 
         await executor._monitor_and_update()
@@ -1148,8 +1265,28 @@ class TestFuturesTradingExecutor:
         mock_client.place_order = AsyncMock(
             return_value=_make_order(order_id="time_stop_close", side="SELL", reduce_only=True)
         )
+        mock_client.get_user_trades = AsyncMock(
+            return_value=[
+                FuturesUserTrade(
+                    trade_id="trade_ts",
+                    order_id="time_stop_close",
+                    symbol="BTCUSDT",
+                    side="SELL",
+                    price=80_100.0,
+                    quantity=0.01,
+                    realized_pnl=1.0,
+                    commission=0.04,
+                    commission_asset="USDT",
+                    time=1_800_000_500_000,
+                )
+            ]
+        )
         executor._client = mock_client
         executor._notifier = AsyncMock()
+        portfolio_manager = MagicMock()
+        portfolio_manager.get_position.return_value = MagicMock(entry_time=None)
+        portfolio_manager.close_position = AsyncMock(return_value=(MagicMock(), 1.0))
+        executor._portfolio_manager = portfolio_manager
         executor._sl_tp_prices["BTCUSDT"] = {
             "sl_price": 78000.0,
             "tp_price": 84000.0,
@@ -1208,8 +1345,28 @@ class TestFuturesTradingExecutor:
         mock_client.place_order = AsyncMock(
             return_value=_make_order(order_id="trailing_close", side="SELL", reduce_only=True)
         )
+        mock_client.get_user_trades = AsyncMock(
+            return_value=[
+                FuturesUserTrade(
+                    trade_id="trade_trail",
+                    order_id="trailing_close",
+                    symbol="BTCUSDT",
+                    side="SELL",
+                    price=80_900.0,
+                    quantity=0.01,
+                    realized_pnl=9.0,
+                    commission=0.04,
+                    commission_asset="USDT",
+                    time=1_800_000_500_000,
+                )
+            ]
+        )
         executor._client = mock_client
         executor._notifier = AsyncMock()
+        portfolio_manager = MagicMock()
+        portfolio_manager.get_position.return_value = MagicMock(entry_time=None)
+        portfolio_manager.close_position = AsyncMock(return_value=(MagicMock(), 9.0))
+        executor._portfolio_manager = portfolio_manager
         executor._sl_tp_prices["BTCUSDT"] = {
             "sl_price": 78000.0,
             "tp_price": 84000.0,

--- a/tests/test_reconciliation.py
+++ b/tests/test_reconciliation.py
@@ -456,3 +456,52 @@ class TestReconcileAll:
         # Spot failed but futures succeeded
         assert len(results) == 1
         assert results[0].market == "futures"
+
+
+class TestAutoFixNotifications:
+    @pytest.mark.asyncio
+    async def test_phantom_db_force_close_emits_reconciliation_alert(self) -> None:
+        """Phantom reconciliation close reports booked fee loss, not a TP win."""
+        portfolio = MagicMock()
+        portfolio.close_position = AsyncMock(return_value=(MagicMock(), -0.061))
+        recon = ExchangeReconciler(
+            portfolio_manager=portfolio,
+            spot_client=None,
+            futures_client=AsyncMock(),
+            spot_symbols=[],
+            futures_symbols=["BTCUSDT"],
+            notifier=MagicMock(),
+            event_log=None,
+            risk_manager=MagicMock(),
+            config=ReconciliationConfig(on_divergence=DivergencePolicy.AUTO_FIX),
+            agent_id="sentiment-macro-bot",
+        )
+        recon._notifier.send_trade_alert = AsyncMock(return_value=True)
+        recon._notifier.send_alert = AsyncMock(return_value=True)
+
+        from src.execution.reconciliation import Divergence
+
+        await recon._auto_fix(
+            [
+                Divergence(
+                    symbol="BTCUSDT",
+                    market="futures",
+                    divergence_type="phantom_db",
+                    db_state={
+                        "quantity": 0.001,
+                        "side": "LONG",
+                        "entry_price": 76_832.20,
+                    },
+                    exchange_state={"quantity": 0.0},
+                    severity="critical",
+                    message="phantom futures position",
+                )
+            ]
+        )
+
+        recon._notifier.send_trade_alert.assert_awaited_once()
+        call_kwargs = recon._notifier.send_trade_alert.call_args.kwargs
+        assert call_kwargs["close_reason"] == "reconciliation"
+        assert call_kwargs["pnl"] == pytest.approx(-0.061)
+        assert call_kwargs["price"] == pytest.approx(76_832.20)
+        assert call_kwargs["entry_price"] == pytest.approx(76_832.20)


### PR DESCRIPTION
Closes #114

## Problem

For `sentiment-macro-bot::BTCUSDT` on 2026-05-26, Telegram announced a winning Take Profit (+1.04 USDT at 77875.70) while the DB position was force-closed at entry price (−0.061 fee loss, no `order_id`). The exchange never held the position — reconciliation had already cleared the phantom DB record, but the futures monitor still inferred a TP win from mark proximity.

## Before

- `_resolve_close_execution_details` guessed `take_profit` / `stop_loss` from mark-to-target distance when SL/TP orders were not confirmed filled
- Monitor emitted `send_trade_alert` using mark price and `qty × (price − entry)` even without a real exchange fill
- Reconciliation `AUTO_FIX` force-closed phantom positions silently (no trade-close notification reflecting booked P&L)

## After

- Exchange-close notifications require a **confirmed filled** SL/TP order (`FILLED` / `TRIGGERED`) **and** a real fill price + booked PnL from Binance trades / `portfolio.close_position`
- Flat exchange with no confirmed fill → tracking cleanup only, **no** fabricated TP/SL win alert
- Phantom reconciliation force-closes emit `send_trade_alert` with `close_reason=reconciliation`, entry price, and actual `realized_pnl` (−fee)
- Entry/open notification path unchanged; `TelegramNotifier.send_trade_alert` formatting contract unchanged

## Tests

- **(a)** `test_monitor_sends_close_notification_on_tp_close` — alert price/PnL match fill + `positions.realized_pnl`, not TP target
- **(b)** `test_monitor_phantom_flat_skips_take_profit_win_alert` + `test_phantom_db_force_close_emits_reconciliation_alert`
- **(c)** `test_monitor_sends_close_notification_on_tp_close` regression for genuine winning TP fills

```
uv run python -m pytest tests/test_futures_executor.py tests/test_reconciliation.py -v
```

Co-Authored-By: Grok <noreply@x.ai>