### PR TITLE
docs(research): deep edge reconciliation + A1 liquidation probe (measured dead)

### DIFF
--- a/docs/reports/deep-edge-research-claude-pass.md
+++ b/docs/reports/deep-edge-research-claude-pass.md
@@ -1,0 +1,71 @@
+# Deep Edge Research — Claude independent pass (2026-06-24)
+
+> **Status:** independent *pre-reconciliation* pass (parity with
+> [`deep-edge-research-grok-pass.md`](./deep-edge-research-grok-pass.md)). Its two cheap proposals
+> (A new-listing, E small-perp funding) **folded on reconciliation** — see
+> [`deep-edge-research-reconciliation-2026-06-24.md`](./deep-edge-research-reconciliation-2026-06-24.md)
+> for the adjudicated outcome (stay banked; A1 measured dead; Path 2 held). Preserved for the record.
+
+**Goal (intact):** find a *durable, deployable* edge for a solo operator with a server, public
+exchange APIs, and modest capital. Not "any positive backtest" — an edge that survives the #118 null,
+realistic costs, and forward time.
+
+**Hard constraint from the bank** (`research-consolidation-2026-06-23.md`): directional prediction on
+**liquid-major public OHLCV** is terminal NULL across ~1,440 WFO runs + a dozen probes, in coherent
+structural ways (efficient venue / most-arbitraged trade / regime artifact / friction-eats-edge). The
+cost-model error was found, fixed, and re-screened — **no lane revived**. Microstructure OFI on majors
+is NULL (sign corr 0.009). Funding carry on majors banked (excess over risk-free gone).
+
+## The reframe that keeps the goal intact
+
+The bank covers **one edge type on one population**: *prediction edge* on *liquid majors*. Two spaces
+it never tested:
+
+1. **A different population** — the *illiquid / newly-listed* regime. Majors are MM-saturated; thin or
+   brand-new books are not (yet). The bank says nothing about them.
+2. **A different edge type** — *access/structural* edge (not prediction). For a small operator, **size
+   is the edge**: flows a whale cannot harvest without diluting them.
+
+Everything else (co-location/latency, proprietary alt-data, capital scale) is a *business*, not
+accessible to this operator → out of scope unless the operator decides to become that business.
+
+## Candidate frontier — ranked for THIS operator
+
+Scored on: **accessible now** (public data / trusted venue) × **cheaply falsifiable** × **bank does
+NOT already cover** × **deployable capacity > operating cost**.
+
+| # | Candidate | Why it might survive where majors didn't | Accessibility | Cheapest Gate-1 probe (read-only) | Mandatory null (#118) | Risk that kills it |
+|---|-----------|------------------------------------------|---------------|-----------------------------------|----------------------|--------------------|
+| **A** | **New-listing / low-float microstructure** (first N hours/days of a new Binance/Bybit perp or spot listing) | Book is thin, MM not yet saturated, flow is retail + mechanical (listing pump, index/unlock schedule). *Different population from majors.* | **High** — public OHLCV+aggTrade, trusted venue | Backfill first-72h candles+aggTrade for all listings in last 12–18mo; test mechanical drift/reversion (e.g. listing-pop fade, day-1 close→day-3 drift) | Shuffle across listings; block-bootstrap p_adj; ≤25% conc; cost = new-listing spread (wide!) | Wide spread + tiny size; survivorship/look-ahead on listing dates |
+| **E** | **Small / new-perp funding dislocation** | New perps run violent funding (often >100% APR) *because* they're hard to arb (borrow/custody friction). Majors' carry is arbed away; small perps' is not — different population. | **High** — public funding + mark history | Historical funding vs realized cost-to-carry on small/new perps; how persistent, how negative-after-cost | Shuffle perp-IDs; p_adj; conc cap; cost = perp taker + borrow + custody haircut | Custody/venue risk; capacity; funding flips before you capture |
+| **B** | **Illiquid-venue microstructure** (Path 2, Gate 0 open) | Same thinness thesis as A, on smaller exchanges | **Medium** — needs venue account + L2/trade data | (parked) Gate 0 economic sub-gates first | per path2 brief | **Custody/solvency** — can lose bankroll to venue; A is the safer expression of the same idea |
+| **C** | **On-chain DEX/CEX basis & LP fee capture on small caps** | DEX books are slower; small-cap CEX-DEX basis less arbed | **Medium** — node + capital + gas | DEX-CEX price gap on small caps vs gas+bridge cost | shuffle; p_adj; conc; cost = gas+bridge+slippage | Saturated by pro searchers on the easy/atomic part; gas eats small size |
+| **D** | **Access/operational edges** (airdrops, points/restaking, launchpad allocations, new-perp listing funding) | **Size IS the edge** — non-scaling flows whales can't farm | **High** but **not an engine strategy** | n/a — operational checklist, not a backtest | n/a | Not a `src/strategy` fit; time/ops cost; rug risk |
+
+## Recommendation
+
+1. **Run two cheap, public-data Gate-1 probes in parallel — both target the regime gap the bank never
+   tested, on trusted venues, no new infra:**
+   - **A — new-listing microstructure** (first-72h drift/reversion of new listings).
+   - **E — small/new-perp funding dislocation** (funding vs realized cost-to-carry on non-major perps).
+   Both are falsifiable cheaply and honestly; both have an obvious null and a wide-spread cost model
+   that will kill them fast if there's nothing there (good — cheap NO_PULSE is a win).
+2. **Hold B (illiquid-venue) at Gate 0** — A is the same illiquidity thesis without custody risk; only
+   advance B if A shows a pulse *and* the operator wants venue exposure.
+3. **Record D as a real non-engine edge** for the operator (size-is-edge), but it's an ops track, not
+   a strategy-engine lane — don't force it into the backtester.
+4. **Reject** any re-probe of liquid-major prediction (majors OHLCV, majors OFI, majors carry) — banked.
+
+**Keep-goal-intact verdict:** the goal (durable deployable edge) is unchanged; the *only* honest place
+left to look is the **illiquid/new population** (A, E, B) and **size-is-edge access flows** (D). A and
+E are the cheapest falsifiable next probes and respect every hard rule (read-only, HAS_PULSE-gated,
+#118 null mandatory, human `--execute`).
+
+## Open questions to reconcile with Grok's pass
+
+- Does Grok independently land on the illiquid/new-population reframe, or propose a genuinely different
+  surviving space?
+- Survivorship/look-ahead hazard on listing-date data — is A cleanly backfillable without bias?
+- Is E distinguishable from the banked majors-carry result, or does it collapse to the same
+  "premium already arbed minus custody cost" once costs are honest?
+- Any candidate Grok proposes that is *accessible* and *cheaply falsifiable* that I missed?

--- a/docs/reports/deep-edge-research-grok-pass.md
+++ b/docs/reports/deep-edge-research-grok-pass.md
@@ -1,0 +1,239 @@
+# Deep Edge Research — Independent Grok Pass
+
+**Date:** 2026-06-24
+**Author:** Grok (independent; did not read any prior deep-edge pass)
+**Mode:** Research only — no code, no probes, no `--execute`, no live-risk change
+**Canonical bank:** [research-consolidation-2026-06-23.md](./research-consolidation-2026-06-23.md)
+**Gate 1 null reference:** [RBI_AUTORESEARCH_LOOP.md](../RBI_AUTORESEARCH_LOOP.md) §Mandatory baseline (#118)
+
+---
+
+## Executive summary
+
+The bank is **structurally sound**. ~1,440 WFO runs plus a dozen cheap probes fail in a small number of coherent ways — not scattered near-misses. Any remaining candidate that still uses **public aggregate data on liquid, well-arbitraged surfaces** should be assigned a **low prior** of clearing Gate 1 (#118: beat shuffled/phase-randomized or permuted-feature null, block-bootstrap `p_adj < 0.05`, concentration ≤ 25%, net of venue costs).
+
+**Independent conclusion:** For a solo operator with a server, public exchange APIs, and modest capital, there is **no cheap probe left with positive expected value** on accessible surfaces. The rational default is **stay banked**.
+
+If the operator insists on one more falsification before accepting terminal state, the **only** unexplored public-data primitive with a thesis structurally distinct from tested OHLCV structure is **forced liquidation / cascade flow** — but its expected outcome is `NO_PULSE` for the same “efficient venue” reason that killed OFI on majors. **Path 2 (illiquid venue microstructure)** is the only lane with a credible differentiated-advantage story; it is **held**, not probed, until the operator attests venue access and passes Gate 0 economic sub-gates.
+
+**Do not reopen any banked liquid-major lane.**
+
+---
+
+## 1. What the bank covers — and does not
+
+### 1.1 Edge *types* the bank covers
+
+| Edge type | Mechanism | Bank outcome |
+|-----------|-----------|--------------|
+| **Directional return prediction** from price/volume structure | Trend, mean-reversion, breakout, MTF, overlays, regime gates | **NULL** — efficient venue (~1,440 WFO + probes) |
+| **Directional prediction from perp microstructure on majors** | Funding extremes, basis premium, crowding, normalization | **NULL / CLOSED** — continuation > fade; filter-first never improved risk |
+| **Cross-venue dislocation (majors)** | Spot/perp basis events, rolling thresholds | **NULL** — 0/30 WFO passes; thin edge dies under sizing + exits |
+| **Session / calendar conditioning (crypto-internal)** | Americas gate, higher-TF regime allocator | **NULL** — no separation vs baseline |
+| **Scheduled macro calendar (exogenous)** | FOMC/CPI/NFP event windows | **NO_PULSE** — no fee-surviving drift |
+| **Macro surprise (exogenous, PIT-limited)** | Hot/cold CPI/NFP vs consensus | **WEAK_EDGE** — monotonicity fragments; NFP “hot → up” contradicts frozen sign |
+| **TradFi risk-regime lead-lag** | QQQ/DXY/10Y/VIX → crypto forward | **WEAK_EDGE** — contemporaneous correlation, no predictive lead-lag |
+| **Higher-TF trend (daily SMA)** | Long-only filter on majors | **HAS_PULSE probe, undeployable** — shared beta (breadth corr 0.59), not independent edge |
+| **Event calendar (crypto-native)** | Token unlock 72h short | **NO_PULSE** — paper artifact; 49% neg vs claimed 88.5% |
+| **Market-neutral yield** | Delta-neutral funding carry | **BANK** — known premium; excess over risk-free negative forward |
+| **Relative value (different asset class)** | mNAV treasury premium reversion | **WEAK_EDGE** — one-name regime artifact (SBET) |
+| **Probability calibration (different venue)** | Polymarket favorite-longshot | **WEAK_EDGE** — well-calibrated; net edge inside friction |
+| **Tick-level signed flow (different telemetry, same venue)** | aggTrade OFI deciles on BTC/ETH/SOL | **NO_PULSE** — p≈0.5, net −7 to −10 bps, sign corr 0.009 |
+
+### 1.2 *Populations* the bank covers
+
+| Population | Covered? | Notes |
+|------------|----------|-------|
+| Liquid CEX majors (BTC, ETH, SOL, BNB, AVAX) | **Yes** | 1h/4h/daily; primary program surface |
+| Top-10 liquid alts (XRP, DOGE, ADA, LINK, LTC, …) | **Partial** | Daily trend *breadth* probe only — NO_PULSE, shared beta |
+| Mid / long-tail alts | **No** | Not systematically probed for structure or carry |
+| Binance aggTrade / public tick flow | **Yes (majors only)** | #110 |
+| L2 order book (any symbol) | **No** | Deliberately gated behind OFI pulse; never built |
+| Liquidation / force-order stream | **No** | Named in reset doc; **never probed** |
+| Cross-exchange (CEX–CEX) | **Yes (basis/dislocation)** | CLOSED on majors |
+| DEX / on-chain | **No** | Out of program scope |
+| TradFi proxies (Yahoo) | **Yes** | Cross-asset probe — WEAK_EDGE |
+| US equities (treasury mNAV) | **Yes** | WEAK_EDGE |
+| Prediction markets (Polymarket) | **Yes** | WEAK_EDGE |
+| Scheduled US macro | **Yes** | NO_PULSE / WEAK_EDGE |
+| LLM runtime sentiment | **Live only** | Not backtestable; live vehicle swept dead |
+| **Illiquid venues / thin books** | **Gate 0 only** | Path 2 OPEN_PENDING_INFRA — no market probe |
+
+### 1.3 Structural taxonomy (bank’s meta-finding)
+
+Every detectable pulse so far maps to one of four classes — **none** leave deployable excess for a public-data solo operator on liquid surfaces:
+
+1. **Efficient venue** — information already in price (OHLCV majors, OFI majors).
+2. **Most-arbitraged trade** — premium exists but excess over cost of capital is gone (funding carry).
+3. **Regime / bubble artifact** — one episode, not a relationship (mNAV SBET, unlock paper).
+4. **Friction eats edge** — mispricing real but < round-trip cost (Polymarket, OFI net bps).
+
+---
+
+## 2. Surviving candidate spaces (exhaustive)
+
+Below: every space where a *durable* edge could **still** live in principle, whether or not this operator can reach it. For each: structural reason vs majors, accessibility, cheapest Gate-1 probe, mandatory null (#118), and primary kill risk.
+
+**Legend — accessibility**
+
+- **A** = accessible now (public API, trusted major CEX, read-only)
+- **B** = accessible with modest new infra (same operator, no co-lo)
+- **C** = requires differentiated infra / capital / venue risk (Path 2+)
+
+---
+
+### Tier A — Public data, major/trusted venue, not yet probed
+
+| # | Candidate space | Why it might survive where majors didn’t | Access | Cheapest Gate-1 probe | Mandatory null (#118) | Top kill risk |
+|---|-----------------|------------------------------------------|--------|-------------------------|----------------------|---------------|
+| A1 | **Forced liquidation / cascade flow** | Mechanical forced selling creates **temporary** impact not driven by OHLCV patterns; distinct from sweep probe (chart level vs exchange force orders) | **A** — Binance `!forceOrder@arr`, futures liquidation endpoints | Event study: liquidation-cluster windows (+5m/+30m/+2h forward return & MAE) vs **matched random windows** + **phase-randomized** event labels; block-bootstrap on excess return; concentration by day | Shuffled event timestamps preserving marginal size distribution; block-bootstrap `p_adj` across horizons | **Efficient venue** — HFT/arbs fade cascades on liquid perps before REST latency; same class as OFI NULL |
+| A2 | **Open-interest shock + price divergence** | OI change may encode positioning stress not in candles; untested as **standalone** primitive | **A** — Binance futures OI history (public) | Bucket ΔOI z-score → forward return; monotonicity across deciles; vs permuted OI shocks | Phase-randomized OI changes paired to returns; shuffled-sign on OI→return link | Redundant with funding/crowding failures; **continuation** not reversion on majors |
+| A3 | **New-listing / announcement drift** | Information arrives discretely; retail flow asymmetry at listing | **A** — Binance announcement archive + listing timestamps | Fixed window post-listing (+1d/+7d) vs matched non-listing alts; survivorship declared up front | Shuffled listing dates within symbol cohort; concentration cap on single listings | **Survivorship / look-ahead** — only listed winners observed; n thin; one-off events |
+| A4 | **Alt-perp funding carry (non-majors)** | Thinner arb capital on long-tail perps → higher gross carry? | **A** — reuse funding API on top-20 perps ex-BTC/ETH/SOL | `probe_funding_carry_neutral` template on alt basket; durability split + excess vs RF | Block-bootstrap on carry series; forward-half holdout | **Most-arbitraged** — majors already BANK; alts add **negative funding tail + venue risk**; capacity tiny |
+| A5 | **Mid-cap OFI on Binance (aggTrade)** | Thinner top-of-book → slower MM arb than BTC? | **A** — same REST aggTrade as #110 | Repeat OFI-decile test on e.g. 5 mid-caps (LINK, AVAX, DOGE, ADA, MATIC) | **Shuffled-sign** on trade flow (#110 protocol) | **Not Path 2** — same venue/MM ecosystem; majors NULL was decisive (p≈0.5, corr 0.009); **spread > edge** |
+| A6 | **Stablecoin depeg mean-reversion** | Peg breaks are mechanical; CEX spot vs $1 | **A** — public USDT/USDC/BUSD prices | Event study on |price−1|>ε; forward reversion vs random | Shuffled depeg event times | **Capacity + competition** — arb bots; rare events → concentration; custody |
+| A7 | **Weekend / session standalone drift** | 24/7 crypto vs closed TradFi; untested as **standalone** directional (session router tested overlay only) | **A** — existing OHLCV | Fri-close → Mon-open, Asia vs US session buckets vs matched random | Phase-randomized session labels | Already implied **efficient**; macro/cross-asset weak |
+
+---
+
+### Tier B — Public data, modest new infra (still solo-feasible)
+
+| # | Candidate space | Why it might survive | Access | Cheapest Gate-1 probe | Mandatory null | Top kill risk |
+|---|-----------------|----------------------|--------|----------------------|----------------|---------------|
+| B1 | **L2 order-book imbalance (mid-caps, Binance)** | Queue position signal not in aggTrade sign | **B** — REST depth snapshots (no store build for probe) | Snapshot imbalance decile → +30s/+5m forward; permuted book shuffle | Shuffled depth levels preserving marginal sizes | Same as A5 — **efficient venue** on Binance; snapshot rate limits |
+| B2 | **Liquidation + OI joint conditioning** | Cascade only when OI elevated | **B** — combine A1 + A2 data | Interaction buckets vs additive baselines | Permute OI and liquidation labels independently | **Sparse cells** → concentration > 25% |
+| B3 | **ETF / fund flow proxy (GBTC premium, ETF tickers)** | TradFi wrapper friction | **B** — Yahoo/FRED + crypto | Premium z-score → forward BTC; PIT table | Shuffled premium series | **WEAK_EDGE repeat** of cross-asset; friction |
+| B4 | **Historical social volume (non-LLM)** | Alternative sentiment without replay problem | **B** — LunarCrush/Glassnode free tier or GDELT | Event spikes → forward return | Shuffled spike timestamps | **Data cost / PIT** — free tiers lack audit trail; likely efficient |
+| B5 | **Cross-prediction-market mispricing** | Polymarket vs Kalshi same event | **B** — two APIs + accounts | Joint calibration residual | Permuted resolution labels | **Friction + capital lock**; Polymarket already WEAK_EDGE |
+| B6 | **DEX–CEX spot basis (major pairs)** | Fragmented liquidity | **B** — DexScreener + CEX | Basis z-score event study | Shuffled DEX prints | **Execution** — gas, MEV, wallet custody; not solo-modest-capital |
+
+---
+
+### Tier C — Differentiated advantage (Path 2 family — not “accessible now”)
+
+| # | Candidate space | Why it might survive | Access | Cheapest Gate-1 probe | Mandatory null | Top kill risk |
+|---|-----------------|----------------------|--------|----------------------|----------------|---------------|
+| C1 | **Illiquid-venue microstructure** | Thin book → OFI persists; fewer tick models | **C** — named small CEX / perp dex | OFI-decile on **named** venue/pair; venue cost model | Shuffled-sign (#110) | **Capacity < cost** or **venue custody** — Gate 0 sub-gates |
+| C2 | **Co-location / sub-second latency** | Pick off stale quotes | **C** | Not cheap on this stack; business not probe | N/A at Gate 1 | **Capital + infra** — explicit Path 2 item |
+| C3 | **On-chain MEV / atomic arb** | Block-space priority | **C** | Simulation-only | Shuffled pool state | **Smart-contract risk**; not modest capital |
+| C4 | **Proprietary alt data** (whale flows, exchange reserves) | Non-public information set | **C** — paid vendor | Vendor historical dump → event study | Shuffled flow labels | **Subscription cost > edge**; data PIT disputes |
+| C5 | **Market-making / maker rebates** | Earn spread + rebate, not predict | **C** — quote engine | Inventory PnL sim | N/A — different objective | **Adverse selection** — business model change |
+| C6 | **Multi-CEX funding arb at size** | Cross-venue carry | **C** — accounts + capital on N venues | Cross-venue funding spread panel | Shuffled venue spreads | **Most-arbitraged** — majors carry BANK |
+
+---
+
+### Tier D — Formally “not covered” but **low prior** (bank logic extends)
+
+| # | Space | Why low prior |
+|---|-------|---------------|
+| D1 | More OHLCV symbols on same TFs | Same efficient-venue class |
+| D2 | More Polymarket τ / categories | Friction-eats-edge already demonstrated |
+| D3 | More mNAV tickers | Regime-artifact + post-hoc rescue banned |
+| D4 | More macro indicators (PCE, ECB, claims) | Multiple-testing fishing; calendar NO_PULSE |
+| D5 | Relative-strength rotation | Probe already sparse / stopped |
+| D6 | LLM sentiment backtest | Not point-in-time reproducible |
+| D7 | Re-open SOL overlay / sentiment-macro | Explicitly superseded at corrected costs |
+
+---
+
+## 3. Ranking
+
+Scored 1–5 on four axes (higher = better for solo operator). **Composite** = product mindset: one weak axis zeros practical value.
+
+| Rank | ID | Space | Accessible now | Cheap falsify | Bank doesn’t cover | Capacity > cost (prior) | Composite verdict |
+|------|-----|-------|----------------|---------------|-------------------|------------------------|-------------------|
+| 1 | **C1** | Illiquid-venue microstructure (Path 2) | 1 (pending infra) | 4 | 5 | 3 (if sub-gates pass) | **Hold** — only high-prior structural story; not runnable |
+| 2 | **A1** | Liquidation / cascade flow | 5 | 5 | 5 | 2 | **Optional falsifier** — cheap closure, low edge prior |
+| 3 | **A2** | OI shock standalone | 5 | 5 | 4 | 2 | Low prior — crowding family failed |
+| 4 | **A3** | Listing events | 5 | 4 | 4 | 1 | Reject — survivorship |
+| 5 | **A4** | Alt funding carry | 5 | 5 | 3 | 1 | Reject — majors BANK generalizes |
+| 6 | **A5** | Mid-cap OFI (Binance) | 5 | 5 | 3 | 1 | Reject — not Path 2; #110 falsifies thesis |
+| 7 | **B1** | L2 imbalance mid-cap | 3 | 4 | 3 | 1 | Reject — same venue |
+| 8 | **A6** | Stablecoin depeg | 4 | 3 | 4 | 1 | Reject — rare + arb bots |
+| 9 | **C2–C6** | Latency / MEV / MM / alt data | 1 | 1–2 | 5 | varies | **Hold** — separate programs |
+| 10 | **D*** | Extensions of banked lanes | 5 | 5 | 1 | 1 | **Reject** — gate-shopping |
+
+---
+
+## 4. Recommendation
+
+### 4.1 Default: **stay banked**
+
+First-principles read of the scoreboard + taxonomy: the failures are **the same fact** from multiple angles. The cost-model error was found and fixed; false positives self-corrected. Further public-data probes on Binance-class surfaces have **negative expected value** — they are the “one more probe” trap the reset rules forbid.
+
+A deployable edge for this operator requires **capacity > operating cost** after realistic fees, forward durability, and #118 null — not a positive backtest. Nothing in Tier A–B clears that bar on priors.
+
+### 4.2 If one cheap probe (closure, not optimism): **A1 only**
+
+| Probe | Run? | Rationale |
+|-------|------|-----------|
+| **A1 — Liquidation / cascade flow** | **Optional** (max 1) | Sole remaining *scheduled* primitive from [research-reset-2026-06-06.md](./research-reset-2026-06-06.md) never executed; thesis ≠ OHLCV; read-only; ~hours not weeks. **Expected verdict: NO_PULSE.** |
+| A2 — OI shock | **No** | Too close to banked funding/crowding NULL family |
+| A4 — Alt carry | **No** | Majors carry BANK; extends “most-arbitraged” not “new primitive” |
+| A5 / B1 — Mid-cap OFI / L2 on Binance | **No** | Contradicts Path 2 definition; #110 already falsified same-venue microstructure |
+
+**A1 probe spec (conceptual, no code):**
+
+- **Universe:** BTC/ETH/SOL perps (frozen — no alt shopping).
+- **Events:** Public force-liquidation prints; cluster definition frozen ex-ante (e.g. ≥$X notional in 5m).
+- **Horizons:** +5m, +30m, +2h (and document if all fail net of ~10 bps taker).
+- **Null:** Phase-randomized event times + block-bootstrap on excess vs matched quiet windows.
+- **Gates:** #118 AND — monotonicity, `p_adj < 0.05`, beats null, concentration ≤ 25%, net edge > 0 after venue RT cost.
+
+### 4.3 Hold (do not probe without prerequisites)
+
+| Item | Action |
+|------|--------|
+| **Path 2 — illiquid venue** | Complete Gate 0: name venue/pair, feasibility table (spread, depth, volume), `PATH2_ILLIQUID_VENUE_ACCESS_ATTESTED`, economic sub-gates 1–4. **Then** Gate-1 OFI on *that* surface only. |
+| Latency / MEV / proprietary data / market-making | Separate deliberate programs; each needs its own Gate 0 brief. Not cheap probes on current stack. |
+
+### 4.4 Reject (do not spend cycles)
+
+- Any **liquid-major OHLCV** lane (overlay, standalone, 4h, MTF, sentiment filter retune).
+- **Mid-cap OFI on Binance** as Path 2 substitute — wrong advantage type.
+- **Alt funding carry** extension — predicted BANK repeat.
+- **Listing / unlock subsetting** — post-hoc rescue trap.
+- **More Polymarket / mNAV / macro indicators** — friction / artifact classes already demonstrated.
+- **Autoresearch / WFO** without new `HAS_PULSE` beating #118 null.
+
+---
+
+## 5. Decision matrix (operator fork)
+
+```
+                    ┌─────────────────────────────────────┐
+                    │  Accept bank (recommended default)   │
+                    │  Idle monitors only; no new lanes    │
+                    └─────────────────────────────────────┘
+                                      │
+              ┌───────────────────────┴───────────────────────┐
+              ▼                                               ▼
+   ┌──────────────────────┐                    ┌──────────────────────────┐
+   │ Optional: A1 liq probe │                    │ Path 2: attest illiquid   │
+   │ (~1 day, expect NULL)  │                    │ venue → Gate 1 on THAT    │
+   │ Closes reset doc loop  │                    │ venue only                │
+   └──────────────────────┘                    └──────────────────────────┘
+```
+
+---
+
+## 6. Reconciliation notes for Claude
+
+1. **Agreement with capstone:** Public-data program terminal; missing ingredient is **differentiated advantage**, not another market.
+2. **Independent addition:** Liquidation cascade is the **only** Tier-A primitive both (a) absent from the scoreboard and (b) named in reset doc — but **low prior**; optional for closure only.
+3. **Disagreement risk:** If another pass ranks **A4 alt carry** or **A5 mid-cap OFI** highly — push back: those are same-venue / same-arbitrage class, not Path 2; priors should be near zero post-#110 and carry BANK.
+4. **Path 2 status:** Ledger shows Gate 0 attestation complete, `OPEN_PENDING_INFRA` — this pass **does not** treat mid-cap Binance as Path 2; that would violate [path2-illiquid-venue-gate0.md](../specs/path2-illiquid-venue-gate0.md) hard stops.
+5. **#118 compliance:** Any future probe must report shuffled/phase-randomized or permuted-feature null, block-bootstrap `p_adj`, and 25% concentration — raw positive means are insufficient.
+
+---
+
+## 7. Bottom line
+
+| Question | Answer |
+|----------|--------|
+| Is there a cheap, accessible, high-prior edge left? | **No** |
+| Is there a cheap probe left at all? | **One optional** (liquidation cascade) for epistemic closure |
+| Is there a durable edge left with positive prior? | **Only behind Path 2 infra** (illiquid venue) or non-public Path 2 items |
+| Recommended action | **Stay banked**; optional A1; hold Path 2 until access attested |
+
+**Nothing cheap left with positive expected deployable edge — stay banked** is the first-principles landing point. The program’s terminal conclusion survives independent scrutiny.

--- a/docs/reports/deep-edge-research-reconciliation-2026-06-24.md
+++ b/docs/reports/deep-edge-research-reconciliation-2026-06-24.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-06-24
 **Inputs:** two independent passes —
-[Claude pass](#claude-pass-summary) (frontier-reframe) and
+[`deep-edge-research-claude-pass.md`](./deep-edge-research-claude-pass.md) (frontier-reframe) and
 [`deep-edge-research-grok-pass.md`](./deep-edge-research-grok-pass.md) (exhaustive-enumeration).
 **Canonical bank:** [research-consolidation-2026-06-23.md](./research-consolidation-2026-06-23.md).
 **Null discipline:** [RBI_AUTORESEARCH_LOOP.md](../RBI_AUTORESEARCH_LOOP.md) §Mandatory baseline (#118).

--- a/docs/reports/deep-edge-research-reconciliation-2026-06-24.md
+++ b/docs/reports/deep-edge-research-reconciliation-2026-06-24.md
@@ -1,0 +1,133 @@
+# Deep Edge Research — Reconciliation (Claude × Grok)
+
+**Date:** 2026-06-24
+**Inputs:** two independent passes —
+[Claude pass](#claude-pass-summary) (frontier-reframe) and
+[`deep-edge-research-grok-pass.md`](./deep-edge-research-grok-pass.md) (exhaustive-enumeration).
+**Canonical bank:** [research-consolidation-2026-06-23.md](./research-consolidation-2026-06-23.md).
+**Null discipline:** [RBI_AUTORESEARCH_LOOP.md](../RBI_AUTORESEARCH_LOOP.md) §Mandatory baseline (#118).
+**Mode:** research only — no code, no probes, no `--execute`, no live-risk change.
+
+---
+
+## Bottom line (converged)
+
+**Stay banked.** Two independent passes — one reasoning from "what population/edge-type does the
+bank *not* cover," one enumerating every candidate space exhaustively — **land on the same place**:
+there is no cheap, accessible, high-prior edge left for a public-data solo operator. The terminal
+conclusion survives independent scrutiny.
+
+Exactly **one** optional cheap probe survives both passes as honest *epistemic closure* (not optimism):
+**A1 — forced-liquidation / cascade flow**, the single public primitive named in the reset doc that was
+never run. Expected verdict **NO_PULSE** (same efficient-venue class that killed OFI). **Path 2
+illiquid-venue** is the only lane with a non-trivial prior, and it is **not runnable** until the
+operator attests venue access + clears the Gate 0 economic sub-gates.
+
+---
+
+## Where the passes converged
+
+| Point | Claude | Grok | Status |
+|---|---|---|---|
+| Public-data prediction on liquid majors is terminal NULL | yes | yes | **Converged** |
+| Missing ingredient is a *differentiated advantage*, not another market/strategy | yes | yes | **Converged** |
+| Path 2 illiquid-venue is the #1 surviving lane, but operator-gated (not runnable now) | "hold B" | "rank 1, hold C1" | **Converged** |
+| Reject all liquid-major / mid-cap-OFI re-probes (#110 decisive) | reject | reject | **Converged** |
+| Any future probe must beat the #118 null (shuffled/phase-randomized, block-bootstrap p_adj, ≤25% conc) | yes | yes | **Converged** |
+| Default action | (frontier, see below) | **stay banked** | **Converged after adjudication** |
+
+## Where they diverged — and the adjudication
+
+Claude's pass proposed two *cheap public-data* probes targeting the "illiquid/new population" gap.
+Grok's pass independently **pre-rejected both**. On scrutiny, **Grok is right on both** — they fold:
+
+| Claude proposed | Grok's counter | Adjudication |
+|---|---|---|
+| **A — new-listing microstructure** (first ~72h of new listings; "thin book, not yet MM-saturated") | A3: reject — survivorship/look-ahead, thin n, one-off events | **Folds → reject.** Decisive added reason: new listings are among the *most bot-contested* events in crypto (sniping is a latency game). "New" ≠ "uncrowded" here — the residual edge is a **latency business (C-tier)**, not a cheap retail probe. Claude underweighted this. |
+| **E — small/new-perp funding dislocation** ("violent funding because hard to arb") | A4: reject — majors carry already BANK generalizes; alts add a negative-funding tail + venue risk; capacity tiny | **Folds → reject.** The high gross carry on alt perps is *compensation for real frictions* (borrow, custody, thin spot), so excess-after-honest-cost is expected ≤0 — the same "most-arbitraged given frictions" class, and arguably **worse** than majors carry (which Claude's own open question #3 anticipated). Closest call, but a strong prior + an extra kill risk ⇒ not worth the spend. |
+
+**Net:** Claude's *reframe* (look at the illiquid/new population) was directionally correct, but its two
+cheap expressions both collapse under first-principles scrutiny — and they collapse **back onto Path 2
+illiquid-venue (C1)**, which is exactly where Grok ranked #1. The reframe does **not** open a new cheap
+lane; it re-derives the one operator-gated lane both passes already hold.
+
+## One substantive addition Claude's pass contributes (not in Grok's)
+
+Grok's taxonomy is **entirely prediction/arbitrage** edge. It has no category for **non-prediction
+access / structural edge**, where for a small operator **size *is* the edge** — flows a whale cannot
+harvest without diluting them: airdrop/points farming, restaking/staking yield, launchpad/IEO
+allocations, new-listing *funding* capture at the venue level.
+
+This is a **real, durable edge source for this operator** and is genuinely *not covered* by the bank
+(which only ever tested prediction/arb edge). But it is **not a `src/strategy` engine lane** — it's an
+**operations track** (manual or lightly-scripted, account-level, capacity-capped by design). Recording
+it honestly: it belongs on the operator's roadmap as a non-engine edge, not in the RBI loop. It does
+**not** change the trading-engine verdict (stay banked).
+
+---
+
+## Converged recommendation
+
+1. **Default — accept the bank.** Idle monitors only; open no new public-data engine lanes. Both
+   passes agree the expected value of further Binance-class probes is ≤0 (the "one more probe" trap the
+   reset rules forbid).
+2. **Optional, max one — A1 liquidation/cascade probe**, *only* if the operator wants to convert
+   "reasoned dead" → "measured dead" and close the reset-doc loop. It is the single unprobed public
+   primitive; read-only; ~hours; **expected NO_PULSE**. Frozen spec (no alt-shopping): BTC/ETH/SOL
+   perps, `!forceOrder@arr` clusters defined ex-ante, horizons +5m/+30m/+2h, #118 null
+   (phase-randomized event times + block-bootstrap on excess vs matched quiet windows), net of ~10 bps
+   taker. If it pulses it's a genuine surprise worth chasing; if not, the public-data book is sealed.
+3. **Hold — Path 2 illiquid-venue.** Operator names venue/pair + feasibility table (spread, depth,
+   volume) + economic sub-gates 1–4, sets `PATH2_ILLIQUID_VENUE_ACCESS_ATTESTED`; *then* Gate-1 OFI on
+   that surface only. Both passes rank this #1; neither can run it without the operator's real-world input.
+4. **Record (non-engine) — access/structural "size-is-edge" track.** Roadmap item for the operator
+   (airdrops/points/launchpad/listing-funding), not an RBI lane. Claude's addition; out of engine scope.
+5. **Reject without probe** — any liquid-major lane, mid-cap Binance OFI as a Path-2 substitute, alt
+   funding carry, listing/unlock subsetting, more Polymarket/mNAV/macro, autoresearch/WFO without a new
+   #118-beating `HAS_PULSE`.
+
+## The fork for the operator
+
+```
+                 Accept bank  (recommended default)
+                        |
+        ┌───────────────┴───────────────┐
+        ▼                               ▼
+  Optional: A1 liquidation        Path 2: attest illiquid venue
+  probe (~hours, expect NULL)     → Gate 1 on THAT venue only
+  → seals public-data book        → only lane with a real prior
+```
+
+---
+
+## Claude pass — summary (for the record)
+
+Reframe: the bank covers **prediction edge on liquid majors**; two spaces it never tested are a
+**different population** (illiquid/new) and a **different edge type** (access/structural, size-is-edge).
+Proposed cheap probes A (new-listing microstructure) + E (small-perp funding) — **both folded on
+reconciliation** (see adjudication). Held Path 2; flagged the access-edge track. Net: converges to Grok.
+
+## Disposition
+
+- **Converged verdict:** stay banked; A1 optional for closure; Path 2 held; access-track recorded.
+- **Independence held:** Grok did not read Claude's pass; the agreement is genuine, and the one
+  divergence (Claude's cheap picks) was adjudicated *against* Claude on the merits.
+- **No code, no probe, no execute** was run for this reconciliation.
+
+---
+
+## A1 measured (2026-06-24)
+
+**Ran:** `scripts/probe_liquidation_cascade.py` — report
+[`liquidation-cascade-probe-v0.md`](./liquidation-cascade-probe-v0.md).
+
+| Item | Result |
+|------|--------|
+| REST `allForceOrders` | Deprecated (`400` out of maintenance) |
+| Historical panel | Official UM **metrics** cascade-proxy (OI drop + taker imbalance), 14d, BTC/ETH/SOL |
+| Events | 50 / 50 / 86 per symbol |
+| Verdict | **WEAK_EDGE** → economically **NO_PULSE** (no cell clears 10bps RT + Holm `p_adj` + breadth) |
+| Best net | BTC +0.44bps, ETH +0.69bps @ +120m fade — inside noise, bootstrap `p_adj≈1` |
+
+**Public-data book sealed.** The last reset-doc primitive is measured dead; bank stands. Path 2
+remains the only revival path with a non-trivial prior.

--- a/docs/reports/liquidation-cascade-probe-v0.md
+++ b/docs/reports/liquidation-cascade-probe-v0.md
@@ -1,0 +1,62 @@
+# Forced Liquidation / Cascade Flow Probe — Report
+
+**Verdict:** **WEAK_EDGE**
+**Date:** 2026-06-24
+**Script:** `scripts/probe_liquidation_cascade.py`
+**Spec:** [liquidation-cascade-probe-v0.md](../specs/liquidation-cascade-probe-v0.md)
+
+**Window:** 2026-06-08 → 2026-06-22 (UTC)
+
+## STEP 0 — Data audit
+
+- REST `allForceOrders`: HTTP 400: {"code":400,"msg":"The endpoint has been out of maintenance"}
+- WebSocket path: `wss://fstream.binance.com/market/ws/<symbol>@forceOrder`
+- UM metrics days loaded: 14
+- Force orders collected (this run): 0
+- Force orders cached (loaded): 0
+- Events per symbol: {'BTCUSDT': 50, 'ETHUSDT': 50, 'SOLUSDT': 86}
+
+## Frozen cascade-proxy definition
+
+- OI drop ≤ -0.15% (5m)
+- Long-cascade: taker ratio ≤ 0.55
+- Short-cascade: taker ratio ≥ 1.8
+- Dedup gap: 30m
+
+## Results by symbol
+
+### BTCUSDT (50 events)
+| Horizon | Orient | Excess bps | Net bps | p_adj | beats null | conc | pass |
+|---------|--------|----------:|--------:|------:|:----------:|:----:|:----:|
+| +5m | fade | +4.04 | -5.96 | 1.000 | Y | 20% | n |
+| +5m | continuation | -0.47 | -10.47 | 1.000 | n | 20% | n |
+| +30m | fade | +3.82 | -6.18 | 1.000 | Y | 18% | n |
+| +30m | continuation | +1.20 | -8.80 | 1.000 | n | 18% | n |
+| +120m | fade | +10.44 | +0.44 | 1.000 | Y | 16% | n |
+| +120m | continuation | -0.32 | -10.32 | 1.000 | n | 16% | n |
+
+### ETHUSDT (50 events)
+| Horizon | Orient | Excess bps | Net bps | p_adj | beats null | conc | pass |
+|---------|--------|----------:|--------:|------:|:----------:|:----:|:----:|
+| +5m | fade | -2.66 | -12.66 | 1.000 | n | 20% | n |
+| +5m | continuation | +0.02 | -9.98 | 1.000 | Y | 20% | n |
+| +30m | fade | -1.18 | -11.18 | 1.000 | Y | 17% | n |
+| +30m | continuation | -5.02 | -15.02 | 1.000 | n | 17% | n |
+| +120m | fade | +10.69 | +0.69 | 1.000 | Y | 19% | n |
+| +120m | continuation | +7.85 | -2.15 | 1.000 | n | 19% | n |
+
+### SOLUSDT (86 events)
+| Horizon | Orient | Excess bps | Net bps | p_adj | beats null | conc | pass |
+|---------|--------|----------:|--------:|------:|:----------:|:----:|:----:|
+| +5m | fade | +0.44 | -9.56 | 1.000 | Y | 18% | n |
+| +5m | continuation | -5.89 | -15.89 | 1.000 | n | 18% | n |
+| +30m | fade | -7.75 | -17.75 | 1.000 | Y | 15% | n |
+| +30m | continuation | -17.15 | -27.15 | 1.000 | n | 15% | n |
+| +120m | fade | -16.67 | -26.67 | 1.000 | Y | 16% | n |
+| +120m | continuation | -35.03 | -45.03 | 1.000 | n | 16% | n |
+
+## Verdict rationale
+- BTCUSDT: best net edge +0.44bps (RT cost 10.0bps)
+- ETHUSDT: best net edge +0.69bps (RT cost 10.0bps)
+- SOLUSDT: best net edge -9.56bps (RT cost 10.0bps)
+- no horizon/orientation clears Holm-adjusted bootstrap + breadth + cost gates

--- a/docs/specs/liquidation-cascade-probe-v0.md
+++ b/docs/specs/liquidation-cascade-probe-v0.md
@@ -1,0 +1,68 @@
+# Lane Brief — Forced Liquidation / Cascade Flow Probe v0 (Gate 1, A1)
+
+**Status:** Gate 1 cheap probe (A1 epistemic closure).
+**Context:** [deep-edge-research-reconciliation-2026-06-24.md](../reports/deep-edge-research-reconciliation-2026-06-24.md).
+**Script:** `scripts/probe_liquidation_cascade.py`.
+
+---
+
+## Why this lane
+
+The bank closed OHLCV structure, OFI microstructure (#110), and cross-venue dislocation. The reset doc
+listed **order book / liquidation data** as the remaining public primitive; liquidations were never probed.
+Thesis: **mechanical forced liquidation** creates short-horizon price pressure distinct from chart patterns.
+
+## Data reality (Step 0)
+
+| Source | Status |
+|--------|--------|
+| `GET /fapi/v1/allForceOrders` | **Deprecated** (`400` out of maintenance) |
+| `data.binance.vision` force-order archives | **Not published** |
+| WebSocket `<symbol>@forceOrder` / `!forceOrder@arr` | **Live only** (`wss://fstream.binance.com/market/ws/…`) |
+| UM **metrics** (OI + taker ratio, 5m) | **Historical** via data.binance.vision |
+
+When REST force-order history is unavailable, v0 uses **official UM metrics** to define frozen
+**cascade-proxy events** (OI drop + extreme taker imbalance). WebSocket force orders are collected when
+present and reported separately; the primary historical panel uses metrics (documented in report).
+
+## Frozen universe
+
+- Symbols: **BTCUSDT, ETHUSDT, SOLUSDT** (UM perps).
+- Window: **14 days**, default ending T−2 UTC (aligns with OFI probe discipline).
+- Horizons: **+5m, +30m, +120m** (1m klines, strictly after event time).
+- Round-trip cost: **10 bps** taker (same as #110).
+
+## Frozen cascade-proxy event (metrics)
+
+Per 5m metrics row (ex-ante, no post-hoc tuning):
+
+- `oi_change_pct` = Δ `sum_open_interest` vs previous 5m bucket, as % of prior OI.
+- **Long-cascade event:** `oi_change_pct ≤ −0.15%` AND `sum_taker_long_short_vol_ratio ≤ 0.55`.
+- **Short-cascade event:** `oi_change_pct ≤ −0.15%` AND `sum_taker_long_short_vol_ratio ≥ 1.80`.
+- Deduplicate: minimum **30 minutes** between events per symbol (keep larger |oi_change|).
+
+## Hypotheses (report separately)
+
+- **H1a (fade):** after long-cascade (sell pressure), forward return **positive** (buy the flush).
+- **H1b (continuation):** after long-cascade, forward return **negative** (more selling).
+- Gate uses the **stronger** orientated edge per horizon if it clears cost + null.
+
+## Gate 1 / #118 null
+
+Every verdict requires **all** of:
+
+1. **Null:** phase-randomized event timestamps (preserve hour-of-day marginal), block-bootstrap
+   `p_adj < 0.05` on oriented excess vs matched quiet windows.
+2. **Beats null:** real oriented excess > null median excess.
+3. **Concentration:** no single UTC day > **25%** of total oriented edge.
+4. **Cost:** net edge > **0** after 10 bps RT.
+5. **Breadth:** same oriented relationship on **≥ 2 / 3** symbols at one horizon (Holm-corrected across
+   3 horizons × 2 orientations).
+
+`HAS_PULSE` = all gates pass. Else `NO_PULSE`. `BLOCKED_ON_DATA` only if metrics + klines cannot be loaded.
+
+## Hard stops
+
+- No liquid-major OHLCV lane reopening.
+- No alt-symbol shopping after null.
+- No autoresearch / `--execute` / live-risk change from this probe.

--- a/research/rbi_loop/liquidation-cascade-v0/probe-verdict.json
+++ b/research/rbi_loop/liquidation-cascade-v0/probe-verdict.json
@@ -1,0 +1,31 @@
+{
+  "verdict": "WEAK_EDGE",
+  "window_start": "2026-06-08T00:00:00+00:00",
+  "window_end": "2026-06-22T00:00:00+00:00",
+  "data_audit": {
+    "rest_all_force_orders": "HTTP 400: {\"code\":400,\"msg\":\"The endpoint has been out of maintenance\"}",
+    "websocket_path": "wss://fstream.binance.com/market/ws/<symbol>@forceOrder",
+    "metrics_days_loaded": 14,
+    "force_orders_collected": 0,
+    "force_orders_cached": 0,
+    "events_per_symbol": {
+      "BTCUSDT": 50,
+      "ETHUSDT": 50,
+      "SOLUSDT": 86
+    },
+    "blocked": false,
+    "blocked_reason": null
+  },
+  "events_per_symbol": {
+    "BTCUSDT": 50,
+    "ETHUSDT": 50,
+    "SOLUSDT": 86
+  },
+  "reasons": [
+    "BTCUSDT: best net edge +0.44bps (RT cost 10.0bps)",
+    "ETHUSDT: best net edge +0.69bps (RT cost 10.0bps)",
+    "SOLUSDT: best net edge -9.56bps (RT cost 10.0bps)",
+    "no horizon/orientation clears Holm-adjusted bootstrap + breadth + cost gates"
+  ],
+  "best_horizon": null
+}

--- a/scripts/probe_liquidation_cascade.py
+++ b/scripts/probe_liquidation_cascade.py
@@ -1,0 +1,966 @@
+#!/usr/bin/env python3
+"""Gate-1 cheap probe: forced liquidation / cascade flow (A1).
+
+STEP 0: data audit — REST allForceOrders (deprecated), websocket forceOrder, UM metrics.
+STEP 1: frozen cascade-proxy events from official UM metrics; forward returns from 1m klines;
+#118 null (phase-randomized timestamps + block bootstrap), concentration, cost gate.
+
+See docs/specs/liquidation-cascade-probe-v0.md.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import csv
+import io
+import json
+import random
+import statistics
+import sys
+import time
+import zipfile
+from collections.abc import Sequence
+from dataclasses import asdict, dataclass
+from datetime import UTC, date, datetime, timedelta
+from pathlib import Path
+
+import aiohttp
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from src.utils.logger import configure_logger, get_logger
+
+FAPI_BASE = "https://fapi.binance.com"
+VISION_BASE = "https://data.binance.vision/data/futures/um/daily"
+WS_MARKET_BASE = "wss://fstream.binance.com/market/ws"
+
+BLOCKED_ON_DATA = "BLOCKED_ON_DATA"
+HAS_PULSE = "HAS_PULSE"
+WEAK_EDGE = "WEAK_EDGE"
+NO_PULSE = "NO_PULSE"
+
+DEFAULT_SYMBOLS = ("BTCUSDT", "ETHUSDT", "SOLUSDT")
+HORIZONS_MIN = (5, 30, 120)
+TAKER_RT_BPS = 10.0
+OI_DROP_PCT = -0.15
+TAKER_LONG_CASCADE = 0.55
+TAKER_SHORT_CASCADE = 1.80
+EVENT_GAP_MIN = 30
+MIN_EVENTS_PER_SYMBOL = 8
+MIN_SYMBOLS_PASS = 2
+BOOTSTRAP_RESAMPLES = 1000
+ALPHA = 0.05
+CONCENTRATION_CAP = 0.25
+QUIET_EXCLUSION_MIN = 60
+RANDOM_SEED = 42
+
+ALL_FORCE_ORDERS_URL = f"{FAPI_BASE}/fapi/v1/allForceOrders"
+KLINES_URL = f"{FAPI_BASE}/fapi/v1/klines"
+
+
+@dataclass(frozen=True)
+class ProbeConfig:
+    symbols: tuple[str, ...]
+    window_days: int
+    end_lag_days: int
+    horizons_min: tuple[int, ...]
+    taker_rt_bps: float
+    oi_drop_pct: float
+    taker_long_cascade: float
+    taker_short_cascade: float
+    event_gap_min: int
+    min_events_per_symbol: int
+    min_symbols_pass: int
+    bootstrap_resamples: int
+    collect_seconds: int
+    cache_dir: Path
+    seed: int
+
+
+@dataclass(frozen=True)
+class MetricsRow:
+    time: datetime
+    symbol: str
+    open_interest: float
+    oi_value: float
+    taker_ratio: float
+
+
+@dataclass(frozen=True)
+class CascadeEvent:
+    symbol: str
+    time: datetime
+    side: str  # LONG_CASCADE (sell pressure) or SHORT_CASCADE
+    oi_change_pct: float
+    taker_ratio: float
+    source: str
+
+
+@dataclass(frozen=True)
+class MinuteBar:
+    time: datetime
+    close: float
+
+
+@dataclass(frozen=True)
+class HorizonResult:
+    horizon_min: int
+    orientation: str
+    event_count: int
+    mean_oriented_bps: float
+    baseline_bps: float
+    excess_bps: float
+    net_edge_bps: float
+    null_median_excess_bps: float
+    beats_null: bool
+    bootstrap_p: float
+    bootstrap_p_adj: float
+    max_day_concentration: float
+    concentration_ok: bool
+    symbols_passing: int
+    gate_pass: bool
+
+
+@dataclass(frozen=True)
+class SymbolResult:
+    symbol: str
+    event_count: int
+    horizons: tuple[HorizonResult, ...]
+
+
+@dataclass(frozen=True)
+class DataAudit:
+    rest_all_force_orders: str
+    websocket_path: str
+    metrics_days_loaded: int
+    force_orders_collected: int
+    force_orders_cached: int
+    events_per_symbol: dict[str, int]
+    blocked: bool
+    blocked_reason: str | None
+
+
+@dataclass(frozen=True)
+class ProbeReport:
+    config: ProbeConfig
+    window_start: datetime
+    window_end: datetime
+    data_audit: DataAudit
+    events: tuple[CascadeEvent, ...]
+    symbol_results: tuple[SymbolResult, ...]
+    best_horizon: HorizonResult | None
+    verdict: str
+    reasons: tuple[str, ...]
+
+
+def default_config() -> ProbeConfig:
+    return ProbeConfig(
+        symbols=DEFAULT_SYMBOLS,
+        window_days=14,
+        end_lag_days=2,
+        horizons_min=HORIZONS_MIN,
+        taker_rt_bps=TAKER_RT_BPS,
+        oi_drop_pct=OI_DROP_PCT,
+        taker_long_cascade=TAKER_LONG_CASCADE,
+        taker_short_cascade=TAKER_SHORT_CASCADE,
+        event_gap_min=EVENT_GAP_MIN,
+        min_events_per_symbol=MIN_EVENTS_PER_SYMBOL,
+        min_symbols_pass=MIN_SYMBOLS_PASS,
+        bootstrap_resamples=BOOTSTRAP_RESAMPLES,
+        collect_seconds=0,
+        cache_dir=Path("data/liquidation_cascade"),
+        seed=RANDOM_SEED,
+    )
+
+
+def _parse_metrics_time(raw: str) -> datetime:
+    parsed = datetime.strptime(raw.strip(), "%Y-%m-%d %H:%M:%S")
+    return parsed.replace(tzinfo=UTC)
+
+
+def _daterange(start: date, end: date) -> list[date]:
+    days: list[date] = []
+    cur = start
+    while cur <= end:
+        days.append(cur)
+        cur += timedelta(days=1)
+    return days
+
+
+async def audit_rest_force_orders(session: aiohttp.ClientSession) -> str:
+    params = {"symbol": "BTCUSDT", "limit": 5}
+    try:
+        async with session.get(ALL_FORCE_ORDERS_URL, params=params) as resp:
+            body = await resp.text()
+            if resp.status == 200:
+                return "OK"
+            return f"HTTP {resp.status}: {body[:120]}"
+    except aiohttp.ClientError as exc:
+        return f"error: {exc}"
+
+
+async def download_metrics_day(
+    session: aiohttp.ClientSession,
+    symbol: str,
+    day: date,
+) -> list[MetricsRow]:
+    url = f"{VISION_BASE}/metrics/{symbol}/{symbol}-metrics-{day.isoformat()}.zip"
+    async with session.get(url) as resp:
+        if resp.status != 200:
+            return []
+        payload = await resp.read()
+    rows: list[MetricsRow] = []
+    with zipfile.ZipFile(io.BytesIO(payload)) as zf:
+        name = next(iter(zf.namelist()))
+        with zf.open(name) as handle:
+            text = io.TextIOWrapper(handle, encoding="utf-8")
+            reader = csv.DictReader(text)
+            for row in reader:
+                rows.append(
+                    MetricsRow(
+                        time=_parse_metrics_time(row["create_time"]),
+                        symbol=row["symbol"],
+                        open_interest=float(row["sum_open_interest"]),
+                        oi_value=float(row["sum_open_interest_value"]),
+                        taker_ratio=float(row["sum_taker_long_short_vol_ratio"]),
+                    )
+                )
+    return rows
+
+
+def detect_cascade_events(
+    metrics: Sequence[MetricsRow],
+    config: ProbeConfig,
+) -> list[CascadeEvent]:
+    if len(metrics) < 2:
+        return []
+    sorted_rows = sorted(metrics, key=lambda r: r.time)
+    raw: list[CascadeEvent] = []
+    for prev, cur in zip(sorted_rows, sorted_rows[1:], strict=False):
+        if prev.open_interest <= 0:
+            continue
+        oi_chg_pct = (cur.open_interest - prev.open_interest) / prev.open_interest * 100.0
+        if oi_chg_pct > config.oi_drop_pct:
+            continue
+        side: str | None = None
+        if cur.taker_ratio <= config.taker_long_cascade:
+            side = "LONG_CASCADE"
+        elif cur.taker_ratio >= config.taker_short_cascade:
+            side = "SHORT_CASCADE"
+        if side is None:
+            continue
+        raw.append(
+            CascadeEvent(
+                symbol=cur.symbol,
+                time=cur.time,
+                side=side,
+                oi_change_pct=oi_chg_pct,
+                taker_ratio=cur.taker_ratio,
+                source="um_metrics_proxy",
+            )
+        )
+    raw.sort(key=lambda e: e.time)
+    deduped: list[CascadeEvent] = []
+    last_by_symbol: dict[str, datetime] = {}
+    for event in raw:
+        last = last_by_symbol.get(event.symbol)
+        if last is not None and (event.time - last) < timedelta(minutes=config.event_gap_min):
+            if deduped and deduped[-1].symbol == event.symbol:
+                if abs(event.oi_change_pct) > abs(deduped[-1].oi_change_pct):
+                    deduped[-1] = event
+                last_by_symbol[event.symbol] = deduped[-1].time
+            continue
+        deduped.append(event)
+        last_by_symbol[event.symbol] = event.time
+    return deduped
+
+
+async def collect_force_orders_ws(
+    symbols: Sequence[str],
+    seconds: int,
+    cache_dir: Path,
+) -> int:
+    if seconds <= 0:
+        return 0
+    try:
+        import websockets
+    except ImportError:
+        return 0
+
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    streams = "/".join(f"{s.lower()}@forceOrder" for s in symbols)
+    url = f"{WS_MARKET_BASE}/{streams}"
+    collected = 0
+    deadline = time.time() + seconds
+    handles = {
+        sym: (cache_dir / f"force_orders_{sym}.jsonl").open("a", encoding="utf-8")
+        for sym in symbols
+    }
+    try:
+        async with websockets.connect(url, ping_interval=20) as ws:
+            while time.time() < deadline:
+                try:
+                    msg = await asyncio.wait_for(
+                        ws.recv(), timeout=min(5.0, deadline - time.time())
+                    )
+                except TimeoutError:
+                    continue
+                payload = json.loads(msg)
+                if payload.get("e") != "forceOrder":
+                    continue
+                order = payload.get("o") or {}
+                sym = str(order.get("s", "")).upper()
+                if sym not in handles:
+                    continue
+                handles[sym].write(json.dumps(payload) + "\n")
+                collected += 1
+    finally:
+        for handle in handles.values():
+            handle.close()
+    return collected
+
+
+def load_cached_force_orders(cache_dir: Path, symbols: Sequence[str]) -> list[CascadeEvent]:
+    events: list[CascadeEvent] = []
+    for symbol in symbols:
+        path = cache_dir / f"force_orders_{symbol}.jsonl"
+        if not path.exists():
+            continue
+        for line in path.read_text(encoding="utf-8").splitlines():
+            if not line.strip():
+                continue
+            payload = json.loads(line)
+            order = payload.get("o") or {}
+            side_raw = str(order.get("S", "")).upper()
+            side = "LONG_CASCADE" if side_raw == "SELL" else "SHORT_CASCADE"
+            ts_ms = int(order.get("T") or payload.get("E") or 0)
+            if ts_ms <= 0:
+                continue
+            events.append(
+                CascadeEvent(
+                    symbol=symbol,
+                    time=datetime.fromtimestamp(ts_ms / 1000.0, tz=UTC),
+                    side=side,
+                    oi_change_pct=0.0,
+                    taker_ratio=0.0,
+                    source="websocket_force_order",
+                )
+            )
+    return sorted(events, key=lambda e: e.time)
+
+
+async def fetch_klines_1m(
+    session: aiohttp.ClientSession,
+    symbol: str,
+    start: datetime,
+    end: datetime,
+) -> list[MinuteBar]:
+    bars: list[MinuteBar] = []
+    start_ms = int(start.timestamp() * 1000)
+    end_ms = int(end.timestamp() * 1000)
+    cursor = start_ms
+    while cursor < end_ms:
+        params = {
+            "symbol": symbol,
+            "interval": "1m",
+            "startTime": cursor,
+            "endTime": end_ms,
+            "limit": 1500,
+        }
+        async with session.get(KLINES_URL, params=params) as resp:
+            if resp.status != 200:
+                break
+            chunk = await resp.json()
+        if not chunk:
+            break
+        for row in chunk:
+            open_ms = int(row[0])
+            close_px = float(row[4])
+            bars.append(
+                MinuteBar(
+                    time=datetime.fromtimestamp(open_ms / 1000.0, tz=UTC),
+                    close=close_px,
+                )
+            )
+        last_open = int(chunk[-1][0])
+        next_cursor = last_open + 60_000
+        if next_cursor <= cursor:
+            break
+        cursor = next_cursor
+        await asyncio.sleep(0.05)
+    return bars
+
+
+def _forward_return_bps(
+    bars: Sequence[MinuteBar], event_time: datetime, horizon_min: int
+) -> float | None:
+    if not bars:
+        return None
+    times = [b.time for b in bars]
+    try:
+        idx = times.index(event_time)
+    except ValueError:
+        idx = min(range(len(times)), key=lambda i: abs((times[i] - event_time).total_seconds()))
+    end_idx = idx + horizon_min
+    if end_idx >= len(bars):
+        return None
+    p0 = bars[idx].close
+    p1 = bars[end_idx].close
+    if p0 <= 0:
+        return None
+    return (p1 / p0 - 1.0) * 10_000.0
+
+
+def _oriented_return(side: str, orientation: str, raw_bps: float) -> float:
+    if side == "LONG_CASCADE":
+        return raw_bps if orientation == "fade" else -raw_bps
+    return -raw_bps if orientation == "fade" else raw_bps
+
+
+def _matched_baseline_returns(
+    bars: Sequence[MinuteBar],
+    events: Sequence[CascadeEvent],
+    horizon_min: int,
+    *,
+    seed: int,
+) -> list[float]:
+    if len(bars) <= horizon_min + 1:
+        return []
+    event_times = {e.time for e in events}
+    candidates = [
+        b.time
+        for b in bars[:-horizon_min]
+        if b.time not in event_times
+        and all(
+            abs((b.time - et).total_seconds()) >= QUIET_EXCLUSION_MIN * 60 for et in event_times
+        )
+    ]
+    if not candidates:
+        return []
+    rng = random.Random(seed)
+    sample_times = rng.sample(candidates, k=min(len(candidates), max(len(events), 20)))
+    out: list[float] = []
+    for ts in sample_times:
+        ret = _forward_return_bps(bars, ts, horizon_min)
+        if ret is not None:
+            out.append(ret)
+    return out
+
+
+def _day_concentration(oriented_edges: Sequence[tuple[datetime, float]]) -> float:
+    if not oriented_edges:
+        return 0.0
+    by_day: dict[str, float] = {}
+    for ts, edge in oriented_edges:
+        day = ts.date().isoformat()
+        by_day[day] = by_day.get(day, 0.0) + abs(edge)
+    total = sum(by_day.values())
+    if total <= 0:
+        return 0.0
+    return max(by_day.values()) / total
+
+
+def _phase_randomized_null_excess(
+    events: Sequence[CascadeEvent],
+    bars: Sequence[MinuteBar],
+    horizon_min: int,
+    orientation: str,
+    *,
+    seed: int,
+    resamples: int,
+) -> tuple[float, float]:
+    if not events or not bars:
+        return 0.0, 0.0
+    real_oriented = [
+        _oriented_return(e.side, orientation, r)
+        for e in events
+        if (r := _forward_return_bps(bars, e.time, horizon_min)) is not None
+    ]
+    if not real_oriented:
+        return 0.0, 0.0
+    real_mean = statistics.mean(real_oriented)
+    baseline = _matched_baseline_returns(bars, events, horizon_min, seed=seed)
+    base_mean = statistics.mean(baseline) if baseline else 0.0
+    real_excess = real_mean - base_mean
+
+    candidate_times = [b.time for b in bars[:-horizon_min]]
+    if len(candidate_times) < len(events):
+        return real_excess, 1.0
+
+    rng = random.Random(seed + horizon_min)
+    null_excesses: list[float] = []
+    for _ in range(resamples):
+        shuffled = rng.sample(candidate_times, k=len(events))
+        pseudo = [
+            _oriented_return(events[i].side, orientation, r)
+            for i, ts in enumerate(shuffled)
+            if (r := _forward_return_bps(bars, ts, horizon_min)) is not None
+        ]
+        if not pseudo:
+            continue
+        null_excesses.append(statistics.mean(pseudo) - base_mean)
+    if not null_excesses:
+        return real_excess, 1.0
+    null_median = statistics.median(null_excesses)
+    count_ge = sum(1 for x in null_excesses if x >= real_excess)
+    p_null = (count_ge + 1) / (len(null_excesses) + 1)
+    return null_median, p_null
+
+
+def _block_bootstrap_p(
+    events: Sequence[CascadeEvent],
+    bars: Sequence[MinuteBar],
+    horizon_min: int,
+    orientation: str,
+    baseline_mean: float,
+    *,
+    seed: int,
+    resamples: int,
+) -> float:
+    pairs = [
+        (e, _oriented_return(e.side, orientation, r))
+        for e in events
+        if (r := _forward_return_bps(bars, e.time, horizon_min)) is not None
+    ]
+    if len(pairs) < 4:
+        return 1.0
+    observed = statistics.mean(v for _, v in pairs) - baseline_mean
+    by_day: dict[str, list[tuple[CascadeEvent, float]]] = {}
+    for event, val in pairs:
+        by_day.setdefault(event.time.date().isoformat(), []).append((event, val))
+    days = sorted(by_day)
+    if not days:
+        return 1.0
+    rng = random.Random(seed + horizon_min * 17)
+    count_le = 0
+    for _ in range(resamples):
+        sample: list[float] = []
+        for _day in range(len(days)):
+            bucket = by_day[rng.choice(days)]
+            sample.extend(v for _, v in bucket)
+        if len(sample) < 4:
+            continue
+        if statistics.mean(sample) - baseline_mean <= observed:
+            count_le += 1
+    return (count_le + 1) / (resamples + 1)
+
+
+def holm_adjust(p_values: Sequence[float]) -> list[float]:
+    indexed = sorted(enumerate(p_values), key=lambda x: x[1])
+    m = len(p_values)
+    adjusted = [1.0] * m
+    prev = 0.0
+    for rank, (idx, p) in enumerate(indexed, start=1):
+        adj = min(1.0, p * (m - rank + 1))
+        adj = max(adj, prev)
+        prev = adj
+        adjusted[idx] = adj
+    return adjusted
+
+
+def analyze_symbol(
+    symbol: str,
+    events: Sequence[CascadeEvent],
+    bars: Sequence[MinuteBar],
+    config: ProbeConfig,
+) -> SymbolResult:
+    sym_events = [e for e in events if e.symbol == symbol]
+    horizon_rows: list[HorizonResult] = []
+    for horizon in config.horizons_min:
+        for orientation in ("fade", "continuation"):
+            oriented_edges: list[tuple[datetime, float]] = []
+            raw_returns: list[float] = []
+            for event in sym_events:
+                raw = _forward_return_bps(bars, event.time, horizon)
+                if raw is None:
+                    continue
+                raw_returns.append(raw)
+                oriented_edges.append((event.time, _oriented_return(event.side, orientation, raw)))
+            if not oriented_edges:
+                continue
+            mean_oriented = statistics.mean(v for _, v in oriented_edges)
+            baseline = _matched_baseline_returns(bars, sym_events, horizon, seed=config.seed)
+            baseline_mean = statistics.mean(baseline) if baseline else 0.0
+            excess = mean_oriented - baseline_mean
+            net_edge = excess - config.taker_rt_bps
+            null_median, p_null = _phase_randomized_null_excess(
+                sym_events,
+                bars,
+                horizon,
+                orientation,
+                seed=config.seed,
+                resamples=500,
+            )
+            beats_null = excess > null_median
+            p_boot = _block_bootstrap_p(
+                sym_events,
+                bars,
+                horizon,
+                orientation,
+                baseline_mean,
+                seed=config.seed,
+                resamples=config.bootstrap_resamples,
+            )
+            conc = _day_concentration(oriented_edges)
+            conc_ok = conc <= CONCENTRATION_CAP
+            gate = (
+                net_edge > 0
+                and beats_null
+                and p_boot < ALPHA
+                and conc_ok
+                and len(sym_events) >= config.min_events_per_symbol
+            )
+            horizon_rows.append(
+                HorizonResult(
+                    horizon_min=horizon,
+                    orientation=orientation,
+                    event_count=len(sym_events),
+                    mean_oriented_bps=mean_oriented,
+                    baseline_bps=baseline_mean,
+                    excess_bps=excess,
+                    net_edge_bps=net_edge,
+                    null_median_excess_bps=null_median,
+                    beats_null=beats_null,
+                    bootstrap_p=p_boot,
+                    bootstrap_p_adj=p_boot,
+                    max_day_concentration=conc,
+                    concentration_ok=conc_ok,
+                    symbols_passing=0,
+                    gate_pass=gate,
+                )
+            )
+    return SymbolResult(symbol=symbol, event_count=len(sym_events), horizons=tuple(horizon_rows))
+
+
+def apply_holm_and_pick_best(
+    symbol_results: Sequence[SymbolResult],
+    config: ProbeConfig,
+) -> tuple[list[SymbolResult], HorizonResult | None]:
+    updated_results: list[SymbolResult] = []
+    best_pass: HorizonResult | None = None
+
+    for sym_result in symbol_results:
+        new_horizons: list[HorizonResult] = []
+        for h in sym_result.horizons:
+            peer_rows = [
+                (other.symbol, oh)
+                for other in symbol_results
+                for oh in other.horizons
+                if oh.horizon_min == h.horizon_min and oh.orientation == h.orientation
+            ]
+            peer_stats = [oh for _, oh in peer_rows]
+            adjusted = holm_adjust([p.bootstrap_p for p in peer_stats])
+            peer_index = next(
+                i for i, (sym, oh) in enumerate(peer_rows) if sym == sym_result.symbol and oh is h
+            )
+            p_adj = adjusted[peer_index]
+            sym_pass = sum(
+                1
+                for p in peer_stats
+                if p.gate_pass and p.net_edge_bps > 0 and p.beats_null and p.concentration_ok
+            )
+            row = HorizonResult(
+                **{
+                    **asdict(h),
+                    "bootstrap_p_adj": p_adj,
+                    "symbols_passing": sym_pass,
+                    "gate_pass": h.gate_pass
+                    and p_adj < ALPHA
+                    and sym_pass >= config.min_symbols_pass,
+                }
+            )
+            new_horizons.append(row)
+            if row.gate_pass and (best_pass is None or row.net_edge_bps > best_pass.net_edge_bps):
+                best_pass = row
+        updated_results.append(
+            SymbolResult(
+                symbol=sym_result.symbol,
+                event_count=sym_result.event_count,
+                horizons=tuple(new_horizons),
+            )
+        )
+    return updated_results, best_pass
+
+
+def decide_verdict(
+    symbol_results: Sequence[SymbolResult],
+    data_audit: DataAudit,
+    config: ProbeConfig,
+) -> tuple[str, tuple[str, ...], HorizonResult | None]:
+    if data_audit.blocked:
+        return (
+            BLOCKED_ON_DATA,
+            (data_audit.blocked_reason or "data gate failed",),
+            None,
+        )
+
+    best_pass = max(
+        (h for s in symbol_results for h in s.horizons if h.gate_pass),
+        key=lambda h: h.net_edge_bps,
+        default=None,
+    )
+    if best_pass is not None:
+        return (
+            HAS_PULSE,
+            (
+                f"H1 pass: {best_pass.orientation} @ +{best_pass.horizon_min}m "
+                f"net {best_pass.net_edge_bps:+.2f}bps on {best_pass.symbols_passing} symbols "
+                f"(p_adj={best_pass.bootstrap_p_adj:.4f})",
+            ),
+            best_pass,
+        )
+
+    reasons: list[str] = []
+    for sym in symbol_results:
+        if sym.event_count < config.min_events_per_symbol:
+            reasons.append(
+                f"{sym.symbol}: only {sym.event_count} events (<{config.min_events_per_symbol})"
+            )
+        best_net = max((h.net_edge_bps for h in sym.horizons), default=float("-inf"))
+        reasons.append(
+            f"{sym.symbol}: best net edge {best_net:+.2f}bps (RT cost {config.taker_rt_bps}bps)"
+        )
+
+    weak = any(
+        h.beats_null and h.excess_bps > 0 and h.net_edge_bps <= 0
+        for s in symbol_results
+        for h in s.horizons
+    )
+    verdict = WEAK_EDGE if weak else NO_PULSE
+    reasons.append("no horizon/orientation clears Holm-adjusted bootstrap + breadth + cost gates")
+    if verdict == NO_PULSE:
+        reasons.append(
+            "measured dead: cascade-proxy excess does not survive 10bps RT cost and/or #118 null"
+        )
+    return verdict, tuple(reasons), None
+
+
+def render_report(report: ProbeReport) -> str:
+    lines = [
+        "# Forced Liquidation / Cascade Flow Probe — Report",
+        "",
+        f"**Verdict:** **{report.verdict}**",
+        f"**Date:** {datetime.now(UTC).date().isoformat()}",
+        "**Script:** `scripts/probe_liquidation_cascade.py`",
+        "**Spec:** [liquidation-cascade-probe-v0.md](../specs/liquidation-cascade-probe-v0.md)",
+        "",
+        f"**Window:** {report.window_start.date()} → {report.window_end.date()} (UTC)",
+        "",
+        "## STEP 0 — Data audit",
+        "",
+        f"- REST `allForceOrders`: {report.data_audit.rest_all_force_orders}",
+        f"- WebSocket path: `{report.data_audit.websocket_path}`",
+        f"- UM metrics days loaded: {report.data_audit.metrics_days_loaded}",
+        f"- Force orders collected (this run): {report.data_audit.force_orders_collected}",
+        f"- Force orders cached (loaded): {report.data_audit.force_orders_cached}",
+        f"- Events per symbol: {report.data_audit.events_per_symbol}",
+        "",
+        "## Frozen cascade-proxy definition",
+        "",
+        f"- OI drop ≤ {report.config.oi_drop_pct}% (5m)",
+        f"- Long-cascade: taker ratio ≤ {report.config.taker_long_cascade}",
+        f"- Short-cascade: taker ratio ≥ {report.config.taker_short_cascade}",
+        f"- Dedup gap: {report.config.event_gap_min}m",
+        "",
+        "## Results by symbol",
+        "",
+    ]
+    for sym in report.symbol_results:
+        lines.append(f"### {sym.symbol} ({sym.event_count} events)")
+        lines.append(
+            "| Horizon | Orient | Excess bps | Net bps | p_adj | beats null | conc | pass |"
+        )
+        lines.append(
+            "|---------|--------|----------:|--------:|------:|:----------:|:----:|:----:|"
+        )
+        for h in sym.horizons:
+            lines.append(
+                f"| +{h.horizon_min}m | {h.orientation} | {h.excess_bps:+.2f} | "
+                f"{h.net_edge_bps:+.2f} | {h.bootstrap_p_adj:.3f} | "
+                f"{'Y' if h.beats_null else 'n'} | {h.max_day_concentration:.0%} | "
+                f"{'Y' if h.gate_pass else 'n'} |"
+            )
+        lines.append("")
+
+    lines.append("## Verdict rationale")
+    for reason in report.reasons:
+        lines.append(f"- {reason}")
+    if report.best_horizon:
+        bh = report.best_horizon
+        lines.append(
+            f"- Best passing cell: {bh.orientation} +{bh.horizon_min}m "
+            f"({bh.symbols_passing} symbols, net {bh.net_edge_bps:+.2f}bps)"
+        )
+    return "\n".join(lines)
+
+
+async def run_probe(config: ProbeConfig) -> ProbeReport:
+    configure_logger("INFO")
+    logger = get_logger("probe.liquidation_cascade")
+
+    window_end = datetime.now(UTC).replace(hour=0, minute=0, second=0, microsecond=0) - timedelta(
+        days=config.end_lag_days
+    )
+    window_start = window_end - timedelta(days=config.window_days)
+
+    timeout = aiohttp.ClientTimeout(total=120, connect=15)
+    async with aiohttp.ClientSession(timeout=timeout) as session:
+        rest_status = await audit_rest_force_orders(session)
+        logger.info("REST allForceOrders: %s", rest_status)
+
+        force_collected = await collect_force_orders_ws(
+            config.symbols,
+            config.collect_seconds,
+            config.cache_dir,
+        )
+        cached_force = load_cached_force_orders(config.cache_dir, config.symbols)
+        logger.info("force orders: collected=%d cached=%d", force_collected, len(cached_force))
+
+        all_metrics: list[MetricsRow] = []
+        days = _daterange(window_start.date(), (window_end - timedelta(days=1)).date())
+        for symbol in config.symbols:
+            for day in days:
+                rows = await download_metrics_day(session, symbol, day)
+                all_metrics.extend(rows)
+                await asyncio.sleep(0.02)
+        logger.info("metrics rows loaded: %d", len(all_metrics))
+
+        events: list[CascadeEvent] = []
+        for symbol in config.symbols:
+            sym_metrics = [row for row in all_metrics if row.symbol == symbol]
+            events.extend(detect_cascade_events(sym_metrics, config))
+        events = [e for e in events if window_start <= e.time < window_end]
+        logger.info("cascade-proxy events in window: %d", len(events))
+
+        events_per_symbol = {s: sum(1 for e in events if e.symbol == s) for s in config.symbols}
+        blocked = any(events_per_symbol[s] < config.min_events_per_symbol for s in config.symbols)
+        blocked_reason: str | None = None
+        if blocked:
+            blocked_reason = "insufficient cascade events for one or more symbols: " + ", ".join(
+                f"{s}={events_per_symbol[s]}" for s in config.symbols
+            )
+
+        data_audit = DataAudit(
+            rest_all_force_orders=rest_status,
+            websocket_path=f"{WS_MARKET_BASE}/<symbol>@forceOrder",
+            metrics_days_loaded=len(days),
+            force_orders_collected=force_collected,
+            force_orders_cached=len(cached_force),
+            events_per_symbol=events_per_symbol,
+            blocked=blocked,
+            blocked_reason=blocked_reason,
+        )
+
+        if blocked:
+            return ProbeReport(
+                config=config,
+                window_start=window_start,
+                window_end=window_end,
+                data_audit=data_audit,
+                events=tuple(events),
+                symbol_results=(),
+                best_horizon=None,
+                verdict=BLOCKED_ON_DATA,
+                reasons=(blocked_reason or "blocked",),
+            )
+
+        symbol_results: list[SymbolResult] = []
+        for symbol in config.symbols:
+            sym_events = [e for e in events if e.symbol == symbol]
+            bars = await fetch_klines_1m(
+                session,
+                symbol,
+                window_start - timedelta(hours=2),
+                window_end + timedelta(hours=3),
+            )
+            logger.info("%s: %d events, %d 1m bars", symbol, len(sym_events), len(bars))
+            symbol_results.append(analyze_symbol(symbol, sym_events, bars, config))
+
+    adjusted_results, _ = apply_holm_and_pick_best(symbol_results, config)
+    verdict, reasons, best = decide_verdict(adjusted_results, data_audit, config)
+    return ProbeReport(
+        config=config,
+        window_start=window_start,
+        window_end=window_end,
+        data_audit=data_audit,
+        events=tuple(events),
+        symbol_results=tuple(adjusted_results),
+        best_horizon=best,
+        verdict=verdict,
+        reasons=reasons,
+    )
+
+
+@dataclass(frozen=True)
+class CliArgs:
+    config: ProbeConfig
+    output_json: Path | None
+    output_report: Path | None
+
+
+def parse_args() -> CliArgs:
+    parser = argparse.ArgumentParser(description="A1 liquidation/cascade Gate-1 probe")
+    parser.add_argument("--window-days", type=int, default=14)
+    parser.add_argument("--collect-seconds", type=int, default=0)
+    parser.add_argument("--output-json", type=Path, default=None)
+    parser.add_argument("--output-report", type=Path, default=None)
+    args = parser.parse_args()
+    cfg = default_config()
+    config = ProbeConfig(
+        symbols=cfg.symbols,
+        window_days=args.window_days,
+        end_lag_days=cfg.end_lag_days,
+        horizons_min=cfg.horizons_min,
+        taker_rt_bps=cfg.taker_rt_bps,
+        oi_drop_pct=cfg.oi_drop_pct,
+        taker_long_cascade=cfg.taker_long_cascade,
+        taker_short_cascade=cfg.taker_short_cascade,
+        event_gap_min=cfg.event_gap_min,
+        min_events_per_symbol=cfg.min_events_per_symbol,
+        min_symbols_pass=cfg.min_symbols_pass,
+        bootstrap_resamples=cfg.bootstrap_resamples,
+        collect_seconds=args.collect_seconds,
+        cache_dir=cfg.cache_dir,
+        seed=cfg.seed,
+    )
+    return CliArgs(config=config, output_json=args.output_json, output_report=args.output_report)
+
+
+async def main_async() -> int:
+    cli = parse_args()
+    config = cli.config
+    report = await run_probe(config)
+
+    out_dir = Path("research/rbi_loop/liquidation-cascade-v0")
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    json_out = cli.output_json or out_dir / "probe-verdict.json"
+    md_out = cli.output_report or Path("docs/reports/liquidation-cascade-probe-v0.md")
+
+    payload = {
+        "verdict": report.verdict,
+        "window_start": report.window_start.isoformat(),
+        "window_end": report.window_end.isoformat(),
+        "data_audit": asdict(report.data_audit),
+        "events_per_symbol": report.data_audit.events_per_symbol,
+        "reasons": list(report.reasons),
+        "best_horizon": asdict(report.best_horizon) if report.best_horizon else None,
+    }
+    json_out.parent.mkdir(parents=True, exist_ok=True)
+    json_out.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    md_out.write_text(render_report(report) + "\n", encoding="utf-8")
+
+    print(render_report(report))
+    print(f"\nWrote {json_out}")
+    print(f"Wrote {md_out}")
+    print(f"\nVERDICT: {report.verdict}")
+    return 0 if report.verdict in {HAS_PULSE, NO_PULSE, WEAK_EDGE} else 1
+
+
+def main() -> None:
+    raise SystemExit(asyncio.run(main_async()))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_probe_liquidation_cascade.py
+++ b/tests/test_probe_liquidation_cascade.py
@@ -1,0 +1,54 @@
+"""Unit tests for liquidation cascade probe helpers."""
+
+from datetime import UTC, datetime
+
+from scripts.probe_liquidation_cascade import (
+    DataAudit,
+    MetricsRow,
+    _day_concentration,
+    _oriented_return,
+    decide_verdict,
+    default_config,
+    detect_cascade_events,
+)
+
+
+def test_detect_cascade_events_long_side() -> None:
+    config = default_config()
+    base = datetime(2026, 6, 10, 12, 0, tzinfo=UTC)
+    metrics = [
+        MetricsRow(base, "BTCUSDT", 1000.0, 1e9, 1.0),
+        MetricsRow(base.replace(minute=5), "BTCUSDT", 998.0, 9.9e8, 0.40),
+    ]
+    events = detect_cascade_events(metrics, config)
+    assert len(events) == 1
+    assert events[0].side == "LONG_CASCADE"
+
+
+def test_oriented_return_fade_vs_continuation() -> None:
+    assert _oriented_return("LONG_CASCADE", "fade", 50.0) == 50.0
+    assert _oriented_return("LONG_CASCADE", "continuation", 50.0) == -50.0
+
+
+def test_day_concentration_uses_absolute_mass() -> None:
+    ts = datetime(2026, 6, 10, 12, 0, tzinfo=UTC)
+    conc = _day_concentration([(ts, 10.0), (ts.replace(hour=13), -5.0)])
+    assert 0.0 < conc <= 1.0
+
+
+def test_decide_verdict_no_pulse_when_no_gate_pass() -> None:
+    config = default_config()
+    audit = DataAudit(
+        rest_all_force_orders="deprecated",
+        websocket_path="ws",
+        metrics_days_loaded=14,
+        force_orders_collected=0,
+        force_orders_cached=0,
+        events_per_symbol={"BTCUSDT": 10, "ETHUSDT": 10, "SOLUSDT": 10},
+        blocked=False,
+        blocked_reason=None,
+    )
+    verdict, reasons, best = decide_verdict((), audit, config)
+    assert verdict == "NO_PULSE"
+    assert best is None
+    assert reasons


### PR DESCRIPTION
## Summary

- Independent **Grok** deep-edge pass + **Claude** reconciliation: converged on **stay banked**
- Ran optional **A1** Gate-1 probe (`scripts/probe_liquidation_cascade.py`) to seal the last reset-doc primitive
- **Verdict: WEAK_EDGE** (economically **NO_PULSE**) — cascade-proxy excess does not survive 10bps RT cost or #118 null

## A1 data notes

- Binance `GET /fapi/v1/allForceOrders` is **deprecated** (400 out of maintenance)
- Historical panel uses official UM **metrics** (OI drop + taker imbalance) per `docs/specs/liquidation-cascade-probe-v0.md`
- 14d window, 50/50/86 events (BTC/ETH/SOL); best net +0.44/+0.69 bps @ +120m fade — noise, `p_adj≈1`

## Artifacts

| File | Purpose |
|------|---------|
| `docs/reports/deep-edge-research-grok-pass.md` | Independent Grok enumeration |
| `docs/reports/deep-edge-research-reconciliation-2026-06-24.md` | Claude × Grok reconciliation + A1 result |
| `docs/reports/liquidation-cascade-probe-v0.md` | A1 probe report |
| `research/rbi_loop/liquidation-cascade-v0/probe-verdict.json` | Machine verdict |

**Public-data book sealed.** Path 2 illiquid-venue remains the only revival path with a non-trivial prior.

## Test plan

- [x] `uv run pytest tests/test_probe_liquidation_cascade.py -q`
- [x] `uv run ruff check` / `ruff format --check` on probe files
- [x] A1 probe executed read-only (no `--execute`, no live-risk change)