### PR TITLE
feat(incentive_ops): Phase-0 baseline orchestrator

### DIFF
--- a/tests/test_incentive_ops_baseline.py
+++ b/tests/test_incentive_ops_baseline.py
@@ -1,0 +1,366 @@
+"""Tests for Phase-0 baseline orchestrator (mocked HTTP, no real network)."""
+
+from __future__ import annotations
+
+import hashlib
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import yaml
+from click.testing import CliRunner
+
+from tools.incentive_ops import baseline as blmod
+from tools.incentive_ops.baseline import (
+    BaselineError,
+    baseline_close,
+    baseline_start,
+    baseline_status,
+    baseline_tick,
+    capture_with_dedup,
+    is_active_research,
+    split_universe,
+)
+from tools.incentive_ops.capture import load_verifications
+from tools.incentive_ops.cli import cli
+from tools.incentive_ops.registry import load_registry
+from tools.incentive_ops.types import Actionability, ActionabilityResult, ReviewerDecision
+
+FIXED_NOW = datetime(2026, 6, 27, 12, 0, 0, tzinfo=UTC)
+
+
+@pytest.fixture
+def baseline_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> dict[str, Path]:
+    """Isolate runs/captures/snapshots/verifications under tmp_path."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    reg_src = Path("research/a1-incentive-farming/starter-registry-v0.yaml")
+    handoff_src = Path("docs/specs/a1-phase0-tooling-handoff-v0.md")
+    spec_src = Path("docs/specs/a1-incentive-farming-pilot-v0.md")
+
+    reg_dst = repo / reg_src
+    reg_dst.parent.mkdir(parents=True, exist_ok=True)
+    reg_dst.write_text(reg_src.read_text(encoding="utf-8"), encoding="utf-8")
+    (repo / handoff_src).parent.mkdir(parents=True, exist_ok=True)
+    (repo / handoff_src).write_text(handoff_src.read_text(encoding="utf-8"), encoding="utf-8")
+    (repo / spec_src).parent.mkdir(parents=True, exist_ok=True)
+    (repo / spec_src).write_text(spec_src.read_text(encoding="utf-8"), encoding="utf-8")
+
+    runs = repo / "research/a1-incentive-farming/runs"
+    captures = repo / "research/a1-incentive-farming/captures"
+    snapshots = repo / "research/a1-incentive-farming/snapshots"
+    verifications = repo / "research/a1-incentive-farming/verifications"
+    ev_inputs = repo / "research/a1-incentive-farming/ev_inputs"
+    for d in (runs, captures, snapshots, verifications, ev_inputs):
+        d.mkdir(parents=True, exist_ok=True)
+
+    monkeypatch.chdir(repo)
+    monkeypatch.setattr(blmod, "RUNS_ROOT", runs)
+    monkeypatch.setattr(blmod, "REGISTRY_PATH", str(reg_dst))
+    monkeypatch.setattr(blmod, "HANDOFF_PATH", str(handoff_src))
+    monkeypatch.setattr(blmod, "SPEC_PATH", str(spec_src))
+    monkeypatch.setattr(blmod, "SNAPSHOTS_ROOT", snapshots)
+
+    from tools.incentive_ops import capture as capmod
+
+    monkeypatch.setattr(capmod, "CAPTURES_ROOT", captures)
+    monkeypatch.setattr(capmod, "SNAPSHOTS_ROOT", snapshots)
+    monkeypatch.setattr(capmod, "VERIFICATIONS_ROOT", verifications)
+    monkeypatch.setattr(capmod, "EV_INPUTS_ROOT", ev_inputs)
+
+    monkeypatch.setattr(blmod, "_get_git_sha", lambda: "abc123deadbeef")
+
+    return {
+        "repo": repo,
+        "runs": runs,
+        "captures": captures,
+        "snapshots": snapshots,
+        "verifications": verifications,
+        "registry": reg_dst,
+    }
+
+
+def _mock_fetch(raw_by_url: dict[str, bytes]):
+    def _fetch(url: str) -> bytes:
+        if url not in raw_by_url:
+            raise blmod.CaptureError(f"no mock for {url}")
+        return raw_by_url[url]
+
+    return _fetch
+
+
+def _all_records():
+    recs, _ = load_registry(warn=False)
+    return recs
+
+
+def test_split_universe_active_vs_control():
+    recs = _all_records()
+    split = split_universe(recs)
+    assert len(split.frozen_program_ids) == 17
+    assert set(split.frozen_program_ids) == set(split.active_research_program_ids) | set(
+        split.control_program_ids
+    )
+    # archetype / synthetic / wrong tier excluded from active fetch
+    assert "testnet-incentive-archetype" in split.control_program_ids
+    assert "fixed-threshold-airdrop-archetype" in split.control_program_ids
+    assert "undisclosed-sybil-points-farm-archetype" in split.control_program_ids
+    assert "binance-launchpool" in split.control_program_ids
+    assert "coinlist-token-sale" in split.active_research_program_ids
+    assert "layer3-quests" in split.active_research_program_ids
+    assert len(split.active_research_program_ids) == 7
+
+
+@patch("tools.incentive_ops.baseline.fetch_raw")
+def test_start_freezes_exact_utc_window(mock_fetch, baseline_env):
+    recs = _all_records()
+    raw = {r.official_source_url: b"<html>terms</html>" for r in recs if is_active_research(r)}
+    mock_fetch.side_effect = lambda url: raw[url]
+
+    manifest = baseline_start(duration_days=14, now=FIXED_NOW)
+
+    assert manifest["status"] == "RUNNING"
+    assert manifest["started_at_utc"] == "2026-06-27T12:00:00Z"
+    assert manifest["planned_end_at_utc"] == "2026-07-11T12:00:00Z"
+    assert manifest["duration_days"] == 14
+    assert manifest["starting_git_sha"] == "abc123deadbeef"
+    assert manifest["zero_capital"] is True
+    assert manifest["wallets_used"] is False
+    assert manifest["eligibility_lookups_used"] is False
+
+    run_dir = baseline_env["runs"] / manifest["run_id"]
+    assert (run_dir / "manifest.yaml").exists()
+    assert (run_dir / "reports" / "day-0.md").exists()
+    assert list((run_dir / "observations").glob("*.yaml"))
+
+
+@patch("tools.incentive_ops.baseline.fetch_raw")
+def test_second_start_refuses_while_running(mock_fetch, baseline_env):
+    recs = _all_records()
+    raw = {r.official_source_url: b"<html>terms</html>" for r in recs if is_active_research(r)}
+    mock_fetch.side_effect = lambda url: raw[url]
+
+    baseline_start(duration_days=14, now=FIXED_NOW)
+    with pytest.raises(BaselineError, match="another RUNNING baseline"):
+        baseline_start(duration_days=14, now=FIXED_NOW + timedelta(hours=1))
+
+
+@patch("tools.incentive_ops.baseline._run_gates")
+@patch("tools.incentive_ops.baseline.fetch_raw")
+def test_start_failure_does_not_leave_running(mock_fetch, mock_gates, baseline_env):
+    recs = _all_records()
+    raw = {r.official_source_url: b"<html>terms</html>" for r in recs if is_active_research(r)}
+    mock_fetch.side_effect = lambda url: raw[url]
+    mock_gates.side_effect = BaselineError("simulated gate failure")
+
+    with pytest.raises(BaselineError, match="simulated gate failure"):
+        baseline_start(duration_days=14, now=FIXED_NOW)
+
+    manifests = list(baseline_env["runs"].glob("*/manifest.yaml"))
+    assert len(manifests) == 1
+    data = yaml.safe_load(manifests[0].read_text(encoding="utf-8"))
+    assert data["status"] == "ABORTED"
+    assert data["status"] != "RUNNING"
+
+
+def test_identical_hash_deduplicates_raw_storage(baseline_env):
+    recs = _all_records()
+    rec = next(r for r in recs if r.id == "coinlist-token-sale")
+    body = b"<html>same content</html>"
+    sha = hashlib.sha256(body).hexdigest()
+
+    with patch("tools.incentive_ops.baseline.fetch_raw", return_value=body):
+        cap1, _ = capture_with_dedup(rec, FIXED_NOW)
+        cap2, _ = capture_with_dedup(rec, FIXED_NOW + timedelta(hours=1))
+
+    assert cap1.snapshot_sha256 == cap2.snapshot_sha256 == sha
+    assert cap1.raw_path == cap2.raw_path
+    raw_files = list((baseline_env["snapshots"] / rec.id).glob("*.raw"))
+    assert len(raw_files) == 1
+
+
+def test_changed_hash_creates_new_immutable_artifact(baseline_env):
+    recs = _all_records()
+    rec = next(r for r in recs if r.id == "coinlist-token-sale")
+
+    with patch("tools.incentive_ops.baseline.fetch_raw", return_value=b"v1"):
+        cap1, _ = capture_with_dedup(rec, FIXED_NOW)
+    with patch("tools.incentive_ops.baseline.fetch_raw", return_value=b"v2-different"):
+        cap2, changed = capture_with_dedup(rec, FIXED_NOW + timedelta(hours=1), prior_cap=cap1)
+
+    assert changed is True
+    assert cap1.snapshot_sha256 != cap2.snapshot_sha256
+    assert cap1.raw_path != cap2.raw_path
+    raw_files = list((baseline_env["snapshots"] / rec.id).glob("*.raw"))
+    assert len(raw_files) == 2
+
+
+def test_verification_sidecar_pending_binding(baseline_env):
+    from tools.incentive_ops.baseline import _make_pending_verification
+    from tools.incentive_ops.capture import write_verification_sidecar
+
+    recs = _all_records()
+    rec = next(r for r in recs if r.id == "layer3-quests")
+
+    with patch("tools.incentive_ops.baseline.fetch_raw", return_value=b"<html>layer3</html>"):
+        cap, _ = capture_with_dedup(rec, FIXED_NOW)
+        write_verification_sidecar(_make_pending_verification(cap))
+    with patch("tools.incentive_ops.baseline.fetch_raw", return_value=b"<html>layer3-v2</html>"):
+        cap2, _ = capture_with_dedup(rec, FIXED_NOW + timedelta(hours=2), prior_cap=cap)
+        write_verification_sidecar(_make_pending_verification(cap2))
+
+    vers = load_verifications(str(baseline_env["verifications"]))
+    ver = vers[rec.id]
+    assert ver.snapshot_sha256 == cap2.snapshot_sha256
+    assert ver.terms_match_snapshot is False
+    assert ver.live_round_open is False
+    assert ver.reviewer_decision == ReviewerDecision.PENDING
+    assert str(ver.jurisdiction_status) == "UNKNOWN"
+    assert ver.verified_at is None
+    assert ver.eligibility_open is None
+
+
+@patch("tools.incentive_ops.baseline.fetch_raw")
+def test_archetype_control_records_not_fetched(mock_fetch, baseline_env):
+    recs = _all_records()
+    active = [r for r in recs if is_active_research(r)]
+    raw = {r.official_source_url: b"<html>x</html>" for r in active}
+    mock_fetch.side_effect = lambda url: raw[url]
+
+    with patch(
+        "tools.incentive_ops.baseline.capture_with_dedup",
+        wraps=capture_with_dedup,
+    ) as mock_cap:
+        baseline_start(duration_days=14, now=FIXED_NOW)
+        captured_ids = {call.args[0].id for call in mock_cap.call_args_list}
+
+    control_ids = {
+        "testnet-incentive-archetype",
+        "fixed-threshold-airdrop-archetype",
+        "binance-launchpool",
+        "undisclosed-sybil-points-farm-archetype",
+    }
+    assert captured_ids == set(split_universe(recs).active_research_program_ids)
+    assert captured_ids.isdisjoint(control_ids)
+
+
+def test_tick_without_start_fails(baseline_env):
+    with pytest.raises(BaselineError, match="no RUNNING baseline"):
+        baseline_tick(now=FIXED_NOW)
+
+
+@patch("tools.incentive_ops.baseline.fetch_raw")
+def test_tick_cannot_alter_frozen_universe(mock_fetch, baseline_env, monkeypatch):
+    recs = _all_records()
+    raw = {r.official_source_url: b"<html>x</html>" for r in recs if is_active_research(r)}
+    mock_fetch.side_effect = lambda url: raw[url]
+
+    baseline_start(duration_days=14, now=FIXED_NOW)
+
+    # mutate registry on disk to simulate rule change
+    reg_path = baseline_env["registry"]
+    data = yaml.safe_load(reg_path.read_text(encoding="utf-8"))
+    data["programs"][0]["classification"] = "REJECT"
+    reg_path.write_text(yaml.safe_dump(data), encoding="utf-8")
+
+    with pytest.raises(BaselineError, match="changed since baseline start"):
+        baseline_tick(now=FIXED_NOW + timedelta(days=1))
+
+
+@patch("tools.incentive_ops.baseline.check_all_actionability")
+@patch("tools.incentive_ops.baseline.fetch_raw")
+def test_actionable_result_aborts_start(mock_fetch, mock_action, baseline_env):
+    recs = _all_records()
+    raw = {r.official_source_url: b"<html>x</html>" for r in recs if is_active_research(r)}
+    mock_fetch.side_effect = lambda url: raw[url]
+    mock_action.return_value = {
+        "evil": ActionabilityResult(status=Actionability.ACTIONABLE, reason="test"),
+    }
+
+    with pytest.raises(BaselineError):
+        baseline_start(duration_days=14, now=FIXED_NOW)
+
+
+@patch("tools.incentive_ops.baseline.fetch_raw")
+def test_close_before_end_refuses(mock_fetch, baseline_env):
+    recs = _all_records()
+    raw = {r.official_source_url: b"<html>x</html>" for r in recs if is_active_research(r)}
+    mock_fetch.side_effect = lambda url: raw[url]
+
+    baseline_start(duration_days=14, now=FIXED_NOW)
+    with pytest.raises(BaselineError, match="planned end"):
+        baseline_close(abort=False, now=FIXED_NOW + timedelta(days=1))
+
+
+def test_no_wallet_eligibility_capital_paths():
+    """Baseline module must not import eligibility or touch capital paths."""
+    import ast
+    from pathlib import Path
+
+    tree = ast.parse(Path("tools/incentive_ops/baseline.py").read_text(encoding="utf-8"))
+    imported = {
+        alias.name
+        for node in ast.walk(tree)
+        if isinstance(node, ast.ImportFrom) and node.module
+        for alias in node.names
+    }
+    imported_modules = {
+        node.module for node in ast.walk(tree) if isinstance(node, ast.ImportFrom) and node.module
+    }
+    assert "eligibility" not in imported_modules
+    assert "tools.incentive_ops.eligibility" not in imported_modules
+    assert "fetch_eligibility" not in imported
+    assert "validate_caps" not in imported
+
+
+@patch("tools.incentive_ops.baseline.fetch_raw")
+def test_baseline_status_reports_counts(mock_fetch, baseline_env):
+    recs = _all_records()
+    raw = {r.official_source_url: b"<html>x</html>" for r in recs if is_active_research(r)}
+    mock_fetch.side_effect = lambda url: raw[url]
+
+    baseline_start(duration_days=14, now=FIXED_NOW)
+    st = baseline_status(now=FIXED_NOW + timedelta(days=1))
+
+    assert st["elapsed_seconds"] == 86400
+    assert st["remaining_seconds"] == 13 * 86400
+    assert st["actionable_count"] == 0
+    assert st["invariant_violations"] == []
+
+
+@patch("tools.incentive_ops.baseline.fetch_raw")
+def test_baseline_close_abort(mock_fetch, baseline_env):
+    recs = _all_records()
+    raw = {r.official_source_url: b"<html>x</html>" for r in recs if is_active_research(r)}
+    mock_fetch.side_effect = lambda url: raw[url]
+
+    manifest = baseline_start(duration_days=14, now=FIXED_NOW)
+    result = baseline_close(abort=True, now=FIXED_NOW + timedelta(days=1))
+    assert result["manifest"]["status"] == "ABORTED"
+    run_dir = baseline_env["runs"] / manifest["run_id"]
+    assert (run_dir / "reports" / "final.md").exists()
+
+
+@patch("tools.incentive_ops.baseline.fetch_raw")
+def test_cli_smoke_start_tick_status_close(mock_fetch, baseline_env):
+    recs = _all_records()
+    raw = {r.official_source_url: b"<html>x</html>" for r in recs if is_active_research(r)}
+    mock_fetch.side_effect = lambda url: raw[url]
+
+    runner = CliRunner()
+    r1 = runner.invoke(cli, ["baseline", "start", "--days", "14"])
+    assert r1.exit_code == 0, r1.output
+    assert "Baseline started" in r1.output
+
+    r2 = runner.invoke(cli, ["baseline", "tick"])
+    assert r2.exit_code == 0, r2.output
+    assert "Tick OK" in r2.output
+
+    r3 = runner.invoke(cli, ["baseline", "status"])
+    assert r3.exit_code == 0, r3.output
+    assert "baseline status" in r3.output
+
+    r4 = runner.invoke(cli, ["baseline", "close", "--abort"])
+    assert r4.exit_code == 0, r4.output
+    assert "ABORTED" in r4.output

--- a/tests/test_incentive_ops_baseline.py
+++ b/tests/test_incentive_ops_baseline.py
@@ -61,6 +61,10 @@ def baseline_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> dict[str, P
     for d in (runs, captures, snapshots, verifications, ev_inputs):
         d.mkdir(parents=True, exist_ok=True)
 
+    verif_src = Path("research/a1-incentive-farming/verifications")
+    for yf in verif_src.glob("*.yaml"):
+        (verifications / yf.name).write_text(yf.read_text(encoding="utf-8"), encoding="utf-8")
+
     monkeypatch.chdir(repo)
     monkeypatch.setattr(blmod, "RUNS_ROOT", runs)
     monkeypatch.setattr(blmod, "REGISTRY_PATH", str(reg_dst))
@@ -540,3 +544,92 @@ def test_reject_non_positive_days():
     result = runner.invoke(cli, ["baseline", "start", "--days", "0"])
     assert result.exit_code == 1
     assert "must be positive" in result.output
+
+
+def _approved_sidecar(pid: str = "coinlist-token-sale") -> VerificationRecord:
+    return VerificationRecord(
+        id=pid,
+        snapshot_sha256="deadbeef",
+        terms_match_snapshot=True,
+        live_round_open=True,
+        reviewer_decision=ReviewerDecision.APPROVED,
+        verified_at=FIXED_NOW,
+        raw_evidence_path="fake",
+        official_round_terms_url="https://coinlist.co/token-launches",
+        captured_source_url="https://coinlist.co/token-launches",
+        jurisdiction_status=JurisdictionStatus.ELIGIBLE,
+    )
+
+
+def _read_reviewer_decision(verifications_dir: Path, pid: str) -> str:
+    data = yaml.safe_load((verifications_dir / f"{pid}.yaml").read_text(encoding="utf-8"))
+    return str(data["reviewer_decision"])
+
+
+@patch("tools.incentive_ops.baseline.fetch_raw")
+def test_tick_fails_on_approved_sidecar_without_overwriting(mock_fetch, baseline_env):
+    recs = _all_records()
+    raw = {r.official_source_url: b"<html>x</html>" for r in recs if is_active_research(r)}
+    mock_fetch.side_effect = lambda url: raw[url]
+
+    baseline_start(duration_days=14, now=FIXED_NOW)
+    write_verification_sidecar(_approved_sidecar())
+
+    with pytest.raises(BaselineError, match="invariant violations"):
+        baseline_tick(now=FIXED_NOW + timedelta(hours=1))
+
+    assert (
+        _read_reviewer_decision(baseline_env["verifications"], "coinlist-token-sale") == "APPROVED"
+    )
+
+
+@patch("tools.incentive_ops.baseline.fetch_raw")
+def test_close_fails_on_approved_sidecar_without_overwriting(mock_fetch, baseline_env):
+    recs = _all_records()
+    raw = {r.official_source_url: b"<html>x</html>" for r in recs if is_active_research(r)}
+    mock_fetch.side_effect = lambda url: raw[url]
+
+    baseline_start(duration_days=14, now=FIXED_NOW)
+    write_verification_sidecar(_approved_sidecar())
+
+    with pytest.raises(BaselineError, match="invariant violations"):
+        baseline_close(abort=True, now=FIXED_NOW + timedelta(hours=1))
+
+    assert (
+        _read_reviewer_decision(baseline_env["verifications"], "coinlist-token-sale") == "APPROVED"
+    )
+
+
+@patch("tools.incentive_ops.baseline.fetch_raw")
+def test_missing_frozen_verification_sidecar_is_invariant_violation(mock_fetch, baseline_env):
+    recs = _all_records()
+    raw = {r.official_source_url: b"<html>x</html>" for r in recs if is_active_research(r)}
+    mock_fetch.side_effect = lambda url: raw[url]
+
+    baseline_start(duration_days=14, now=FIXED_NOW)
+    (baseline_env["verifications"] / "binance-launchpool.yaml").unlink()
+
+    st = baseline_status(now=FIXED_NOW + timedelta(hours=1))
+    assert any(
+        "binance-launchpool: missing verification sidecar" in v for v in st["invariant_violations"]
+    )
+
+    with pytest.raises(BaselineError, match="missing verification sidecar"):
+        baseline_tick(now=FIXED_NOW + timedelta(hours=2))
+
+
+@patch("tools.incentive_ops.baseline.fetch_raw")
+@patch("tools.incentive_ops.baseline._write_day0_report")
+def test_day0_report_failure_never_persists_running(mock_report, mock_fetch, baseline_env):
+    recs = _all_records()
+    raw = {r.official_source_url: b"<html>x</html>" for r in recs if is_active_research(r)}
+    mock_fetch.side_effect = lambda url: raw[url]
+    mock_report.side_effect = OSError("simulated report write failure")
+
+    with pytest.raises(BaselineError, match="simulated report write failure"):
+        baseline_start(duration_days=14, now=FIXED_NOW)
+
+    manifest_path = next(baseline_env["runs"].glob("*/manifest.yaml"))
+    data = yaml.safe_load(manifest_path.read_text(encoding="utf-8"))
+    assert data["status"] != "RUNNING"
+    assert data["status"] == "ABORTED"

--- a/tests/test_incentive_ops_baseline.py
+++ b/tests/test_incentive_ops_baseline.py
@@ -22,10 +22,16 @@ from tools.incentive_ops.baseline import (
     is_active_research,
     split_universe,
 )
-from tools.incentive_ops.capture import load_verifications
+from tools.incentive_ops.capture import load_verifications, write_verification_sidecar
 from tools.incentive_ops.cli import cli
 from tools.incentive_ops.registry import load_registry
-from tools.incentive_ops.types import Actionability, ActionabilityResult, ReviewerDecision
+from tools.incentive_ops.types import (
+    Actionability,
+    ActionabilityResult,
+    JurisdictionStatus,
+    ReviewerDecision,
+    VerificationRecord,
+)
 
 FIXED_NOW = datetime(2026, 6, 27, 12, 0, 0, tzinfo=UTC)
 
@@ -364,3 +370,173 @@ def test_cli_smoke_start_tick_status_close(mock_fetch, baseline_env):
     r4 = runner.invoke(cli, ["baseline", "close", "--abort"])
     assert r4.exit_code == 0, r4.output
     assert "ABORTED" in r4.output
+
+
+@patch("tools.incentive_ops.baseline.fetch_raw")
+def test_start_aborts_when_any_active_capture_fails(mock_fetch, baseline_env):
+    recs = _all_records()
+    active = [r for r in recs if is_active_research(r)]
+    raw = {r.official_source_url: b"<html>ok</html>" for r in active}
+    fail_url = active[0].official_source_url
+
+    def _side_effect(url: str) -> bytes:
+        if url == fail_url:
+            raise blmod.CaptureError("simulated fetch failure")
+        return raw[url]
+
+    mock_fetch.side_effect = _side_effect
+
+    with pytest.raises(BaselineError, match="capture failures"):
+        baseline_start(duration_days=14, now=FIXED_NOW)
+
+    manifests = list(baseline_env["runs"].glob("*/manifest.yaml"))
+    data = yaml.safe_load(manifests[0].read_text(encoding="utf-8"))
+    assert data["status"] == "ABORTED"
+
+
+@patch("tools.incentive_ops.baseline.fetch_raw")
+def test_approved_verification_sidecar_reports_invariant_violation(mock_fetch, baseline_env):
+    recs = _all_records()
+    raw = {r.official_source_url: b"<html>x</html>" for r in recs if is_active_research(r)}
+    mock_fetch.side_effect = lambda url: raw[url]
+
+    baseline_start(duration_days=14, now=FIXED_NOW)
+
+    write_verification_sidecar(
+        VerificationRecord(
+            id="coinlist-token-sale",
+            snapshot_sha256="deadbeef",
+            terms_match_snapshot=True,
+            live_round_open=True,
+            reviewer_decision=ReviewerDecision.APPROVED,
+            verified_at=FIXED_NOW,
+            raw_evidence_path="fake",
+            official_round_terms_url="https://coinlist.co/token-launches",
+            captured_source_url="https://coinlist.co/token-launches",
+            jurisdiction_status=JurisdictionStatus.ELIGIBLE,
+        )
+    )
+
+    st = baseline_status(now=FIXED_NOW + timedelta(hours=1))
+    assert any("reviewer_decision=APPROVED" in v for v in st["invariant_violations"])
+
+
+@patch("tools.incentive_ops.baseline.fetch_raw")
+def test_tick_rejects_handoff_spec_and_git_changes(mock_fetch, baseline_env, monkeypatch):
+    recs = _all_records()
+    raw = {r.official_source_url: b"<html>x</html>" for r in recs if is_active_research(r)}
+    mock_fetch.side_effect = lambda url: raw[url]
+
+    handoff = baseline_env["repo"] / blmod.HANDOFF_PATH
+    spec = baseline_env["repo"] / blmod.SPEC_PATH
+    handoff_original = handoff.read_text(encoding="utf-8")
+    spec_original = spec.read_text(encoding="utf-8")
+
+    baseline_start(duration_days=14, now=FIXED_NOW)
+
+    handoff.write_text(handoff_original + "\n# mutated\n", encoding="utf-8")
+    with pytest.raises(BaselineError, match="handoff content changed"):
+        baseline_tick(now=FIXED_NOW + timedelta(hours=1))
+
+    handoff.write_text(handoff_original, encoding="utf-8")
+    spec.write_text(spec_original + "\n# mutated\n", encoding="utf-8")
+    with pytest.raises(BaselineError, match="spec content changed"):
+        baseline_tick(now=FIXED_NOW + timedelta(hours=2))
+
+    spec.write_text(spec_original, encoding="utf-8")
+    monkeypatch.setattr(blmod, "_get_git_sha", lambda: "different-sha")
+    with pytest.raises(BaselineError, match="git revision changed"):
+        baseline_tick(now=FIXED_NOW + timedelta(hours=3))
+
+
+def test_same_second_raw_snapshots_do_not_collide(baseline_env):
+    recs = _all_records()
+    rec = next(r for r in recs if r.id == "coinlist-token-sale")
+
+    with patch("tools.incentive_ops.baseline.fetch_raw", return_value=b"content-a"):
+        cap_a, _ = capture_with_dedup(rec, FIXED_NOW)
+    with patch("tools.incentive_ops.baseline.fetch_raw", return_value=b"content-b"):
+        cap_b, _ = capture_with_dedup(rec, FIXED_NOW)
+
+    assert cap_a.raw_path != cap_b.raw_path
+    raw_files = list((baseline_env["snapshots"] / rec.id).glob("*.raw"))
+    assert len(raw_files) == 2
+
+
+@patch("tools.incentive_ops.baseline.fetch_raw")
+def test_same_second_observations_do_not_collide(mock_fetch, baseline_env):
+    from tools.incentive_ops.baseline import _write_observation
+
+    recs = _all_records()
+    raw = {r.official_source_url: b"<html>x</html>" for r in recs if is_active_research(r)}
+    mock_fetch.side_effect = lambda url: raw[url]
+
+    manifest = baseline_start(duration_days=14, now=FIXED_NOW)
+    run_dir = baseline_env["runs"] / manifest["run_id"]
+    manifest_data = yaml.safe_load((run_dir / "manifest.yaml").read_text(encoding="utf-8"))
+    gate = {"classify_counts": {}, "actionability_counts": {}, "actionable_program_ids": []}
+    cap = blmod.CaptureTickResult(successes=manifest_data["active_research_program_ids"])
+
+    p1 = _write_observation(
+        run_dir,
+        kind="tick",
+        capture_result=cap,
+        gate_result=gate,
+        manifest=manifest_data,
+        now=FIXED_NOW,
+    )
+    cap2 = blmod.CaptureTickResult(successes=manifest_data["active_research_program_ids"][:-1])
+    p2 = _write_observation(
+        run_dir,
+        kind="tick",
+        capture_result=cap2,
+        gate_result=gate,
+        manifest=manifest_data,
+        now=FIXED_NOW,
+    )
+    assert p1 != p2
+    assert p1.exists() and p2.exists()
+
+
+@patch("tools.incentive_ops.baseline.fetch_raw")
+def test_start_refuses_when_lock_held(mock_fetch, baseline_env):
+    import fcntl
+    import os
+
+    recs = _all_records()
+    raw = {r.official_source_url: b"<html>x</html>" for r in recs if is_active_research(r)}
+    mock_fetch.side_effect = lambda url: raw[url]
+
+    baseline_env["runs"].mkdir(parents=True, exist_ok=True)
+    lock_path = baseline_env["runs"] / ".baseline.lock"
+    fd = os.open(lock_path, os.O_CREAT | os.O_RDWR)
+    fcntl.flock(fd, fcntl.LOCK_EX)
+    try:
+        with pytest.raises(BaselineError, match="lock held"):
+            baseline_start(duration_days=14, now=FIXED_NOW)
+    finally:
+        fcntl.flock(fd, fcntl.LOCK_UN)
+        os.close(fd)
+
+
+@patch("tools.incentive_ops.baseline.fetch_raw")
+def test_day0_report_shows_running_status(mock_fetch, baseline_env):
+    recs = _all_records()
+    raw = {r.official_source_url: b"<html>x</html>" for r in recs if is_active_research(r)}
+    mock_fetch.side_effect = lambda url: raw[url]
+
+    manifest = baseline_start(duration_days=14, now=FIXED_NOW)
+    report = (baseline_env["runs"] / manifest["run_id"] / "reports" / "day-0.md").read_text(
+        encoding="utf-8"
+    )
+    assert "**Status:** RUNNING" in report
+
+
+def test_reject_non_positive_days():
+    with pytest.raises(BaselineError, match="duration_days must be positive"):
+        baseline_start(duration_days=0, now=FIXED_NOW)
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["baseline", "start", "--days", "0"])
+    assert result.exit_code == 1
+    assert "must be positive" in result.output

--- a/tools/incentive_ops/baseline.py
+++ b/tools/incentive_ops/baseline.py
@@ -1,0 +1,664 @@
+"""baseline.py — Phase-0 14-day baseline orchestrator (atomic start, no capital).
+
+Freezes registry universe, captures active-research sources with hash dedup,
+writes matching pending verification sidecars, and records observations.
+Does not approve programs, deploy capital, or use wallets/eligibility lookups.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import subprocess
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from src.utils.logger import get_logger
+
+from .actionability import check_all_actionability
+from .capture import (
+    SNAPSHOTS_ROOT,
+    _compute_sha256,
+    _ensure_dirs,
+    _is_unverified,
+    _write_raw_snapshot,
+    _write_sidecar,
+    fetch_raw,
+    load_captures,
+    load_ev_inputs,
+    load_verifications,
+    write_verification_sidecar,
+)
+from .classify import check_classification
+from .registry import load_registry, validate_registry
+from .types import (
+    Actionability,
+    CaptureError,
+    CaptureRecord,
+    Classification,
+    JurisdictionStatus,
+    ProgramRecord,
+    ReviewerDecision,
+    VerificationRecord,
+)
+
+logger = get_logger(__name__)
+
+RUNS_ROOT = Path("research/a1-incentive-farming/runs")
+REGISTRY_PATH = "research/a1-incentive-farming/starter-registry-v0.yaml"
+HANDOFF_PATH = "docs/specs/a1-phase0-tooling-handoff-v0.md"
+SPEC_PATH = "docs/specs/a1-incentive-farming-pilot-v0.md"
+
+
+class BaselineError(RuntimeError):
+    """Baseline orchestration failure (fail closed)."""
+
+    pass
+
+
+@dataclass
+class UniverseSplit:
+    frozen_program_ids: list[str]
+    active_research_program_ids: list[str]
+    control_program_ids: list[str]
+
+
+@dataclass
+class CaptureTickResult:
+    successes: list[str] = field(default_factory=list)
+    failures: dict[str, str] = field(default_factory=dict)
+    hash_changed: list[str] = field(default_factory=list)
+    hash_unchanged: list[str] = field(default_factory=list)
+    prior_hashes: dict[str, str] = field(default_factory=dict)
+    new_hashes: dict[str, str] = field(default_factory=dict)
+
+
+def _sha256_file(path: Path | str) -> str:
+    p = Path(path)
+    return hashlib.sha256(p.read_bytes()).hexdigest()
+
+
+def _get_git_sha() -> str:
+    try:
+        out = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=5,
+        )
+        return out.stdout.strip()
+    except Exception:
+        return "unknown"
+
+
+def _iso_utc(dt: datetime) -> str:
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=UTC)
+    return dt.astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _parse_utc(s: str) -> datetime:
+    return datetime.fromisoformat(str(s).replace("Z", "+00:00")).astimezone(UTC)
+
+
+def _rel_path(path: Path) -> str:
+    try:
+        return str(path.relative_to(Path.cwd()))
+    except ValueError:
+        return str(path)
+
+
+def _is_archetype_or_synthetic(verification_status: str) -> bool:
+    v = verification_status.upper()
+    return "ARCHETYPE" in v or "SYNTHETIC" in v
+
+
+def is_active_research(rec: ProgramRecord) -> bool:
+    """Records eligible for official-source refetch during baseline."""
+    if rec.classification not in (Classification.IN_CORE, Classification.IN_CONDITIONAL):
+        return False
+    if _is_archetype_or_synthetic(rec.verification_status):
+        return False
+    if rec.live_round_status in ("NOT_LIVE_REFERENCE_ONLY", "NOT_A_REAL_PROGRAM"):
+        return False
+    return True
+
+
+def split_universe(records: list[ProgramRecord]) -> UniverseSplit:
+    frozen = sorted(r.id for r in records)
+    active = sorted(r.id for r in records if is_active_research(r))
+    control = sorted(set(frozen) - set(active))
+    return UniverseSplit(
+        frozen_program_ids=frozen,
+        active_research_program_ids=active,
+        control_program_ids=control,
+    )
+
+
+def find_running_manifest(runs_root: Path | None = None) -> Path | None:
+    root = runs_root or RUNS_ROOT
+    if not root.exists():
+        return None
+    for manifest_path in sorted(root.glob("*/manifest.yaml"), reverse=True):
+        try:
+            data = yaml.safe_load(manifest_path.read_text(encoding="utf-8")) or {}
+            if data.get("status") == "RUNNING":
+                return manifest_path
+        except Exception:
+            logger.warning("unreadable manifest %s", manifest_path)
+    return None
+
+
+def load_manifest(manifest_path: Path | str) -> dict[str, Any]:
+    p = Path(manifest_path)
+    data = yaml.safe_load(p.read_text(encoding="utf-8")) or {}
+    if not isinstance(data, dict):
+        raise BaselineError(f"manifest must be mapping: {p}")
+    return data
+
+
+def save_manifest(manifest_path: Path | str, data: dict[str, Any]) -> None:
+    p = Path(manifest_path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(yaml.safe_dump(data, sort_keys=False), encoding="utf-8")
+
+
+def _find_raw_by_hash(pid: str, sha: str) -> str | None:
+    pid_dir = SNAPSHOTS_ROOT / pid
+    if not pid_dir.exists():
+        return None
+    for raw_file in sorted(pid_dir.glob("*.raw")):
+        if _compute_sha256(raw_file.read_bytes()) == sha:
+            return _rel_path(raw_file)
+    return None
+
+
+def _make_pending_verification(cap: CaptureRecord) -> VerificationRecord:
+    return VerificationRecord(
+        id=cap.id,
+        snapshot_sha256=cap.snapshot_sha256,
+        terms_match_snapshot=False,
+        live_round_open=False,
+        reviewer_decision=ReviewerDecision.PENDING,
+        verified_at=None,
+        raw_evidence_path=cap.raw_path,
+        official_round_terms_url=cap.source_url,
+        captured_source_url=cap.source_url,
+        jurisdiction_status=JurisdictionStatus.UNKNOWN,
+        eligibility_open=None,
+        eligibility_close=None,
+        claim_date=None,
+        vesting_end=None,
+    )
+
+
+def capture_with_dedup(
+    rec: ProgramRecord,
+    captured_at: datetime,
+    *,
+    prior_cap: CaptureRecord | None = None,
+) -> tuple[CaptureRecord, bool]:
+    """Fetch, deduplicate by raw sha, write capture sidecar. Returns (cap, hash_changed)."""
+    if _is_unverified(rec.official_source_url):
+        raise CaptureError(f"{rec.id}: official_source_url is UNVERIFIED")
+
+    raw = fetch_raw(rec.official_source_url)
+    sha = _compute_sha256(raw)
+    prior_sha = prior_cap.snapshot_sha256 if prior_cap else None
+    hash_changed = prior_sha is not None and prior_sha != sha
+
+    existing_path = _find_raw_by_hash(rec.id, sha)
+    if existing_path:
+        raw_path = existing_path
+    else:
+        _ensure_dirs()
+        raw_path = _rel_path(_write_raw_snapshot(rec.id, captured_at, raw))
+
+    cap = CaptureRecord(
+        id=rec.id,
+        snapshot_sha256=sha,
+        captured_at=captured_at,
+        raw_path=raw_path,
+        source_url=rec.official_source_url,
+    )
+    _write_sidecar(rec.id, cap)
+    return cap, hash_changed if prior_sha else False
+
+
+def _run_gates() -> dict[str, Any]:
+    """Validate, classify --check, actionability. Abort if any ACTIONABLE."""
+    validate_registry(REGISTRY_PATH)
+    ok, _, mismatches, counts = check_classification(REGISTRY_PATH)
+    if not ok:
+        raise BaselineError(f"classify --check failed: {mismatches}")
+    action_results = check_all_actionability()
+    actionable = [
+        pid for pid, res in action_results.items() if res.status == Actionability.ACTIONABLE
+    ]
+    if actionable:
+        raise BaselineError(f"ACTIONABLE records detected: {actionable}")
+    status_counts: dict[str, int] = {}
+    for res in action_results.values():
+        k = str(res.status)
+        status_counts[k] = status_counts.get(k, 0) + 1
+    return {
+        "classify_counts": counts,
+        "actionability_counts": status_counts,
+        "actionable_program_ids": actionable,
+    }
+
+
+_INVARIANT_EXPECTATIONS: dict[str, bool] = {
+    "zero_capital": True,
+    "wallets_used": False,
+    "eligibility_lookups_used": False,
+    "reviewer_decisions_locked_pending": True,
+    "rule_changes_allowed": False,
+}
+
+
+def _assert_invariants(manifest: dict[str, Any]) -> list[str]:
+    violations: list[str] = []
+    for key, expected in _INVARIANT_EXPECTATIONS.items():
+        if manifest.get(key) is not expected:
+            violations.append(f"{key}={manifest.get(key)} expected {expected}")
+    return violations
+
+
+def _capture_active_subset(
+    records: list[ProgramRecord],
+    active_ids: list[str],
+    captured_at: datetime,
+) -> CaptureTickResult:
+    result = CaptureTickResult()
+    id_set = set(active_ids)
+    prior = load_captures()
+    for rec in records:
+        if rec.id not in id_set:
+            continue
+        prior_cap = prior.get(rec.id)
+        if prior_cap:
+            result.prior_hashes[rec.id] = prior_cap.snapshot_sha256
+        try:
+            cap, changed = capture_with_dedup(rec, captured_at, prior_cap=prior_cap)
+            result.successes.append(rec.id)
+            result.new_hashes[rec.id] = cap.snapshot_sha256
+            if prior_cap and cap.snapshot_sha256 == prior_cap.snapshot_sha256:
+                result.hash_unchanged.append(rec.id)
+            elif changed or prior_cap is None:
+                result.hash_changed.append(rec.id)
+            else:
+                result.hash_unchanged.append(rec.id)
+            ver = _make_pending_verification(cap)
+            write_verification_sidecar(ver)
+        except (CaptureError, Exception) as e:
+            result.failures[rec.id] = str(e)
+            logger.warning("capture failed %s: %s", rec.id, e)
+    return result
+
+
+def _count_verification_states() -> dict[str, int]:
+    vers = load_verifications()
+    verified = sum(1 for v in vers.values() if v.reviewer_decision == ReviewerDecision.APPROVED)
+    pending = sum(1 for v in vers.values() if v.reviewer_decision == ReviewerDecision.PENDING)
+    return {"verified": verified, "unverified": len(vers) - verified, "pending": pending}
+
+
+def _count_ev_readiness() -> dict[str, int]:
+    evs = load_ev_inputs()
+    ready = sum(1 for e in evs.values() if str(e.readiness) == "READY")
+    return {"ready": ready, "unready": len(evs) - ready}
+
+
+def _write_observation(
+    run_dir: Path,
+    *,
+    kind: str,
+    capture_result: CaptureTickResult,
+    gate_result: dict[str, Any],
+    manifest: dict[str, Any],
+    now: datetime,
+) -> Path:
+    obs_dir = run_dir / "observations"
+    obs_dir.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "timestamp_utc": _iso_utc(now),
+        "kind": kind,
+        "captures": {
+            "successes": capture_result.successes,
+            "failures": capture_result.failures,
+            "hash_changed": capture_result.hash_changed,
+            "hash_unchanged": capture_result.hash_unchanged,
+            "prior_hashes": capture_result.prior_hashes,
+            "new_hashes": capture_result.new_hashes,
+        },
+        "verification_counts": _count_verification_states(),
+        "ev_counts": _count_ev_readiness(),
+        "actionability": gate_result,
+        "invariants": {
+            "zero_capital": manifest.get("zero_capital", True),
+            "wallets_used": manifest.get("wallets_used", False),
+            "eligibility_lookups_used": manifest.get("eligibility_lookups_used", False),
+            "rule_changes_allowed": manifest.get("rule_changes_allowed", False),
+        },
+    }
+    out = obs_dir / f"{now.strftime('%Y%m%dT%H%M%SZ')}.yaml"
+    out.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
+    return out
+
+
+def _write_day0_report(
+    run_dir: Path,
+    manifest: dict[str, Any],
+    capture_result: CaptureTickResult,
+    gate_result: dict[str, Any],
+) -> Path:
+    reports = run_dir / "reports"
+    reports.mkdir(parents=True, exist_ok=True)
+    lines = [
+        "# Baseline Day-0 Report",
+        "",
+        f"**Run ID:** {manifest['run_id']}",
+        f"**Status:** {manifest['status']}",
+        f"**Planned window:** {_iso_utc(_parse_utc(manifest['started_at_utc']))} → "
+        f"{_iso_utc(_parse_utc(manifest['planned_end_at_utc']))}",
+        "",
+        "## Frozen universe",
+        f"- All programs ({len(manifest['frozen_program_ids'])}): "
+        f"{', '.join(manifest['frozen_program_ids'])}",
+        f"- Active research ({len(manifest['active_research_program_ids'])}): "
+        f"{', '.join(manifest['active_research_program_ids'])}",
+        f"- Controls ({len(manifest['control_program_ids'])}): "
+        f"{', '.join(manifest['control_program_ids'])}",
+        "",
+        "## Captures (active research only)",
+        f"- Successes: {len(capture_result.successes)}",
+        f"- Failures: {len(capture_result.failures)}",
+        f"- Hash changed: {capture_result.hash_changed or 'none'}",
+        f"- Hash unchanged: {capture_result.hash_unchanged or 'none'}",
+        "",
+        "## Gates",
+        f"- Classify counts: {gate_result.get('classify_counts', {})}",
+        f"- Actionability counts: {gate_result.get('actionability_counts', {})}",
+        f"- ACTIONABLE: {gate_result.get('actionable_program_ids', [])}",
+        "",
+        "## Invariants",
+        "- zero_capital: true",
+        "- wallets_used: false",
+        "- eligibility_lookups_used: false",
+        "- reviewer_decisions_locked_pending: true",
+        "- rule_changes_allowed: false",
+        "",
+        "No programs approved. No capital deployed.",
+    ]
+    out = reports / "day-0.md"
+    out.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return out
+
+
+def _write_final_report(
+    run_dir: Path,
+    manifest: dict[str, Any],
+    capture_result: CaptureTickResult,
+    gate_result: dict[str, Any],
+    violations: list[str],
+) -> Path:
+    reports = run_dir / "reports"
+    reports.mkdir(parents=True, exist_ok=True)
+    lines = [
+        "# Baseline Final Report",
+        "",
+        f"**Run ID:** {manifest['run_id']}",
+        f"**Final status:** {manifest['status']}",
+        f"**Started:** {manifest.get('started_at_utc')}",
+        f"**Ended:** {manifest.get('actual_end_at_utc')}",
+        "",
+        "## Last tick captures",
+        f"- Successes: {len(capture_result.successes)}",
+        f"- Failures: {capture_result.failures}",
+        f"- Hash changed: {capture_result.hash_changed}",
+        "",
+        "## Final gates",
+        f"- Actionability: {gate_result.get('actionability_counts', {})}",
+        "",
+        "## Invariant violations",
+        f"{violations or 'none'}",
+        "",
+        "No programs approved. No capital deployed.",
+    ]
+    out = reports / "final.md"
+    out.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return out
+
+
+def _build_manifest_skeleton(
+    run_id: str,
+    *,
+    duration_days: int,
+    universe: UniverseSplit,
+    now: datetime,
+    started_at: datetime,
+    planned_end: datetime,
+) -> dict[str, Any]:
+    return {
+        "run_id": run_id,
+        "status": "PENDING",
+        "created_at_utc": _iso_utc(now),
+        "started_at_utc": _iso_utc(started_at),
+        "planned_end_at_utc": _iso_utc(planned_end),
+        "actual_end_at_utc": None,
+        "duration_days": duration_days,
+        "starting_git_sha": _get_git_sha(),
+        "registry_path": REGISTRY_PATH,
+        "registry_sha256": _sha256_file(REGISTRY_PATH),
+        "handoff_path": HANDOFF_PATH,
+        "handoff_sha256": _sha256_file(HANDOFF_PATH),
+        "spec_path": SPEC_PATH,
+        "spec_sha256": _sha256_file(SPEC_PATH),
+        "frozen_program_ids": universe.frozen_program_ids,
+        "active_research_program_ids": universe.active_research_program_ids,
+        "control_program_ids": universe.control_program_ids,
+        "zero_capital": True,
+        "wallets_used": False,
+        "eligibility_lookups_used": False,
+        "reviewer_decisions_locked_pending": True,
+        "rule_changes_allowed": False,
+    }
+
+
+def baseline_start(*, duration_days: int = 14, now: datetime | None = None) -> dict[str, Any]:
+    """Atomically start a baseline run. Sets RUNNING only after all steps succeed."""
+    if find_running_manifest():
+        raise BaselineError("another RUNNING baseline exists; refuse second start")
+
+    now = now or datetime.now(UTC)
+    started_at = now
+    planned_end = started_at + timedelta(days=duration_days)
+    run_id = f"baseline-{now.strftime('%Y%m%dT%H%M%SZ')}"
+    run_dir = RUNS_ROOT / run_id
+    manifest_path = run_dir / "manifest.yaml"
+
+    records, _ = load_registry(REGISTRY_PATH, warn=False)
+    universe = split_universe(records)
+    manifest = _build_manifest_skeleton(
+        run_id,
+        duration_days=duration_days,
+        universe=universe,
+        now=now,
+        started_at=started_at,
+        planned_end=planned_end,
+    )
+    save_manifest(manifest_path, manifest)
+
+    try:
+        capture_result = _capture_active_subset(records, universe.active_research_program_ids, now)
+        gate_result = _run_gates()
+        if gate_result.get("actionable_program_ids"):
+            raise BaselineError("ACTIONABLE records after gates")
+
+        _write_observation(
+            run_dir,
+            kind="day-0",
+            capture_result=capture_result,
+            gate_result=gate_result,
+            manifest=manifest,
+            now=now,
+        )
+        _write_day0_report(run_dir, manifest, capture_result, gate_result)
+
+        manifest["status"] = "RUNNING"
+        save_manifest(manifest_path, manifest)
+        logger.info("baseline %s started RUNNING", run_id)
+        return manifest
+    except Exception as e:
+        manifest["status"] = "ABORTED"
+        manifest["actual_end_at_utc"] = _iso_utc(now)
+        manifest["abort_reason"] = str(e)
+        save_manifest(manifest_path, manifest)
+        raise BaselineError(f"baseline start aborted: {e}") from e
+
+
+def _get_running_manifest() -> tuple[Path, dict[str, Any]]:
+    mp = find_running_manifest()
+    if mp is None:
+        raise BaselineError("no RUNNING baseline; start first")
+    return mp, load_manifest(mp)
+
+
+def _verify_frozen_universe(manifest: dict[str, Any]) -> None:
+    records, _ = load_registry(REGISTRY_PATH, warn=False)
+    current = split_universe(records)
+    if current.frozen_program_ids != manifest["frozen_program_ids"]:
+        raise BaselineError("frozen_program_ids changed since baseline start")
+    if current.active_research_program_ids != manifest["active_research_program_ids"]:
+        raise BaselineError("active_research_program_ids changed since baseline start")
+    if current.control_program_ids != manifest["control_program_ids"]:
+        raise BaselineError("control_program_ids changed since baseline start")
+    if _sha256_file(REGISTRY_PATH) != manifest["registry_sha256"]:
+        raise BaselineError("registry content changed since baseline start")
+
+
+def baseline_tick(*, now: datetime | None = None) -> dict[str, Any]:
+    """Refetch active-research sources; record observation. Requires RUNNING manifest."""
+    manifest_path, manifest = _get_running_manifest()
+    if manifest.get("rule_changes_allowed"):
+        raise BaselineError("rule_changes_allowed is true; refuse tick")
+
+    _verify_frozen_universe(manifest)
+    now = now or datetime.now(UTC)
+    records, _ = load_registry(REGISTRY_PATH, warn=False)
+
+    capture_result = _capture_active_subset(records, manifest["active_research_program_ids"], now)
+    gate_result = _run_gates()
+    if gate_result.get("actionable_program_ids"):
+        raise BaselineError("ACTIONABLE records detected during tick")
+
+    obs = _write_observation(
+        manifest_path.parent,
+        kind="tick",
+        capture_result=capture_result,
+        gate_result=gate_result,
+        manifest=manifest,
+        now=now,
+    )
+    return {
+        "observation": str(obs),
+        "captures": capture_result,
+        "gates": gate_result,
+    }
+
+
+def baseline_status(*, now: datetime | None = None) -> dict[str, Any]:
+    """Report elapsed/remaining time and aggregate counts for the RUNNING baseline."""
+    now = now or datetime.now(UTC)
+    mp = find_running_manifest()
+    if mp is None:
+        latest = _latest_manifest()
+        if latest is None:
+            raise BaselineError("no baseline runs found")
+        manifest = load_manifest(latest)
+        status_note = f"no RUNNING baseline; showing latest ({manifest.get('status')})"
+        manifest_path = latest
+    else:
+        manifest = load_manifest(mp)
+        status_note = "RUNNING"
+        manifest_path = mp
+
+    started = _parse_utc(manifest["started_at_utc"])
+    planned_end = _parse_utc(manifest["planned_end_at_utc"])
+    elapsed = now - started
+    remaining = planned_end - now
+
+    violations = _assert_invariants(manifest)
+    gate_result = check_all_actionability()
+    actionable = sum(1 for r in gate_result.values() if r.status == Actionability.ACTIONABLE)
+    status_counts: dict[str, int] = {}
+    for res in gate_result.values():
+        k = str(res.status)
+        status_counts[k] = status_counts.get(k, 0) + 1
+
+    obs_dir = manifest_path.parent / "observations"
+    last_obs: dict[str, Any] = {}
+    if obs_dir.exists():
+        obs_files = sorted(obs_dir.glob("*.yaml"))
+        if obs_files:
+            last_obs = yaml.safe_load(obs_files[-1].read_text(encoding="utf-8")) or {}
+
+    return {
+        "status_note": status_note,
+        "manifest": manifest,
+        "elapsed_seconds": int(elapsed.total_seconds()),
+        "remaining_seconds": int(remaining.total_seconds()),
+        "planned_end_at_utc": manifest["planned_end_at_utc"],
+        "verification_counts": _count_verification_states(),
+        "ev_counts": _count_ev_readiness(),
+        "actionability_counts": status_counts,
+        "actionable_count": actionable,
+        "invariant_violations": violations,
+        "last_observation": last_obs,
+    }
+
+
+def _latest_manifest() -> Path | None:
+    if not RUNS_ROOT.exists():
+        return None
+    manifests = sorted(RUNS_ROOT.glob("*/manifest.yaml"), reverse=True)
+    return manifests[0] if manifests else None
+
+
+def baseline_close(*, abort: bool = False, now: datetime | None = None) -> dict[str, Any]:
+    """Close RUNNING baseline after final tick. Requires planned end unless --abort."""
+    manifest_path, manifest = _get_running_manifest()
+    now = now or datetime.now(UTC)
+    planned_end = _parse_utc(manifest["planned_end_at_utc"])
+
+    if not abort and now < planned_end:
+        raise BaselineError(
+            f"planned end {_iso_utc(planned_end)} not reached; use --abort to close early"
+        )
+
+    tick_result = baseline_tick(now=now)
+    violations = _assert_invariants(manifest)
+    if violations:
+        raise BaselineError(f"invariant violations: {violations}")
+
+    gate_result = tick_result["gates"]
+    capture_result: CaptureTickResult = tick_result["captures"]
+
+    manifest = load_manifest(manifest_path)
+    manifest["status"] = "ABORTED" if abort else "COMPLETE"
+    manifest["actual_end_at_utc"] = _iso_utc(now)
+    save_manifest(manifest_path, manifest)
+
+    _write_final_report(
+        manifest_path.parent,
+        manifest,
+        capture_result,
+        gate_result,
+        violations,
+    )
+    return {"manifest": manifest, "tick": tick_result}

--- a/tools/incentive_ops/baseline.py
+++ b/tools/incentive_ops/baseline.py
@@ -7,8 +7,12 @@ Does not approve programs, deploy capital, or use wallets/eligibility lookups.
 
 from __future__ import annotations
 
+import fcntl
 import hashlib
+import os
 import subprocess
+from collections.abc import Iterator
+from contextlib import contextmanager
 from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
@@ -48,6 +52,7 @@ from .types import (
 logger = get_logger(__name__)
 
 RUNS_ROOT = Path("research/a1-incentive-farming/runs")
+LOCK_PATH = RUNS_ROOT / ".baseline.lock"
 REGISTRY_PATH = "research/a1-incentive-farming/starter-registry-v0.yaml"
 HANDOFF_PATH = "docs/specs/a1-phase0-tooling-handoff-v0.md"
 SPEC_PATH = "docs/specs/a1-incentive-farming-pilot-v0.md"
@@ -162,9 +167,28 @@ def load_manifest(manifest_path: Path | str) -> dict[str, Any]:
 
 
 def save_manifest(manifest_path: Path | str, data: dict[str, Any]) -> None:
+    """Atomically replace manifest via temp file (POSIX rename)."""
     p = Path(manifest_path)
     p.parent.mkdir(parents=True, exist_ok=True)
-    p.write_text(yaml.safe_dump(data, sort_keys=False), encoding="utf-8")
+    tmp = p.with_suffix(".yaml.tmp")
+    tmp.write_text(yaml.safe_dump(data, sort_keys=False), encoding="utf-8")
+    tmp.replace(p)
+
+
+@contextmanager
+def _baseline_start_lock() -> Iterator[None]:
+    """Exclusive non-blocking lock for baseline start (prevents concurrent starts)."""
+    RUNS_ROOT.mkdir(parents=True, exist_ok=True)
+    fd = os.open(LOCK_PATH, os.O_CREAT | os.O_RDWR, 0o644)
+    try:
+        try:
+            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError as e:
+            raise BaselineError("another baseline start in progress (lock held)") from e
+        yield
+    finally:
+        fcntl.flock(fd, fcntl.LOCK_UN)
+        os.close(fd)
 
 
 def _find_raw_by_hash(pid: str, sha: str) -> str | None:
@@ -261,12 +285,35 @@ _INVARIANT_EXPECTATIONS: dict[str, bool] = {
 }
 
 
+def _check_reviewer_decisions_locked(frozen_ids: list[str]) -> list[str]:
+    """Inspect verification sidecars; none of the frozen universe may be APPROVED."""
+    vers = load_verifications()
+    violations: list[str] = []
+    for pid in frozen_ids:
+        ver = vers.get(pid)
+        if ver is None:
+            continue
+        if ver.reviewer_decision != ReviewerDecision.PENDING:
+            violations.append(f"{pid}: reviewer_decision={ver.reviewer_decision} (must be PENDING)")
+    return violations
+
+
 def _assert_invariants(manifest: dict[str, Any]) -> list[str]:
     violations: list[str] = []
     for key, expected in _INVARIANT_EXPECTATIONS.items():
         if manifest.get(key) is not expected:
             violations.append(f"{key}={manifest.get(key)} expected {expected}")
+    if manifest.get("reviewer_decisions_locked_pending"):
+        violations.extend(_check_reviewer_decisions_locked(manifest.get("frozen_program_ids", [])))
     return violations
+
+
+def _require_all_active_captures(capture_result: CaptureTickResult, active_ids: list[str]) -> None:
+    if capture_result.failures:
+        raise BaselineError(f"capture failures for active research: {capture_result.failures}")
+    missing = sorted(set(active_ids) - set(capture_result.successes))
+    if missing:
+        raise BaselineError(f"active research capture incomplete; missing: {missing}")
 
 
 def _capture_active_subset(
@@ -346,9 +393,23 @@ def _write_observation(
             "rule_changes_allowed": manifest.get("rule_changes_allowed", False),
         },
     }
-    out = obs_dir / f"{now.strftime('%Y%m%dT%H%M%SZ')}.yaml"
+    out = _collision_safe_observation_path(obs_dir, now, kind, payload)
     out.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
     return out
+
+
+def _collision_safe_observation_path(
+    obs_dir: Path, now: datetime, kind: str, payload: dict[str, Any]
+) -> Path:
+    ts = now.strftime("%Y%m%dT%H%M%SZ")
+    digest = hashlib.sha256(yaml.safe_dump(payload, sort_keys=True).encode()).hexdigest()[:12]
+    base = f"{ts}_{kind}_{digest}"
+    candidate = obs_dir / f"{base}.yaml"
+    seq = 0
+    while candidate.exists():
+        seq += 1
+        candidate = obs_dir / f"{base}_{seq}.yaml"
+    return candidate
 
 
 def _write_day0_report(
@@ -472,54 +533,66 @@ def _build_manifest_skeleton(
 
 def baseline_start(*, duration_days: int = 14, now: datetime | None = None) -> dict[str, Any]:
     """Atomically start a baseline run. Sets RUNNING only after all steps succeed."""
-    if find_running_manifest():
-        raise BaselineError("another RUNNING baseline exists; refuse second start")
+    if duration_days <= 0:
+        raise BaselineError(f"duration_days must be positive, got {duration_days}")
 
-    now = now or datetime.now(UTC)
-    started_at = now
-    planned_end = started_at + timedelta(days=duration_days)
-    run_id = f"baseline-{now.strftime('%Y%m%dT%H%M%SZ')}"
-    run_dir = RUNS_ROOT / run_id
-    manifest_path = run_dir / "manifest.yaml"
+    with _baseline_start_lock():
+        if find_running_manifest():
+            raise BaselineError("another RUNNING baseline exists; refuse second start")
 
-    records, _ = load_registry(REGISTRY_PATH, warn=False)
-    universe = split_universe(records)
-    manifest = _build_manifest_skeleton(
-        run_id,
-        duration_days=duration_days,
-        universe=universe,
-        now=now,
-        started_at=started_at,
-        planned_end=planned_end,
-    )
-    save_manifest(manifest_path, manifest)
+        now = now or datetime.now(UTC)
+        started_at = now
+        planned_end = started_at + timedelta(days=duration_days)
+        run_id = f"baseline-{now.strftime('%Y%m%dT%H%M%SZ')}"
+        run_dir = RUNS_ROOT / run_id
+        manifest_path = run_dir / "manifest.yaml"
 
-    try:
-        capture_result = _capture_active_subset(records, universe.active_research_program_ids, now)
-        gate_result = _run_gates()
-        if gate_result.get("actionable_program_ids"):
-            raise BaselineError("ACTIONABLE records after gates")
-
-        _write_observation(
-            run_dir,
-            kind="day-0",
-            capture_result=capture_result,
-            gate_result=gate_result,
-            manifest=manifest,
+        records, _ = load_registry(REGISTRY_PATH, warn=False)
+        universe = split_universe(records)
+        manifest = _build_manifest_skeleton(
+            run_id,
+            duration_days=duration_days,
+            universe=universe,
             now=now,
+            started_at=started_at,
+            planned_end=planned_end,
         )
-        _write_day0_report(run_dir, manifest, capture_result, gate_result)
+        save_manifest(manifest_path, manifest)
 
-        manifest["status"] = "RUNNING"
-        save_manifest(manifest_path, manifest)
-        logger.info("baseline %s started RUNNING", run_id)
-        return manifest
-    except Exception as e:
-        manifest["status"] = "ABORTED"
-        manifest["actual_end_at_utc"] = _iso_utc(now)
-        manifest["abort_reason"] = str(e)
-        save_manifest(manifest_path, manifest)
-        raise BaselineError(f"baseline start aborted: {e}") from e
+        try:
+            capture_result = _capture_active_subset(
+                records, universe.active_research_program_ids, now
+            )
+            _require_all_active_captures(capture_result, universe.active_research_program_ids)
+            gate_result = _run_gates()
+            if gate_result.get("actionable_program_ids"):
+                raise BaselineError("ACTIONABLE records after gates")
+
+            violations = _assert_invariants(manifest)
+            if violations:
+                raise BaselineError(f"invariant violations before RUNNING: {violations}")
+
+            manifest["status"] = "RUNNING"
+            save_manifest(manifest_path, manifest)
+
+            _write_observation(
+                run_dir,
+                kind="day-0",
+                capture_result=capture_result,
+                gate_result=gate_result,
+                manifest=manifest,
+                now=now,
+            )
+            _write_day0_report(run_dir, manifest, capture_result, gate_result)
+
+            logger.info("baseline %s started RUNNING", run_id)
+            return manifest
+        except Exception as e:
+            manifest["status"] = "ABORTED"
+            manifest["actual_end_at_utc"] = _iso_utc(now)
+            manifest["abort_reason"] = str(e)
+            save_manifest(manifest_path, manifest)
+            raise BaselineError(f"baseline start aborted: {e}") from e
 
 
 def _get_running_manifest() -> tuple[Path, dict[str, Any]]:
@@ -529,7 +602,8 @@ def _get_running_manifest() -> tuple[Path, dict[str, Any]]:
     return mp, load_manifest(mp)
 
 
-def _verify_frozen_universe(manifest: dict[str, Any]) -> None:
+def _verify_frozen_artifacts(manifest: dict[str, Any]) -> None:
+    """Reject tick/close if any frozen artifact or executing revision changed."""
     records, _ = load_registry(REGISTRY_PATH, warn=False)
     current = split_universe(records)
     if current.frozen_program_ids != manifest["frozen_program_ids"]:
@@ -540,6 +614,14 @@ def _verify_frozen_universe(manifest: dict[str, Any]) -> None:
         raise BaselineError("control_program_ids changed since baseline start")
     if _sha256_file(REGISTRY_PATH) != manifest["registry_sha256"]:
         raise BaselineError("registry content changed since baseline start")
+    handoff_path = manifest.get("handoff_path", HANDOFF_PATH)
+    if _sha256_file(handoff_path) != manifest["handoff_sha256"]:
+        raise BaselineError("handoff content changed since baseline start")
+    spec_path = manifest.get("spec_path", SPEC_PATH)
+    if _sha256_file(spec_path) != manifest["spec_sha256"]:
+        raise BaselineError("spec content changed since baseline start")
+    if _get_git_sha() != manifest["starting_git_sha"]:
+        raise BaselineError("git revision changed since baseline start")
 
 
 def baseline_tick(*, now: datetime | None = None) -> dict[str, Any]:
@@ -548,7 +630,7 @@ def baseline_tick(*, now: datetime | None = None) -> dict[str, Any]:
     if manifest.get("rule_changes_allowed"):
         raise BaselineError("rule_changes_allowed is true; refuse tick")
 
-    _verify_frozen_universe(manifest)
+    _verify_frozen_artifacts(manifest)
     now = now or datetime.now(UTC)
     records, _ = load_registry(REGISTRY_PATH, warn=False)
 

--- a/tools/incentive_ops/baseline.py
+++ b/tools/incentive_ops/baseline.py
@@ -286,12 +286,13 @@ _INVARIANT_EXPECTATIONS: dict[str, bool] = {
 
 
 def _check_reviewer_decisions_locked(frozen_ids: list[str]) -> list[str]:
-    """Inspect verification sidecars; none of the frozen universe may be APPROVED."""
+    """Inspect all frozen verification sidecars; each must exist and be PENDING."""
     vers = load_verifications()
     violations: list[str] = []
     for pid in frozen_ids:
         ver = vers.get(pid)
         if ver is None:
+            violations.append(f"{pid}: missing verification sidecar")
             continue
         if ver.reviewer_decision != ReviewerDecision.PENDING:
             violations.append(f"{pid}: reviewer_decision={ver.reviewer_decision} (must be PENDING)")
@@ -306,6 +307,12 @@ def _assert_invariants(manifest: dict[str, Any]) -> list[str]:
     if manifest.get("reviewer_decisions_locked_pending"):
         violations.extend(_check_reviewer_decisions_locked(manifest.get("frozen_program_ids", [])))
     return violations
+
+
+def _require_invariants(manifest: dict[str, Any]) -> None:
+    violations = _assert_invariants(manifest)
+    if violations:
+        raise BaselineError(f"invariant violations: {violations}")
 
 
 def _require_all_active_captures(capture_result: CaptureTickResult, active_ids: list[str]) -> None:
@@ -324,6 +331,7 @@ def _capture_active_subset(
     result = CaptureTickResult()
     id_set = set(active_ids)
     prior = load_captures()
+    existing_vers = load_verifications()
     for rec in records:
         if rec.id not in id_set:
             continue
@@ -340,8 +348,9 @@ def _capture_active_subset(
                 result.hash_changed.append(rec.id)
             else:
                 result.hash_unchanged.append(rec.id)
-            ver = _make_pending_verification(cap)
-            write_verification_sidecar(ver)
+            existing = existing_vers.get(rec.id)
+            if existing is None or existing.reviewer_decision == ReviewerDecision.PENDING:
+                write_verification_sidecar(_make_pending_verification(cap))
         except (CaptureError, Exception) as e:
             result.failures[rec.id] = str(e)
             logger.warning("capture failed %s: %s", rec.id, e)
@@ -568,23 +577,22 @@ def baseline_start(*, duration_days: int = 14, now: datetime | None = None) -> d
             if gate_result.get("actionable_program_ids"):
                 raise BaselineError("ACTIONABLE records after gates")
 
-            violations = _assert_invariants(manifest)
-            if violations:
-                raise BaselineError(f"invariant violations before RUNNING: {violations}")
+            _require_invariants(manifest)
 
-            manifest["status"] = "RUNNING"
-            save_manifest(manifest_path, manifest)
-
+            running_manifest = dict(manifest)
+            running_manifest["status"] = "RUNNING"
             _write_observation(
                 run_dir,
                 kind="day-0",
                 capture_result=capture_result,
                 gate_result=gate_result,
-                manifest=manifest,
+                manifest=running_manifest,
                 now=now,
             )
-            _write_day0_report(run_dir, manifest, capture_result, gate_result)
+            _write_day0_report(run_dir, running_manifest, capture_result, gate_result)
 
+            manifest["status"] = "RUNNING"
+            save_manifest(manifest_path, manifest)
             logger.info("baseline %s started RUNNING", run_id)
             return manifest
         except Exception as e:
@@ -631,6 +639,7 @@ def baseline_tick(*, now: datetime | None = None) -> dict[str, Any]:
         raise BaselineError("rule_changes_allowed is true; refuse tick")
 
     _verify_frozen_artifacts(manifest)
+    _require_invariants(manifest)
     now = now or datetime.now(UTC)
     records, _ = load_registry(REGISTRY_PATH, warn=False)
 
@@ -723,10 +732,9 @@ def baseline_close(*, abort: bool = False, now: datetime | None = None) -> dict[
             f"planned end {_iso_utc(planned_end)} not reached; use --abort to close early"
         )
 
+    _require_invariants(manifest)
     tick_result = baseline_tick(now=now)
     violations = _assert_invariants(manifest)
-    if violations:
-        raise BaselineError(f"invariant violations: {violations}")
 
     gate_result = tick_result["gates"]
     capture_result: CaptureTickResult = tick_result["captures"]

--- a/tools/incentive_ops/capture.py
+++ b/tools/incentive_ops/capture.py
@@ -101,9 +101,12 @@ def ensure_raw_evidence(cap: CaptureRecord) -> bytes:
 def _write_raw_snapshot(pid: str, captured_at: datetime, raw: bytes) -> Path:
     _ensure_dirs()
     ts = captured_at.strftime("%Y%m%dT%H%M%SZ")
+    sha_short = hashlib.sha256(raw).hexdigest()[:16]
     pid_dir = SNAPSHOTS_ROOT / pid
     pid_dir.mkdir(parents=True, exist_ok=True)
-    out = pid_dir / f"{ts}.raw"
+    out = pid_dir / f"{ts}_{sha_short}.raw"
+    if out.exists():
+        return out
     out.write_bytes(raw)
     return out
 

--- a/tools/incentive_ops/cli.py
+++ b/tools/incentive_ops/cli.py
@@ -14,6 +14,13 @@ from src.utils.logger import configure_logger, get_logger
 
 from .accounting import load_ledger, realized_report, validate_caps
 from .actionability import main_actionability
+from .baseline import (
+    BaselineError,
+    baseline_close,
+    baseline_start,
+    baseline_status,
+    baseline_tick,
+)
 from .capture import capture_all
 from .classify import check_classification
 from .deadlines import main_deadlines
@@ -212,6 +219,78 @@ def cmd_report(ledger: str | None) -> None:
     click.echo(f"report: {rpt}")
     if ledger:
         click.echo(f"  loaded from {ledger}")
+
+
+@cli.group("baseline")
+def baseline_group() -> None:
+    """Phase-0 14-day baseline orchestrator (atomic start, no capital)."""
+
+
+@baseline_group.command("start")
+@click.option("--days", default=14, type=int, help="Baseline duration in days")
+def cmd_baseline_start(days: int) -> None:
+    """Atomically freeze universe, capture, gate, and begin RUNNING baseline."""
+    try:
+        manifest = baseline_start(duration_days=days)
+        click.echo(f"Baseline started: {manifest['run_id']}")
+        click.echo(f"  status={manifest['status']}")
+        click.echo(f"  window={manifest['started_at_utc']} → {manifest['planned_end_at_utc']}")
+        click.echo(f"  active_research={len(manifest['active_research_program_ids'])}")
+        click.echo(f"  controls={len(manifest['control_program_ids'])}")
+        sys.exit(0)
+    except BaselineError as e:
+        click.echo(f"BASELINE START FAIL: {e}", err=True)
+        sys.exit(1)
+
+
+@baseline_group.command("tick")
+def cmd_baseline_tick() -> None:
+    """Refetch active-research sources and record one observation."""
+    try:
+        result = baseline_tick()
+        caps = result["captures"]
+        click.echo(f"Tick OK: observation={result['observation']}")
+        click.echo(f"  successes={len(caps.successes)} failures={len(caps.failures)}")
+        click.echo(f"  hash_changed={caps.hash_changed}")
+        sys.exit(0)
+    except BaselineError as e:
+        click.echo(f"BASELINE TICK FAIL: {e}", err=True)
+        sys.exit(1)
+
+
+@baseline_group.command("status")
+def cmd_baseline_status() -> None:
+    """Report elapsed/remaining time and gate counts for the baseline."""
+    try:
+        st = baseline_status()
+        m = st["manifest"]
+        click.echo(f"=== baseline status ({st['status_note']}) ===")
+        click.echo(f"run_id={m['run_id']} status={m['status']}")
+        click.echo(f"elapsed={st['elapsed_seconds']}s remaining={st['remaining_seconds']}s")
+        click.echo(f"verification={st['verification_counts']}")
+        click.echo(f"ev={st['ev_counts']}")
+        click.echo(f"actionability={st['actionability_counts']}")
+        if st["invariant_violations"]:
+            click.echo(f"INVARIANT VIOLATIONS: {st['invariant_violations']}")
+        sys.exit(0)
+    except BaselineError as e:
+        click.echo(f"BASELINE STATUS FAIL: {e}", err=True)
+        sys.exit(1)
+
+
+@baseline_group.command("close")
+@click.option("--abort", is_flag=True, help="Close before planned end (marks ABORTED)")
+def cmd_baseline_close(abort: bool) -> None:
+    """Run final tick, write final.md, set COMPLETE or ABORTED."""
+    try:
+        result = baseline_close(abort=abort)
+        m = result["manifest"]
+        click.echo(f"Baseline closed: {m['run_id']} status={m['status']}")
+        click.echo(f"  ended_at={m['actual_end_at_utc']}")
+        sys.exit(0)
+    except BaselineError as e:
+        click.echo(f"BASELINE CLOSE FAIL: {e}", err=True)
+        sys.exit(1)
 
 
 @cli.command("caps-check")

--- a/tools/incentive_ops/cli.py
+++ b/tools/incentive_ops/cli.py
@@ -227,9 +227,12 @@ def baseline_group() -> None:
 
 
 @baseline_group.command("start")
-@click.option("--days", default=14, type=int, help="Baseline duration in days")
+@click.option("--days", default=14, type=int, help="Baseline duration in days (must be > 0)")
 def cmd_baseline_start(days: int) -> None:
     """Atomically freeze universe, capture, gate, and begin RUNNING baseline."""
+    if days <= 0:
+        click.echo(f"BASELINE START FAIL: --days must be positive, got {days}", err=True)
+        sys.exit(1)
     try:
         manifest = baseline_start(duration_days=days)
         click.echo(f"Baseline started: {manifest['run_id']}")


### PR DESCRIPTION
## Summary

Implements the smallest safe Phase-0 baseline orchestrator for A1 incentive-ops. Adds `baseline start|tick|status|close` CLI commands backed by `tools/incentive_ops/baseline.py`.

**This PR does not execute a real baseline start.** Merge and review first; operator runs `baseline start --days 14` manually after approval.

## What it does

- **Atomic start**: refuses if another RUNNING baseline exists; freezes UTC window, registry/spec hashes, and program sets; captures active-research sources with SHA-256 dedup; writes pending verification sidecars; runs validate/classify/actionability; aborts on any ACTIONABLE; writes day-0 observation + report; sets RUNNING only after all steps succeed.
- **Tick**: refetches active-research only, rebinds pending verification sidecars, records observations, asserts invariants.
- **Status**: elapsed/remaining time, capture/gate counts, invariant violations.
- **Close**: final tick + `final.md`; COMPLETE or ABORTED (early close requires `--abort`).

## Frozen universe (17 records)

| Set | Count | IDs |
|-----|-------|-----|
| **Active research** | 7 | `binance-learn-and-earn`, `coinbase-learning-rewards`, `coinlist-token-sale`, `galxe-quests-oat`, `kaito-yaps`, `layer3-quests`, `legion-merit-sale` |
| **Controls** | 10 | `binance-launchpool`, `capped-cashback-card`, `eigenlayer-restaking-points`, `fixed-threshold-airdrop-archetype`, `lst-restaking-points-archetype`, `metamask-rewards`, `testnet-incentive-archetype`, `undisclosed-sybil-points-farm-archetype`, `uniswap-v3-lp`, `votium-vote-incentives` |

## Quality gates

```
UV_CACHE_DIR=/tmp/uv-cache uv run ruff check .
UV_CACHE_DIR=/tmp/uv-cache uv run ruff format --check .
UV_CACHE_DIR=/tmp/uv-cache uv run pytest -v
git diff --check
```

All pass (1156 passed, 1 skipped).

## Out of scope

- No eligibility adapters (#124/#125)
- No wallet/address/signing/claims/capital/production deploy
- No `src/strategy` or RBI changes