### PR TITLE
[incentive-ops] EIP-55 checksum + Solana base58 on Address (#125)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,7 @@ dependencies = [
     "asyncpg>=0.29.0",
     "openai>=1.0.0",
     "yfinance>=0.2.40",
+    "eth-hash[pycryptodome]>=0.8.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_incentive_ops_types.py
+++ b/tests/test_incentive_ops_types.py
@@ -31,6 +31,30 @@ def test_address_evm_ok():
     assert str(a) == "0x0000000000000000000000000000000000000000"
 
 
+def test_address_accepts_valid_eip55_checksum():
+    vitalik = "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
+    a = Address(vitalik)
+    assert str(a) == vitalik
+
+
+def test_address_accepts_non_checksummed_evm_case():
+    lower = "0xd8da6bf26964af9d7eed9e03e53415d37aa96045"
+    upper = "0xD8DA6BF26964AF9D7EED9E03E53415D37AA96045"
+    assert str(Address(lower)) == lower
+    assert str(Address(upper)) == upper
+
+
+def test_address_rejects_wrong_eip55_checksum():
+    with pytest.raises(ValueError, match="Invalid EIP-55 checksum"):
+        Address("0xd8dA6BF26964aF9D7eEd9e03E53415D37aA9604E")
+
+
+def test_address_accepts_solana_base58_pubkey():
+    wrapped_sol = "So11111111111111111111111111111111111111112"
+    a = Address(wrapped_sol)
+    assert str(a) == wrapped_sol
+
+
 def test_address_rejects_privkey():
     with pytest.raises(SuspectedSecretError):
         Address("0x" + "a" * 64)

--- a/tools/incentive_ops/types.py
+++ b/tools/incentive_ops/types.py
@@ -12,6 +12,8 @@ from datetime import date, datetime
 from enum import StrEnum
 from typing import Any
 
+from eth_hash.auto import keccak
+
 
 # Errors (fail closed)
 class SuspectedSecretError(ValueError):
@@ -283,11 +285,14 @@ class EligibilitySnapshot:
 
 
 class Address:
-    """Validated address value object. Address-only. Rejects secrets. EVM primary."""
+    """Validated address value object. Address-only. Rejects secrets. EVM + Solana."""
 
     _EVM_RE = re.compile(r"^0x[0-9a-fA-F]{40}$")
     _PRIVKEY_RE = re.compile(r"^(0x)?[0-9a-fA-F]{64}$")
     _MNEMONIC_WORD_RE = re.compile(r"^[a-z]+$")
+    _SOLANA_RE = re.compile(r"^[1-9A-HJ-NP-Za-km-z]{32,44}$")
+    _BASE58_ALPHABET = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
+    _BASE58_INDEX = {c: i for i, c in enumerate(_BASE58_ALPHABET)}
 
     def __init__(self, value: str) -> None:
         if not isinstance(value, str):
@@ -298,8 +303,13 @@ class Address:
         if self._looks_like_secret(v):
             # Never include the value in the exception message or attributes
             raise SuspectedSecretError("Input looks like a private key or mnemonic seed; rejected")
-        if not self._is_valid_format(v):
-            raise ValueError("Invalid address format (expected EVM 0x + 40 hex)")
+        fmt = self._detect_format(v)
+        if fmt is None:
+            raise ValueError(
+                "Invalid address format (expected EVM 0x + 40 hex or Solana base58 pubkey)"
+            )
+        if fmt == "evm":
+            self._validate_eip55(v)
         self._value = self._normalize(v)
 
     @staticmethod
@@ -314,8 +324,59 @@ class Address:
         return False
 
     @staticmethod
-    def _is_valid_format(v: str) -> bool:
-        return bool(Address._EVM_RE.match(v))
+    def _detect_format(v: str) -> str | None:
+        if Address._EVM_RE.match(v):
+            return "evm"
+        if Address._is_solana_pubkey(v):
+            return "solana"
+        return None
+
+    @staticmethod
+    def _b58decode(value: str) -> bytes:
+        num = 0
+        for char in value:
+            num = num * 58 + Address._BASE58_INDEX[char]
+        pad = 0
+        for char in value:
+            if char == "1":
+                pad += 1
+            else:
+                break
+        decoded = num.to_bytes((num.bit_length() + 7) // 8, "big") if num else b""
+        return b"\x00" * pad + decoded
+
+    @staticmethod
+    def _is_solana_pubkey(v: str) -> bool:
+        if not Address._SOLANA_RE.match(v):
+            return False
+        try:
+            return len(Address._b58decode(v)) == 32
+        except KeyError:
+            return False
+
+    @staticmethod
+    def _eip55_checksum(hex_addr: str) -> str:
+        """Return ``0x`` + EIP-55 checksummed address for a 40-char hex string (any case)."""
+        lower = hex_addr.lower()
+        digest = keccak(lower.encode("ascii")).hex()
+        out = ["0x"]
+        for i, ch in enumerate(lower):
+            if ch in "0123456789":
+                out.append(ch)
+            elif int(digest[i], 16) >= 8:
+                out.append(ch.upper())
+            else:
+                out.append(ch)
+        return "".join(out)
+
+    @staticmethod
+    def _validate_eip55(v: str) -> None:
+        hex_part = v[2:]
+        # All-lower or all-upper are accepted as non-checksummed (incl. all-digit addresses).
+        if hex_part == hex_part.lower() or hex_part == hex_part.upper():
+            return
+        if v != Address._eip55_checksum(hex_part):
+            raise ValueError("Invalid EIP-55 checksum")
 
     @staticmethod
     def _normalize(v: str) -> str:

--- a/uv.lock
+++ b/uv.lock
@@ -573,6 +573,7 @@ dependencies = [
     { name = "aiohttp" },
     { name = "asyncpg" },
     { name = "click" },
+    { name = "eth-hash", extra = ["pycryptodome"] },
     { name = "httpx" },
     { name = "openai" },
     { name = "pg8000" },
@@ -598,6 +599,7 @@ requires-dist = [
     { name = "asyncpg", specifier = ">=0.29.0" },
     { name = "black", marker = "extra == 'dev'", specifier = ">=24.0.0" },
     { name = "click", specifier = ">=8.1.0" },
+    { name = "eth-hash", extras = ["pycryptodome"], specifier = ">=0.8.0" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.10.0" },
     { name = "openai", specifier = ">=1.0.0" },
@@ -653,6 +655,20 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
+]
+
+[[package]]
+name = "eth-hash"
+version = "0.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3c/f5/c67fc24f2f676aa9b7ab29679d44f113f314c817207cd4319353356f62da/eth_hash-0.8.0.tar.gz", hash = "sha256:b009752b620da2e9c7668014849d1f5fadbe4f138603f1871cc5d4ca706896b1", size = 12225, upload-time = "2026-03-25T16:36:55.099Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/87/b36792150ca0b28e4df683a34be15a61461ca0e349e5b5cf3ec8f694edb9/eth_hash-0.8.0-py3-none-any.whl", hash = "sha256:523718a51b369ab89866b929a5c93c52978cd866ea309192ad980dd8271f9fac", size = 7965, upload-time = "2026-03-25T16:36:54.205Z" },
+]
+
+[package.optional-dependencies]
+pycryptodome = [
+    { name = "pycryptodome" },
 ]
 
 [[package]]
@@ -1514,6 +1530,36 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
+]
+
+[[package]]
+name = "pycryptodome"
+version = "3.23.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/a6/8452177684d5e906854776276ddd34eca30d1b1e15aa1ee9cefc289a33f5/pycryptodome-3.23.0.tar.gz", hash = "sha256:447700a657182d60338bab09fdb27518f8856aecd80ae4c6bdddb67ff5da44ef", size = 4921276, upload-time = "2025-05-17T17:21:45.242Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/5d/bdb09489b63cd34a976cc9e2a8d938114f7a53a74d3dd4f125ffa49dce82/pycryptodome-3.23.0-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:0011f7f00cdb74879142011f95133274741778abba114ceca229adbf8e62c3e4", size = 2495152, upload-time = "2025-05-17T17:20:20.833Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/ce/7840250ed4cc0039c433cd41715536f926d6e86ce84e904068eb3244b6a6/pycryptodome-3.23.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:90460fc9e088ce095f9ee8356722d4f10f86e5be06e2354230a9880b9c549aae", size = 1639348, upload-time = "2025-05-17T17:20:23.171Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/f0/991da24c55c1f688d6a3b5a11940567353f74590734ee4a64294834ae472/pycryptodome-3.23.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4764e64b269fc83b00f682c47443c2e6e85b18273712b98aa43bcb77f8570477", size = 2184033, upload-time = "2025-05-17T17:20:25.424Z" },
+    { url = "https://files.pythonhosted.org/packages/54/16/0e11882deddf00f68b68dd4e8e442ddc30641f31afeb2bc25588124ac8de/pycryptodome-3.23.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eb8f24adb74984aa0e5d07a2368ad95276cf38051fe2dc6605cbcf482e04f2a7", size = 2270142, upload-time = "2025-05-17T17:20:27.808Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/fc/4347fea23a3f95ffb931f383ff28b3f7b1fe868739182cb76718c0da86a1/pycryptodome-3.23.0-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d97618c9c6684a97ef7637ba43bdf6663a2e2e77efe0f863cce97a76af396446", size = 2309384, upload-time = "2025-05-17T17:20:30.765Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/d9/c5261780b69ce66d8cfab25d2797bd6e82ba0241804694cd48be41add5eb/pycryptodome-3.23.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9a53a4fe5cb075075d515797d6ce2f56772ea7e6a1e5e4b96cf78a14bac3d265", size = 2183237, upload-time = "2025-05-17T17:20:33.736Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/6f/3af2ffedd5cfa08c631f89452c6648c4d779e7772dfc388c77c920ca6bbf/pycryptodome-3.23.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:763d1d74f56f031788e5d307029caef067febf890cd1f8bf61183ae142f1a77b", size = 2343898, upload-time = "2025-05-17T17:20:36.086Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/dc/9060d807039ee5de6e2f260f72f3d70ac213993a804f5e67e0a73a56dd2f/pycryptodome-3.23.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:954af0e2bd7cea83ce72243b14e4fb518b18f0c1649b576d114973e2073b273d", size = 2269197, upload-time = "2025-05-17T17:20:38.414Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/34/e6c8ca177cb29dcc4967fef73f5de445912f93bd0343c9c33c8e5bf8cde8/pycryptodome-3.23.0-cp313-cp313t-win32.whl", hash = "sha256:257bb3572c63ad8ba40b89f6fc9d63a2a628e9f9708d31ee26560925ebe0210a", size = 1768600, upload-time = "2025-05-17T17:20:40.688Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/1d/89756b8d7ff623ad0160f4539da571d1f594d21ee6d68be130a6eccb39a4/pycryptodome-3.23.0-cp313-cp313t-win_amd64.whl", hash = "sha256:6501790c5b62a29fcb227bd6b62012181d886a767ce9ed03b303d1f22eb5c625", size = 1799740, upload-time = "2025-05-17T17:20:42.413Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/61/35a64f0feaea9fd07f0d91209e7be91726eb48c0f1bfc6720647194071e4/pycryptodome-3.23.0-cp313-cp313t-win_arm64.whl", hash = "sha256:9a77627a330ab23ca43b48b130e202582e91cc69619947840ea4d2d1be21eb39", size = 1703685, upload-time = "2025-05-17T17:20:44.388Z" },
+    { url = "https://files.pythonhosted.org/packages/db/6c/a1f71542c969912bb0e106f64f60a56cc1f0fabecf9396f45accbe63fa68/pycryptodome-3.23.0-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:187058ab80b3281b1de11c2e6842a357a1f71b42cb1e15bce373f3d238135c27", size = 2495627, upload-time = "2025-05-17T17:20:47.139Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/4e/a066527e079fc5002390c8acdd3aca431e6ea0a50ffd7201551175b47323/pycryptodome-3.23.0-cp37-abi3-macosx_10_9_x86_64.whl", hash = "sha256:cfb5cd445280c5b0a4e6187a7ce8de5a07b5f3f897f235caa11f1f435f182843", size = 1640362, upload-time = "2025-05-17T17:20:50.392Z" },
+    { url = "https://files.pythonhosted.org/packages/50/52/adaf4c8c100a8c49d2bd058e5b551f73dfd8cb89eb4911e25a0c469b6b4e/pycryptodome-3.23.0-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:67bd81fcbe34f43ad9422ee8fd4843c8e7198dd88dd3d40e6de42ee65fbe1490", size = 2182625, upload-time = "2025-05-17T17:20:52.866Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/e9/a09476d436d0ff1402ac3867d933c61805ec2326c6ea557aeeac3825604e/pycryptodome-3.23.0-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c8987bd3307a39bc03df5c8e0e3d8be0c4c3518b7f044b0f4c15d1aa78f52575", size = 2268954, upload-time = "2025-05-17T17:20:55.027Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/c5/ffe6474e0c551d54cab931918127c46d70cab8f114e0c2b5a3c071c2f484/pycryptodome-3.23.0-cp37-abi3-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:aa0698f65e5b570426fc31b8162ed4603b0c2841cbb9088e2b01641e3065915b", size = 2308534, upload-time = "2025-05-17T17:20:57.279Z" },
+    { url = "https://files.pythonhosted.org/packages/18/28/e199677fc15ecf43010f2463fde4c1a53015d1fe95fb03bca2890836603a/pycryptodome-3.23.0-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:53ecbafc2b55353edcebd64bf5da94a2a2cdf5090a6915bcca6eca6cc452585a", size = 2181853, upload-time = "2025-05-17T17:20:59.322Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/ea/4fdb09f2165ce1365c9eaefef36625583371ee514db58dc9b65d3a255c4c/pycryptodome-3.23.0-cp37-abi3-musllinux_1_2_i686.whl", hash = "sha256:156df9667ad9f2ad26255926524e1c136d6664b741547deb0a86a9acf5ea631f", size = 2342465, upload-time = "2025-05-17T17:21:03.83Z" },
+    { url = "https://files.pythonhosted.org/packages/22/82/6edc3fc42fe9284aead511394bac167693fb2b0e0395b28b8bedaa07ef04/pycryptodome-3.23.0-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:dea827b4d55ee390dc89b2afe5927d4308a8b538ae91d9c6f7a5090f397af1aa", size = 2267414, upload-time = "2025-05-17T17:21:06.72Z" },
+    { url = "https://files.pythonhosted.org/packages/59/fe/aae679b64363eb78326c7fdc9d06ec3de18bac68be4b612fc1fe8902693c/pycryptodome-3.23.0-cp37-abi3-win32.whl", hash = "sha256:507dbead45474b62b2bbe318eb1c4c8ee641077532067fec9c1aa82c31f84886", size = 1768484, upload-time = "2025-05-17T17:21:08.535Z" },
+    { url = "https://files.pythonhosted.org/packages/54/2f/e97a1b8294db0daaa87012c24a7bb714147c7ade7656973fd6c736b484ff/pycryptodome-3.23.0-cp37-abi3-win_amd64.whl", hash = "sha256:c75b52aacc6c0c260f204cbdd834f76edc9fb0d8e0da9fbf8352ef58202564e2", size = 1799636, upload-time = "2025-05-17T17:21:10.393Z" },
+    { url = "https://files.pythonhosted.org/packages/18/3d/f9441a0d798bf2b1e645adc3265e55706aead1255ccdad3856dbdcffec14/pycryptodome-3.23.0-cp37-abi3-win_arm64.whl", hash = "sha256:11eeeb6917903876f134b56ba11abe95c0b0fd5e3330def218083c7d98bbcb3c", size = 1703675, upload-time = "2025-05-17T17:21:13.146Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #125.

## Summary
- EIP-55 mixed-case checksum validation for EVM addresses (accept all-lower/all-upper as non-checksummed)
- Solana base58 pubkey format validation behind the same `Address` VO
- Existing `SuspectedSecretError` rejection of key/seed-shaped input unchanged
- Adds `eth-hash[pycryptodome]` for keccak256

## Tests
- Valid checksummed address accepted
- Wrong-checksum mixed-case rejected
- Key/seed input still `SuspectedSecretError`
- `uv run pytest tests/test_incentive_ops_*.py -q` → 75 passed

Phase-0 read-only; no config/baseline manifest changes. Merge gated until 2026-07-11 tooling freeze window closes.