### PR TITLE
feat(incentive_ops): centralize allowlisted GET in a shared client (closes #124)

### DIFF
--- a/tests/test_incentive_ops_capture_eligibility.py
+++ b/tests/test_incentive_ops_capture_eligibility.py
@@ -39,7 +39,7 @@ def test_capture_refuses_unverified():
         capture_program(bad)
 
 
-@patch("tools.incentive_ops.capture.httpx.Client")
+@patch("tools.incentive_ops.http.httpx.Client")
 def test_capture_uses_allowlisted_and_writes_sidecar(mock_client, tmp_path, monkeypatch):
     # setup mock response
     mock_resp = mock_client.return_value.__enter__.return_value.get.return_value
@@ -73,7 +73,35 @@ def test_eligibility_address_only_and_rejects_secrets():
     assert snap.address.startswith("0x")
 
 
-def test_eligibility_blocks_non_allowlisted(monkeypatch):
-    # temporarily break allow for a host? but since adapter uses fixed, test via direct if extended
-    # for now ensure Address + stub path
-    assert True
+def test_allowlisted_get_blocks_non_allowlisted_host():
+    """The shared GET client rejects a non-allowlisted host before any network I/O."""
+    from tools.incentive_ops.http import allowlisted_get
+    from tools.incentive_ops.types import EndpointNotAllowed
+
+    with pytest.raises(EndpointNotAllowed):
+        allowlisted_get("https://evil.com/steal")
+
+
+def test_adapter_cannot_bypass_allowlist_via_shared_client():
+    """An eligibility adapter that omits its own assert_allowed still cannot reach a
+    non-allowlisted host, because the only GET path (allowlisted_get) enforces it (#124)."""
+    from tools.incentive_ops.eligibility import fetch_eligibility_str, register_adapter
+    from tools.incentive_ops.http import allowlisted_get
+    from tools.incentive_ops.types import Address, EligibilitySnapshot, EndpointNotAllowed
+
+    def _rogue_adapter(program_id: str, addr: Address) -> EligibilitySnapshot:
+        # Deliberately no assert_allowed here; the shared client must still block it.
+        resp = allowlisted_get("https://evil.com/points")
+        return EligibilitySnapshot(
+            program_id=program_id,
+            address=str(addr),
+            eligible=None,
+            points_or_allocation=str(resp.status_code),
+            last_updated=None,
+            source="rogue",
+            raw={},
+        )
+
+    register_adapter("rogue-program", _rogue_adapter)
+    with pytest.raises(EndpointNotAllowed):
+        fetch_eligibility_str("rogue-program", "0x0000000000000000000000000000000000000000")

--- a/tests/test_incentive_ops_capture_eligibility.py
+++ b/tests/test_incentive_ops_capture_eligibility.py
@@ -85,6 +85,7 @@ def test_allowlisted_get_blocks_non_allowlisted_host():
 def test_adapter_cannot_bypass_allowlist_via_shared_client():
     """An eligibility adapter that omits its own assert_allowed still cannot reach a
     non-allowlisted host, because the only GET path (allowlisted_get) enforces it (#124)."""
+    from tools.incentive_ops import eligibility as eligmod
     from tools.incentive_ops.eligibility import fetch_eligibility_str, register_adapter
     from tools.incentive_ops.http import allowlisted_get
     from tools.incentive_ops.types import Address, EligibilitySnapshot, EndpointNotAllowed
@@ -103,5 +104,24 @@ def test_adapter_cannot_bypass_allowlist_via_shared_client():
         )
 
     register_adapter("rogue-program", _rogue_adapter)
-    with pytest.raises(EndpointNotAllowed):
-        fetch_eligibility_str("rogue-program", "0x0000000000000000000000000000000000000000")
+    try:
+        with pytest.raises(EndpointNotAllowed):
+            fetch_eligibility_str("rogue-program", "0x0000000000000000000000000000000000000000")
+    finally:
+        eligmod._ADAPTERS.pop("rogue-program", None)
+
+
+@patch("tools.incentive_ops.http.httpx.Client")
+def test_allowlisted_get_rejects_3xx(mock_client):
+    """3xx responses must raise even though httpx.raise_for_status() accepts them."""
+    import httpx
+
+    from tools.incentive_ops.http import allowlisted_get
+
+    mock_resp = mock_client.return_value.__enter__.return_value.get.return_value
+    mock_resp.status_code = 304
+    mock_resp.raise_for_status = lambda: None
+    mock_resp.request = httpx.Request("GET", "https://layer3.xyz/")
+
+    with pytest.raises(httpx.HTTPStatusError, match="non-2xx \\(304\\)"):
+        allowlisted_get("https://layer3.xyz/")

--- a/tools/incentive_ops/capture.py
+++ b/tools/incentive_ops/capture.py
@@ -18,7 +18,8 @@ import yaml
 
 from src.utils.logger import get_logger
 
-from .allowlist import assert_allowed, is_allowed_url
+from .allowlist import is_allowed_url
+from .http import allowlisted_get
 from .registry import load_registry
 from .types import (
     CaptureError,
@@ -62,13 +63,12 @@ def _is_unverified(url: str) -> bool:
 
 
 def fetch_raw(url: str, timeout: float = 30.0) -> bytes:
-    assert_allowed(url)
     if _is_unverified(url):
         raise CaptureError(f"Refusing UNVERIFIED source: {url}")
+    # allowlisted_get enforces the allowlist (EndpointNotAllowed, propagated) and
+    # never follows redirects; it is the single sanctioned GET path.
     try:
-        with httpx.Client(follow_redirects=False, timeout=timeout) as client:
-            resp = client.get(url)
-            resp.raise_for_status()
+        resp = allowlisted_get(url, timeout=timeout)
     except httpx.HTTPError as e:
         raise CaptureError(f"GET failed for {url}: {e}") from e
     # Only a 200 with a non-empty body is a real snapshot. A 202/204/redirect-with-no-body

--- a/tools/incentive_ops/eligibility.py
+++ b/tools/incentive_ops/eligibility.py
@@ -8,11 +8,9 @@ from __future__ import annotations
 
 from collections.abc import Callable
 
-import httpx
-
 from src.utils.logger import get_logger
 
-from .allowlist import assert_allowed
+from .http import allowlisted_get
 from .types import Address, EligibilitySnapshot
 
 logger = get_logger(__name__)
@@ -44,12 +42,11 @@ def _default_stub(program_id: str, addr: Address) -> EligibilitySnapshot:
 def _example_layer3_adapter(program_id: str, addr: Address) -> EligibilitySnapshot:
     # Example adapter using allowlisted host. In real would query specific quest API if public.
     # For demo we GET the program page (allowlisted) and report no structured points.
+    # The GET goes through the shared allowlisted client, so the allowlist is
+    # enforced even though this adapter no longer calls assert_allowed itself.
     url = "https://layer3.xyz/"
-    assert_allowed(url)
     try:
-        with httpx.Client(timeout=15.0) as client:
-            r = client.get(url)
-            r.raise_for_status()
+        r = allowlisted_get(url, timeout=15.0)
         return EligibilitySnapshot(
             program_id=program_id,
             address=str(addr),

--- a/tools/incentive_ops/http.py
+++ b/tools/incentive_ops/http.py
@@ -33,4 +33,11 @@ def allowlisted_get(url: str, *, timeout: float = DEFAULT_TIMEOUT) -> httpx.Resp
     with httpx.Client(follow_redirects=False, timeout=timeout) as client:
         resp = client.get(url)
     resp.raise_for_status()
+    # raise_for_status() ignores 3xx when redirects are disabled; enforce full 2xx contract.
+    if not 200 <= resp.status_code < 300:
+        raise httpx.HTTPStatusError(
+            f"non-2xx ({resp.status_code}) for {url}",
+            request=resp.request,
+            response=resp,
+        )
     return resp

--- a/tools/incentive_ops/http.py
+++ b/tools/incentive_ops/http.py
@@ -1,0 +1,36 @@
+"""http.py — the single read-only, allowlisted GET path for incentive-ops.
+
+Every outbound GET in this package MUST go through ``allowlisted_get`` so the
+endpoint allowlist cannot be bypassed by a module — or a future eligibility
+adapter — that forgets to call ``assert_allowed``. GET only, no redirects
+(an allowlisted host must not be able to 30x us onto a non-allowlisted one),
+no auth.
+"""
+
+from __future__ import annotations
+
+import httpx
+
+from src.utils.logger import get_logger
+
+from .allowlist import assert_allowed
+
+logger = get_logger(__name__)
+
+DEFAULT_TIMEOUT = 30.0
+
+
+def allowlisted_get(url: str, *, timeout: float = DEFAULT_TIMEOUT) -> httpx.Response:
+    """Perform a read-only GET, enforcing the endpoint allowlist first.
+
+    The ONLY sanctioned way for incentive-ops modules to issue an HTTP GET.
+    Raises ``EndpointNotAllowed`` (before any network I/O) if ``url`` is not
+    allowlisted, never follows redirects, and raises ``httpx.HTTPError`` on a
+    transport error or non-2xx status. Callers do their own body/status
+    validation on the returned response.
+    """
+    assert_allowed(url)
+    with httpx.Client(follow_redirects=False, timeout=timeout) as client:
+        resp = client.get(url)
+    resp.raise_for_status()
+    return resp


### PR DESCRIPTION
Closes #124.

## Summary
Adds `tools/incentive_ops/http.py::allowlisted_get` — the single sanctioned outbound GET path for the incentive-ops package. It enforces the endpoint allowlist (`EndpointNotAllowed` before any network I/O) and never follows redirects (an allowlisted host can't 30x us onto a non-allowlisted one). `capture.fetch_raw` and the eligibility adapter now route through it, so a module — or a future eligibility adapter — that forgets `assert_allowed` **cannot** reach a non-allowlisted host.

## Tests
- `allowlisted_get` rejects a non-allowlisted host (`EndpointNotAllowed`).
- A rogue eligibility adapter that omits `assert_allowed` is still blocked via the shared client (the issue's acceptance criterion).
- Capture mock retargeted to `tools.incentive_ops.http.httpx.Client`.
- Full suite: 1170 passed, 1 skipped.

## ⚠️ Merge hold — do not merge before 2026-07-11
The A1 Phase-0 baseline (`baseline-20260630T222523Z`) is **RUNNING** and freezes the `tools/incentive_ops/` tooling by content hash for the window. This PR changes that tooling, so merging it to `main` before the baseline closes (2026-07-11) will make the daily tick abort with `incentive_ops tooling content changed since baseline start`. Merge after `baseline close`. (This is the freeze working as designed.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)