### PR TITLE
fix(risk): record daily-loss on confirmed futures fill when PnL lookup fails

### DIFF
--- a/src/execution/futures_executor.py
+++ b/src/execution/futures_executor.py
@@ -315,6 +315,38 @@ class FuturesTradingExecutor:
             confirmed_fill=confirmed_fill,
         )
 
+    @staticmethod
+    def _resolve_risk_close_pnl(
+        booked_pnl: float | None,
+        exchange_realized_pnl: float | None,
+        close_price: float | None,
+        entry_px: float,
+        qty: float,
+    ) -> float | None:
+        """Best-effort realized PnL for circuit-breaker accounting on confirmed closes."""
+        if booked_pnl is not None:
+            return booked_pnl
+        if exchange_realized_pnl is not None:
+            return exchange_realized_pnl
+        if close_price is not None and entry_px > 0 and qty > 0 and close_price > 0:
+            return (close_price - entry_px) * qty
+        return None
+
+    @staticmethod
+    def _risk_fallback_close_price(
+        close_details: CloseExecutionDetails,
+        sl_px: float,
+        tp_px: float,
+    ) -> float | None:
+        """Conservative close price for risk accounting when trade fill lookup fails."""
+        if close_details.fill_price is not None and close_details.fill_price > 0:
+            return close_details.fill_price
+        if close_details.reason == "stop_loss" and sl_px > 0:
+            return sl_px
+        if close_details.reason == "take_profit" and tp_px > 0:
+            return tp_px
+        return None
+
     async def run(self) -> None:
         """Main futures trading loop."""
         if not self._config.enabled:
@@ -411,73 +443,97 @@ class FuturesTradingExecutor:
                         symbol=symbol,
                         tracked_orders=tracked_orders,
                     )
-                    pnl: float | None = None
                     if close_details.confirmed_fill and close_details.ticket_id:
-                        close_price = close_details.fill_price
-                        if close_price is None:
+                        alert_fill_price = close_details.fill_price
+                        if alert_fill_price is None:
                             self._logger.warning(
                                 "Confirmed exchange close for %s but fill price unavailable — "
                                 "skipping close alert",
                                 symbol,
                             )
-                        else:
-                            if (
-                                close_details.reason == "stop_loss"
-                                and self._config.sl_cooldown_minutes > 0
-                            ):
+
+                        if (
+                            close_details.reason == "stop_loss"
+                            and self._config.sl_cooldown_minutes > 0
+                        ):
+                            cooldown_close_px = (
+                                alert_fill_price if alert_fill_price is not None else sl_px
+                            )
+                            if cooldown_close_px > 0:
                                 self._sl_cooldown_timestamps[symbol] = time.time()
                                 self._logger.info(
                                     "SL cooldown started for %s (close=%.4f sl=%.4f)",
                                     symbol,
-                                    close_price,
+                                    cooldown_close_px,
                                     sl_px,
                                 )
 
-                            bars_held: int | None = None
-                            if self._portfolio_manager is not None:
-                                tracked_position = self._portfolio_manager.get_position(
-                                    symbol, market="futures"
-                                )
-                                if tracked_position is not None:
-                                    bars_held = self._estimate_bars_held(
-                                        tracked_position.entry_time
-                                    )
+                        bars_held: int | None = None
+                        if self._portfolio_manager is not None:
+                            tracked_position = self._portfolio_manager.get_position(
+                                symbol, market="futures"
+                            )
+                            if tracked_position is not None:
+                                bars_held = self._estimate_bars_held(tracked_position.entry_time)
 
-                            realized_pnl: float | None = None
-                            if self._portfolio_manager is not None:
-                                try:
-                                    _, realized_pnl = await self._portfolio_manager.close_position(
-                                        symbol=symbol,
-                                        price=close_price,
-                                        order_id=close_details.ticket_id,
-                                        market="futures",
-                                        closing_side="SELL",
-                                        realized_pnl_override=close_details.realized_pnl,
-                                    )
-                                except ValueError:
-                                    realized_pnl = close_details.realized_pnl
-
-                            pnl = realized_pnl
-                            if pnl is not None and entry_px > 0 and qty > 0 and close_price > 0:
-                                await self._notifier.send_trade_alert(
+                        booked_pnl: float | None = None
+                        if alert_fill_price is not None and self._portfolio_manager is not None:
+                            try:
+                                _, booked_pnl = await self._portfolio_manager.close_position(
                                     symbol=symbol,
-                                    side="SELL",
-                                    quantity=qty,
-                                    price=close_price,
-                                    pnl=pnl,
+                                    price=alert_fill_price,
+                                    order_id=close_details.ticket_id,
                                     market="futures",
-                                    entry_price=entry_px,
-                                    close_reason=close_details.reason,
-                                    bars_held=bars_held,
-                                    ticket_id=close_details.ticket_id,
+                                    closing_side="SELL",
+                                    realized_pnl_override=close_details.realized_pnl,
                                 )
-                                self._record_risk_close(symbol, pnl, self._account_balance)
-                            else:
-                                self._logger.warning(
-                                    "Confirmed exchange close for %s but booked PnL unavailable — "
-                                    "skipping close alert",
-                                    symbol,
-                                )
+                            except ValueError:
+                                booked_pnl = close_details.realized_pnl
+
+                        if (
+                            booked_pnl is not None
+                            and alert_fill_price is not None
+                            and entry_px > 0
+                            and qty > 0
+                            and alert_fill_price > 0
+                        ):
+                            await self._notifier.send_trade_alert(
+                                symbol=symbol,
+                                side="SELL",
+                                quantity=qty,
+                                price=alert_fill_price,
+                                pnl=booked_pnl,
+                                market="futures",
+                                entry_price=entry_px,
+                                close_reason=close_details.reason,
+                                bars_held=bars_held,
+                                ticket_id=close_details.ticket_id,
+                            )
+                        elif alert_fill_price is not None:
+                            self._logger.warning(
+                                "Confirmed exchange close for %s but booked PnL unavailable — "
+                                "skipping close alert",
+                                symbol,
+                            )
+
+                        risk_close_price = self._risk_fallback_close_price(
+                            close_details, sl_px, sw_prices.get("tp_price", 0.0)
+                        )
+                        risk_pnl = self._resolve_risk_close_pnl(
+                            booked_pnl=booked_pnl,
+                            exchange_realized_pnl=close_details.realized_pnl,
+                            close_price=risk_close_price,
+                            entry_px=entry_px,
+                            qty=qty,
+                        )
+                        if risk_pnl is not None:
+                            self._record_risk_close(symbol, risk_pnl, self._account_balance)
+                        else:
+                            self._logger.warning(
+                                "Confirmed exchange close for %s but no usable PnL for risk "
+                                "recording — daily-loss circuit breaker not updated",
+                                symbol,
+                            )
                     else:
                         self._logger.info(
                             "Position %s flat on exchange with no confirmed SL/TP fill — "

--- a/src/notifications/telegram.py
+++ b/src/notifications/telegram.py
@@ -477,6 +477,8 @@ class TelegramNotifier:
             return "Trailing Stop"
         if r.startswith("TIME_STOP"):
             return "Time Stop"
+        if r == "RECONCILIATION":
+            return "Reconciliation (forced)"
         return reason
 
     def _format_message(self, message: str, level: AlertLevel) -> str:

--- a/tests/test_futures_executor.py
+++ b/tests/test_futures_executor.py
@@ -727,6 +727,39 @@ class TestFuturesTradingExecutor:
         assert executor._calculate_quantity("BTCUSDT", 0.0) == 0.0
         assert executor._calculate_quantity("BTCUSDT", -1.0) == 0.0
 
+    def test_resolve_risk_close_pnl_priority_and_fallback(self) -> None:
+        assert FuturesTradingExecutor._resolve_risk_close_pnl(
+            booked_pnl=-12.5,
+            exchange_realized_pnl=-99.0,
+            close_price=100.0,
+            entry_px=110.0,
+            qty=1.0,
+        ) == pytest.approx(-12.5)
+        assert FuturesTradingExecutor._resolve_risk_close_pnl(
+            booked_pnl=None,
+            exchange_realized_pnl=-8.0,
+            close_price=100.0,
+            entry_px=110.0,
+            qty=1.0,
+        ) == pytest.approx(-8.0)
+        assert FuturesTradingExecutor._resolve_risk_close_pnl(
+            booked_pnl=None,
+            exchange_realized_pnl=None,
+            close_price=95.0,
+            entry_px=100.0,
+            qty=0.5,
+        ) == pytest.approx(-2.5)
+        assert (
+            FuturesTradingExecutor._resolve_risk_close_pnl(
+                booked_pnl=None,
+                exchange_realized_pnl=None,
+                close_price=None,
+                entry_px=100.0,
+                qty=0.5,
+            )
+            is None
+        )
+
     @pytest.mark.asyncio
     async def test_sl_tp_use_long_position_side_in_hedge_mode(self, executor):
         """In hedge mode, SL/TP orders use positionSide=LONG with closePosition=True."""
@@ -913,6 +946,10 @@ class TestFuturesTradingExecutor:
         assert call_kwargs["price"] == pytest.approx(78_100.0)
         assert call_kwargs["pnl"] == pytest.approx(-20.0)
         assert call_kwargs["ticket_id"] == "sl_1"
+        executor._risk_manager.record_trade.assert_called_once_with(
+            "BTCUSDT", pytest.approx(-20.0), 5000.0
+        )
+        executor._risk_manager.register_close_position.assert_called_once_with("BTCUSDT")
         assert "BTCUSDT" not in executor._sl_tp_orders
 
     @pytest.mark.asyncio
@@ -1060,7 +1097,7 @@ class TestFuturesTradingExecutor:
 
     @pytest.mark.asyncio
     async def test_monitor_skips_alert_when_fill_lookup_fails(self, executor):
-        """Confirmed fill without fill price/PnL must not emit a close alert."""
+        """Confirmed fill without trade fill/PnL must not alert but still records risk loss."""
         mock_client = MagicMock()
         mock_client.get_position_risk = AsyncMock(return_value=[])
         mock_client.get_account_info = AsyncMock(
@@ -1093,7 +1130,69 @@ class TestFuturesTradingExecutor:
 
         portfolio_manager.close_position.assert_not_awaited()
         notifier.send_trade_alert.assert_not_awaited()
+        executor._risk_manager.record_trade.assert_called_once_with(
+            "BTCUSDT", pytest.approx(-19.0), 5000.0
+        )
+        executor._risk_manager.register_close_position.assert_called_once_with("BTCUSDT")
         assert "BTCUSDT" not in executor._sl_tp_orders
+
+    @pytest.mark.asyncio
+    async def test_monitor_records_risk_close_when_booked_pnl_missing_on_confirmed_fill(
+        self, executor
+    ):
+        """Confirmed fill with trade price but no booked PnL records conservative risk loss."""
+        fill_price = 78_100.0
+        mock_client = MagicMock()
+        mock_client.get_position_risk = AsyncMock(return_value=[])
+        mock_client.get_account_info = AsyncMock(
+            return_value=MagicMock(total_margin_balance=5000.0, available_balance=5000.0)
+        )
+        mock_client.get_order_status = AsyncMock(
+            return_value=_make_order(
+                order_id="sl_1", side="SELL", price=fill_price, status="FILLED"
+            )
+        )
+        mock_client.get_user_trades = AsyncMock(
+            return_value=[
+                FuturesUserTrade(
+                    trade_id="trade_sl",
+                    order_id="sl_1",
+                    symbol="BTCUSDT",
+                    side="SELL",
+                    price=fill_price,
+                    quantity=0.01,
+                    realized_pnl=0.0,
+                    commission=0.04,
+                    commission_asset="USDT",
+                    time=1_800_000_500_000,
+                )
+            ]
+        )
+        executor._client = mock_client
+        notifier = AsyncMock()
+        executor._notifier = notifier
+        portfolio_manager = MagicMock()
+        portfolio_manager.get_position.return_value = MagicMock(entry_time=None)
+        portfolio_manager.close_position = AsyncMock(side_effect=ValueError("no position"))
+        executor._portfolio_manager = portfolio_manager
+        executor._fetch_close_execution_details = AsyncMock(return_value=(None, None))
+
+        executor._sl_tp_orders["BTCUSDT"] = {"sl_order_id": "sl_1", "tp_order_id": "tp_1"}
+        executor._positions["BTCUSDT"] = {
+            "entry_price": 80_000.0,
+            "mark_price": 78_000.0,
+            "amount": 0.01,
+            "unrealized_pnl": -20.0,
+        }
+        executor._sl_tp_prices["BTCUSDT"] = {"sl_price": fill_price, "tp_price": 84_000.0}
+
+        await executor._monitor_and_update()
+
+        notifier.send_trade_alert.assert_not_awaited()
+        executor._risk_manager.record_trade.assert_called_once_with(
+            "BTCUSDT", pytest.approx(-19.0), 5000.0
+        )
+        executor._risk_manager.register_close_position.assert_called_once_with("BTCUSDT")
 
     @pytest.mark.asyncio
     async def test_monitor_sends_close_notification_on_tp_close(self, executor):

--- a/tests/test_telegram.py
+++ b/tests/test_telegram.py
@@ -450,6 +450,11 @@ class TestHelpers:
     def test_humanize_close_reason_passthrough(self) -> None:
         assert TelegramNotifier._humanize_close_reason("custom reason") == "custom reason"
 
+    def test_humanize_close_reason_reconciliation(self) -> None:
+        assert (
+            TelegramNotifier._humanize_close_reason("reconciliation") == "Reconciliation (forced)"
+        )
+
     def test_format_market_label_paper(self) -> None:
         assert TelegramNotifier._format_market_label("paper-spot") == "📄 PAPER SPOT"
 


### PR DESCRIPTION
Closes #116

Follow-up to #115. The phantom-TP fix correctly gates user-facing close alerts on trade-sourced fill price + booked PnL, but the same branch also gated `_record_risk_close`. On a confirmed SL/TP fill where Binance fill/PnL lookup or portfolio booking failed, a genuine realized loss never reached the daily-loss circuit breaker.

## Before

Exchange-close path (`_monitor_and_update`, flat position + tracked SL/TP):

| Condition | Alert | `_record_risk_close` |
|-----------|-------|----------------------|
| Confirmed fill + fill price + booked PnL | ✅ | ✅ |
| Confirmed fill, missing fill price or booked PnL | ❌ | ❌ (gap) |
| Flat exchange, no confirmed fill | ❌ | ❌ |

## After

| Condition | Alert | `_record_risk_close` |
|-----------|-------|----------------------|
| Confirmed fill + fill price + booked PnL | ✅ (unchanged) | ✅ booked PnL |
| Confirmed fill, alert prerequisites missing | ❌ (unchanged) | ✅ best-effort: booked → exchange realized → conservative `(close_price − entry) × qty` using trade fill or SL/TP trigger price |
| Flat exchange, no confirmed fill | ❌ (unchanged) | ❌ (unchanged) |

**#115 preserved:** `send_trade_alert` still requires trade-sourced fill price and booked PnL — the conservative fallback is risk/circuit-breaker accounting only and never surfaces in alerts.

## Tests

- `test_monitor_skips_alert_when_fill_lookup_fails` — confirmed SL, trades API fails: no alert, `_record_risk_close` with conservative loss
- `test_monitor_records_risk_close_when_booked_pnl_missing_on_confirmed_fill` — fetch `(None, None)` + no booked PnL: no alert, risk recorded
- `test_monitor_sends_close_notification_on_sl_close` — regression: real PnL path still alerts + records
- `test_monitor_clears_sl_tp_when_position_closed_by_exchange` / `test_monitor_phantom_flat_skips_take_profit_win_alert` — flat/unconfirmed unchanged

Ready for Claude review.