### PR TITLE
fix(monitoring): route crypto alerts to Alertmanager, dedupe drift sentinel

### DIFF
--- a/config/prometheus.yml
+++ b/config/prometheus.yml
@@ -1,6 +1,14 @@
 global:
   scrape_interval: 15s
 
+# Alerts are routed through the ctrader stack's Alertmanager (shared on this
+# host via the external ctrader-network), which owns the Telegram receiver.
+alerting:
+  alertmanagers:
+    - static_configs:
+        - targets:
+            - ctrader-alertmanager:9093
+
 rule_files:
   - /etc/prometheus/alerts.yml
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -102,6 +102,7 @@ services:
           memory: 256M
     networks:
       - crypto-net
+      - ctrader-net
     logging:
       driver: "json-file"
       options:
@@ -233,3 +234,8 @@ networks:
     ipam:
       config:
         - subnet: 172.28.0.0/16
+  # Existing network of the ctrader monitoring stack; gives Prometheus a route
+  # to ctrader-alertmanager for alert delivery (see config/prometheus.yml).
+  ctrader-net:
+    external: true
+    name: ctrader-network

--- a/ops/systemd/crypto-agent-production-drift-sentinel.service
+++ b/ops/systemd/crypto-agent-production-drift-sentinel.service
@@ -10,7 +10,7 @@ User=emilio
 WorkingDirectory=/opt/crypto-agent
 Environment=EXPECTED_DEPLOY_BRANCH=main
 EnvironmentFile=-/etc/default/crypto-agent-production-drift-sentinel
-ExecStart=/usr/bin/python3 scripts/production_drift_sentinel.py --production-local --remote-dir /opt/crypto-agent --watch-service agent_sol_sparse --signal-stale-hours 72 --fail-on error --output-prefix data/reports/production-drift-sentinel
+ExecStart=/usr/bin/python3 scripts/production_drift_sentinel.py --production-local --remote-dir /opt/crypto-agent --watch-service agent_sol_sparse --signal-stale-hours 72 --fail-on error --output-prefix data/reports/production-drift-sentinel --dedupe-state data/reports/.production-drift-sentinel.last-alert
 
 [Install]
 WantedBy=multi-user.target

--- a/scripts/production_drift_sentinel.py
+++ b/scripts/production_drift_sentinel.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import os
 import sys
@@ -63,6 +64,13 @@ def parse_args() -> argparse.Namespace:
         default="docs/reports/production-drift-sentinel",
         help="Path prefix for markdown/json artifacts",
     )
+    parser.add_argument(
+        "--dedupe-state",
+        help=(
+            "Path to a state file recording the last alerted findings; when set, "
+            "an unchanged set of findings exits 0 so schedulers only alert on change"
+        ),
+    )
     return parser.parse_args()
 
 
@@ -77,6 +85,32 @@ def _exit_code(fail_on: str, findings: list[object]) -> int:
     if fail_on == "warning":
         return 1 if (has_error or has_warning) else 0
     return 1 if has_error else 0
+
+
+def _findings_fingerprint(findings: list[object]) -> str:
+    parts = sorted(
+        f"{getattr(finding, 'severity', '')}|{getattr(finding, 'code', '')}|{getattr(finding, 'message', '')}"
+        for finding in findings
+    )
+    return hashlib.sha256("\n".join(parts).encode("utf-8")).hexdigest()
+
+
+def _apply_dedupe(exit_code: int, state_path: Path, fingerprint: str) -> int:
+    previous: str | None = None
+    if state_path.exists():
+        previous = state_path.read_text(encoding="utf-8").strip() or None
+
+    if exit_code == 0:
+        state_path.unlink(missing_ok=True)
+        return 0
+
+    if previous == fingerprint:
+        print("Findings unchanged since last alert; exiting 0 (dedupe)")
+        return 0
+
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    state_path.write_text(fingerprint + "\n", encoding="utf-8")
+    return exit_code
 
 
 def _render_markdown(report: DriftReport, expected_branch: str) -> str:
@@ -330,7 +364,14 @@ def main() -> int:
     print(f"Markdown report: {markdown_path}")
     print(f"JSON report: {json_path}")
 
-    return _exit_code(args.fail_on, report.findings)
+    exit_code = _exit_code(args.fail_on, report.findings)
+    if args.dedupe_state:
+        exit_code = _apply_dedupe(
+            exit_code,
+            Path(args.dedupe_state),
+            _findings_fingerprint(report.findings),
+        )
+    return exit_code
 
 
 if __name__ == "__main__":

--- a/tests/test_production_drift_sentinel.py
+++ b/tests/test_production_drift_sentinel.py
@@ -443,3 +443,68 @@ def test_analyze_drift_detects_watched_service_signal_drought() -> None:
 
     codes = {finding.code for finding in findings}
     assert "WATCH_SERVICE_SIGNAL_DROUGHT" in codes
+
+
+def _load_sentinel_script():
+    import importlib.util
+    from pathlib import Path
+
+    root = Path(__file__).resolve().parent.parent
+    spec = importlib.util.spec_from_file_location(
+        "production_drift_sentinel_script",
+        root / "scripts" / "production_drift_sentinel.py",
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _finding(severity: str, code: str, message: str) -> object:
+    from types import SimpleNamespace
+
+    return SimpleNamespace(severity=severity, code=code, message=message)
+
+
+def test_dedupe_first_alert_passes_through_and_records_state(tmp_path) -> None:
+    script = _load_sentinel_script()
+    state = tmp_path / "state"
+    findings = [_finding("error", "GIT_DRIFT", "branch mismatch")]
+
+    result = script._apply_dedupe(1, state, script._findings_fingerprint(findings))
+
+    assert result == 1
+    assert state.exists()
+
+
+def test_dedupe_suppresses_repeat_of_same_findings(tmp_path) -> None:
+    script = _load_sentinel_script()
+    state = tmp_path / "state"
+    fingerprint = script._findings_fingerprint([_finding("error", "GIT_DRIFT", "branch mismatch")])
+
+    assert script._apply_dedupe(1, state, fingerprint) == 1
+    assert script._apply_dedupe(1, state, fingerprint) == 0
+
+
+def test_dedupe_alerts_again_when_findings_change(tmp_path) -> None:
+    script = _load_sentinel_script()
+    state = tmp_path / "state"
+
+    first = script._findings_fingerprint([_finding("error", "GIT_DRIFT", "branch mismatch")])
+    second = script._findings_fingerprint(
+        [_finding("error", "WATCH_SERVICE_SIGNAL_DROUGHT", "no signals")]
+    )
+
+    assert script._apply_dedupe(1, state, first) == 1
+    assert script._apply_dedupe(1, state, second) == 1
+
+
+def test_dedupe_clean_run_resets_state_so_next_drift_alerts(tmp_path) -> None:
+    script = _load_sentinel_script()
+    state = tmp_path / "state"
+    fingerprint = script._findings_fingerprint([_finding("error", "GIT_DRIFT", "branch mismatch")])
+
+    assert script._apply_dedupe(1, state, fingerprint) == 1
+    assert script._apply_dedupe(0, state, script._findings_fingerprint([])) == 0
+    assert not state.exists()
+    assert script._apply_dedupe(1, state, fingerprint) == 1

--- a/tests/test_production_drift_sentinel.py
+++ b/tests/test_production_drift_sentinel.py
@@ -447,6 +447,7 @@ def test_analyze_drift_detects_watched_service_signal_drought() -> None:
 
 def _load_sentinel_script():
     import importlib.util
+    import sys
     from pathlib import Path
 
     root = Path(__file__).resolve().parent.parent
@@ -454,9 +455,14 @@ def _load_sentinel_script():
         "production_drift_sentinel_script",
         root / "scripts" / "production_drift_sentinel.py",
     )
-    module = importlib.util.module_from_spec(spec)
+    assert spec is not None
     assert spec.loader is not None
-    spec.loader.exec_module(module)
+    module = importlib.util.module_from_spec(spec)
+    original_sys_path = list(sys.path)
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        sys.path[:] = original_sys_path
     return module
 
 


### PR DESCRIPTION
## Context

A full server audit on 2026-07-05 found that a critical `AgentNotCycling` alert went unnoticed for ~29h. Two contributing monitoring defects live in this repo:

1. **Alerts evaluated into the void**: `config/prometheus.yml` loads `prometheus-alerts.yml` (3 rules) but had no `alerting:` section — firing alerts were never delivered anywhere.
2. **Alert fatigue by design**: the production drift sentinel exits 1 whenever drift findings exist, and the hourly timer's `OnFailure` hook re-sent the same Telegram alert every hour (52 notifications in 24h for one ongoing drift). Real criticals drown in this noise.

## Changes

- **`config/prometheus.yml`**: add `alerting:` section targeting `ctrader-alertmanager:9093` — the Alertmanager already running on this host with a working Telegram receiver (avoids standing up a third monitoring stack).
- **`docker-compose.prod.yml`**: attach the `prometheus` service to the external `ctrader-network` so it can reach that Alertmanager.
- **`scripts/production_drift_sentinel.py`**: new optional `--dedupe-state <file>` flag. When set, an unchanged set of findings exits 0 (suppressing the systemd `OnFailure` re-alert); the alert fires again only when findings change, and a clean run clears the state so the next drift alerts immediately.
- **`ops/systemd/crypto-agent-production-drift-sentinel.service`**: pass `--dedupe-state data/reports/.production-drift-sentinel.last-alert`.
- **`tests/test_production_drift_sentinel.py`**: 4 new tests covering first-alert passthrough, repeat suppression, change re-alerting, and state reset on clean runs.

## Validation

- `promtool check config`: SUCCESS (config + 3 rules)
- `docker compose -f docker-compose.prod.yml config`: valid
- `pytest tests/test_production_drift_sentinel.py`: 23 passed (19 existing + 4 new)

## Deploy notes

After merge, on the server: `docker compose -f docker-compose.prod.yml up -d prometheus` (picks up the network + config), copy the updated unit to `/etc/systemd/system/` and `systemctl daemon-reload`. The `ctrader-network` docker network must exist (it does — created by the ctrader stack).

🤖 Generated with [Claude Code](https://claude.com/claude-code)