### PR TITLE
feat(tests): CI guard for incentive-ops baseline freeze

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ jobs:
         run: uv run ruff check .
       - name: Run ruff format
         run: uv run ruff format --check .
+      - name: Incentive-ops baseline freeze guard
+        run: uv run python scripts/check_incentive_ops_freeze.py
 
   test:
     runs-on: ubuntu-latest

--- a/scripts/check_incentive_ops_freeze.py
+++ b/scripts/check_incentive_ops_freeze.py
@@ -77,8 +77,16 @@ def main() -> int:
     manifests = sorted(RUNS_ROOT.glob("*/manifest.yaml")) if RUNS_ROOT.is_dir() else []
     running = []
     for mp in manifests:
-        data = yaml.safe_load(mp.read_text(encoding="utf-8"))
-        if isinstance(data, dict) and data.get("status") == "RUNNING":
+        try:
+            data = yaml.safe_load(mp.read_text(encoding="utf-8"))
+        except yaml.YAMLError as exc:
+            print(f"freeze-guard: FAIL — unparseable manifest {mp}: {exc}", file=sys.stderr)
+            return 1
+        if not isinstance(data, dict):
+            # An empty/non-mapping manifest must not silently read as "no baseline".
+            print(f"freeze-guard: FAIL — manifest is not a mapping: {mp}", file=sys.stderr)
+            return 1
+        if data.get("status") == "RUNNING":
             running.append((mp, data))
 
     if not running:

--- a/scripts/check_incentive_ops_freeze.py
+++ b/scripts/check_incentive_ops_freeze.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""CI guard: refuse changes to frozen incentive-ops artifacts during a RUNNING baseline.
+
+Scans research/a1-incentive-farming/runs/*/manifest.yaml for a RUNNING baseline.
+If one exists, recomputes the content hashes of the five frozen artifacts
+(registry, handoff, spec, tooling tree, endpoint allowlist) from the working
+tree and compares them to the manifest — the same semantics as the daily tick's
+_verify_frozen_artifacts, so a PR that touches a frozen path without changing
+its content still passes.
+
+Exit 0: no RUNNING baseline, or all frozen hashes match.
+Exit 1: at least one frozen artifact differs from its manifest hash.
+
+Deliberately standalone (only pyyaml) and outside tools/incentive_ops/, so the
+guard itself is not part of the frozen surface it protects.
+"""
+
+import hashlib
+import sys
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+RUNS_ROOT = REPO_ROOT / "research/a1-incentive-farming/runs"
+TOOLING_DIR = REPO_ROOT / "tools/incentive_ops"
+REGISTRY_PATH = REPO_ROOT / "research/a1-incentive-farming/starter-registry-v0.yaml"
+ALLOWLIST_PATH = REPO_ROOT / "config/incentive_ops/endpoint_allowlist.yaml"
+
+
+def _sha256_file(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _sha256_tree(root: Path, *, suffix: str = ".py") -> str:
+    """Mirror of tools.incentive_ops.baseline._sha256_tree (kept standalone)."""
+    h = hashlib.sha256()
+    for p in sorted(root.rglob(f"*{suffix}")):
+        if "__pycache__" in p.parts:
+            continue
+        h.update(p.relative_to(root).as_posix().encode())
+        h.update(b"\0")
+        h.update(p.read_bytes())
+        h.update(b"\0")
+    return h.hexdigest()
+
+
+def _frozen_artifact_mismatches(manifest: dict) -> list[str]:
+    """Return one message per frozen artifact whose current hash differs."""
+    checks = [
+        ("registry", REGISTRY_PATH, manifest.get("registry_sha256")),
+        ("handoff", REPO_ROOT / manifest.get("handoff_path", ""), manifest.get("handoff_sha256")),
+        ("spec", REPO_ROOT / manifest.get("spec_path", ""), manifest.get("spec_sha256")),
+        ("allowlist", ALLOWLIST_PATH, manifest.get("allowlist_sha256")),
+    ]
+    mismatches: list[str] = []
+    for name, path, expected in checks:
+        if not expected:
+            mismatches.append(f"{name}: manifest is missing its sha256 field")
+            continue
+        if not path.is_file():
+            mismatches.append(f"{name}: frozen file missing: {path.relative_to(REPO_ROOT)}")
+            continue
+        actual = _sha256_file(path)
+        if actual != expected:
+            mismatches.append(f"{name}: {path.relative_to(REPO_ROOT)} changed (was frozen)")
+
+    expected_tooling = manifest.get("tooling_sha256")
+    if not expected_tooling:
+        mismatches.append("tooling: manifest is missing tooling_sha256")
+    elif _sha256_tree(TOOLING_DIR) != expected_tooling:
+        mismatches.append("tooling: tools/incentive_ops/*.py changed (was frozen)")
+    return mismatches
+
+
+def main() -> int:
+    manifests = sorted(RUNS_ROOT.glob("*/manifest.yaml")) if RUNS_ROOT.is_dir() else []
+    running = []
+    for mp in manifests:
+        data = yaml.safe_load(mp.read_text(encoding="utf-8"))
+        if isinstance(data, dict) and data.get("status") == "RUNNING":
+            running.append((mp, data))
+
+    if not running:
+        print("freeze-guard: no RUNNING baseline; nothing frozen")
+        return 0
+
+    failed = False
+    for mp, manifest in running:
+        mismatches = _frozen_artifact_mismatches(manifest)
+        run_id = manifest.get("run_id", mp.parent.name)
+        if not mismatches:
+            print(f"freeze-guard: OK — frozen artifacts match RUNNING baseline {run_id}")
+            continue
+        failed = True
+        end = manifest.get("planned_end_at_utc", "unknown")
+        print(
+            f"freeze-guard: FAIL — baseline {run_id} is RUNNING (freeze until {end}) "
+            "and these frozen artifacts differ:",
+            file=sys.stderr,
+        )
+        for msg in mismatches:
+            print(f"  - {msg}", file=sys.stderr)
+        print(
+            "  Hold this change until the baseline closes, or close/abort the baseline first.",
+            file=sys.stderr,
+        )
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_check_incentive_ops_freeze.py
+++ b/tests/test_check_incentive_ops_freeze.py
@@ -1,0 +1,111 @@
+"""Tests for the CI freeze guard (scripts/check_incentive_ops_freeze.py)."""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from scripts import check_incentive_ops_freeze as guard
+
+
+def _make_repo(tmp_path: Path, *, status: str = "RUNNING") -> Path:
+    """Build a minimal repo layout with one baseline manifest and frozen artifacts."""
+    registry = tmp_path / "research/a1-incentive-farming/starter-registry-v0.yaml"
+    handoff = tmp_path / "docs/specs/handoff.md"
+    spec = tmp_path / "docs/specs/spec.md"
+    allowlist = tmp_path / "config/incentive_ops/endpoint_allowlist.yaml"
+    tooling = tmp_path / "tools/incentive_ops"
+    for f, content in [
+        (registry, "programs: []\n"),
+        (handoff, "# handoff\n"),
+        (spec, "# spec\n"),
+        (allowlist, "endpoints: []\n"),
+        (tooling / "baseline.py", "X = 1\n"),
+    ]:
+        f.parent.mkdir(parents=True, exist_ok=True)
+        f.write_text(content, encoding="utf-8")
+
+    manifest = {
+        "run_id": "baseline-test",
+        "status": status,
+        "planned_end_at_utc": "2026-07-11T22:25:23Z",
+        "registry_sha256": guard._sha256_file(registry),
+        "handoff_path": "docs/specs/handoff.md",
+        "handoff_sha256": guard._sha256_file(handoff),
+        "spec_path": "docs/specs/spec.md",
+        "spec_sha256": guard._sha256_file(spec),
+        "allowlist_sha256": guard._sha256_file(allowlist),
+        "tooling_sha256": guard._sha256_tree(tooling),
+    }
+    mp = tmp_path / "research/a1-incentive-farming/runs/baseline-test/manifest.yaml"
+    mp.parent.mkdir(parents=True, exist_ok=True)
+    mp.write_text(yaml.safe_dump(manifest), encoding="utf-8")
+    return tmp_path
+
+
+@pytest.fixture
+def repo(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    root = _make_repo(tmp_path)
+    monkeypatch.setattr(guard, "REPO_ROOT", root)
+    monkeypatch.setattr(guard, "RUNS_ROOT", root / "research/a1-incentive-farming/runs")
+    monkeypatch.setattr(guard, "TOOLING_DIR", root / "tools/incentive_ops")
+    monkeypatch.setattr(
+        guard, "REGISTRY_PATH", root / "research/a1-incentive-farming/starter-registry-v0.yaml"
+    )
+    monkeypatch.setattr(
+        guard, "ALLOWLIST_PATH", root / "config/incentive_ops/endpoint_allowlist.yaml"
+    )
+    return root
+
+
+def test_passes_when_frozen_artifacts_unchanged(repo: Path):
+    """A RUNNING baseline with matching hashes exits 0."""
+    assert guard.main() == 0
+
+
+def test_fails_when_tooling_content_changes(repo: Path):
+    """Changing any tools/incentive_ops/*.py flips the tree hash and fails."""
+    (repo / "tools/incentive_ops/baseline.py").write_text("X = 2\n", encoding="utf-8")
+    assert guard.main() == 1
+
+
+def test_fails_when_new_tooling_file_added(repo: Path):
+    """Adding a new .py file (e.g. http.py in #132) changes the tree hash."""
+    (repo / "tools/incentive_ops/http.py").write_text("Y = 1\n", encoding="utf-8")
+    assert guard.main() == 1
+
+
+def test_fails_when_allowlist_changes(repo: Path):
+    """The endpoint allowlist is frozen alongside the tooling."""
+    path = repo / "config/incentive_ops/endpoint_allowlist.yaml"
+    path.write_text("endpoints: [new]\n", encoding="utf-8")
+    assert guard.main() == 1
+
+
+def test_touch_without_content_change_passes(repo: Path):
+    """Content-hash semantics: rewriting identical bytes is not a violation."""
+    path = repo / "tools/incentive_ops/baseline.py"
+    path.write_text(path.read_text(encoding="utf-8"), encoding="utf-8")
+    assert guard.main() == 0
+
+
+def test_no_running_baseline_passes_with_changes(repo: Path):
+    """Once the baseline is not RUNNING, the freeze lifts entirely."""
+    mp = repo / "research/a1-incentive-farming/runs/baseline-test/manifest.yaml"
+    manifest = yaml.safe_load(mp.read_text(encoding="utf-8"))
+    manifest["status"] = "COMPLETE"
+    mp.write_text(yaml.safe_dump(manifest), encoding="utf-8")
+    (repo / "tools/incentive_ops/baseline.py").write_text("X = 3\n", encoding="utf-8")
+    assert guard.main() == 0
+
+
+def test_missing_frozen_file_fails(repo: Path):
+    """Deleting a frozen artifact is a violation, not a silent pass."""
+    (repo / "research/a1-incentive-farming/starter-registry-v0.yaml").unlink()
+    assert guard.main() == 1
+
+
+def test_no_runs_dir_passes(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Repos/branches without any baseline runs are unaffected."""
+    monkeypatch.setattr(guard, "RUNS_ROOT", tmp_path / "nonexistent")
+    assert guard.main() == 0

--- a/tests/test_check_incentive_ops_freeze.py
+++ b/tests/test_check_incentive_ops_freeze.py
@@ -109,3 +109,17 @@ def test_no_runs_dir_passes(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     """Repos/branches without any baseline runs are unaffected."""
     monkeypatch.setattr(guard, "RUNS_ROOT", tmp_path / "nonexistent")
     assert guard.main() == 0
+
+
+def test_empty_manifest_fails(repo: Path):
+    """A corrupted/empty manifest must fail loudly, not read as 'no baseline'."""
+    mp = repo / "research/a1-incentive-farming/runs/baseline-test/manifest.yaml"
+    mp.write_text("", encoding="utf-8")
+    assert guard.main() == 1
+
+
+def test_unparseable_manifest_fails(repo: Path):
+    """Invalid YAML in a manifest is a hard failure, not a bypass."""
+    mp = repo / "research/a1-incentive-farming/runs/baseline-test/manifest.yaml"
+    mp.write_text("status: [unclosed\n  - :bad", encoding="utf-8")
+    assert guard.main() == 1


### PR DESCRIPTION
## Why

PRs #132/#133 merged during the Phase-0 baseline's merge-freeze window, flipping the frozen `tooling_sha256` and breaking every daily tick from 07-04 until they were reverted (#see commits `ac43cec`/`4e106f0`). The freeze existed only as a policy note, so nothing stopped the merge.

## What

- `scripts/check_incentive_ops_freeze.py`: scans `research/a1-incentive-farming/runs/*/manifest.yaml` for a RUNNING baseline; if found, recomputes the five frozen-artifact content hashes (registry, handoff, spec, `tools/incentive_ops/*.py` tree, endpoint allowlist) and exits 1 on any mismatch. Same content-hash semantics as the tick's `_verify_frozen_artifacts`, so touching a frozen path without changing bytes still passes. No RUNNING baseline → no-op.
- CI: runs the guard in the `lint` job, so a PR that would break the freeze fails before merge.
- 8 unit tests covering pass/fail/lift/missing-file/no-runs cases.

The guard is deliberately standalone (pyyaml only) and lives outside `tools/incentive_ops/` so it is not itself part of the frozen surface.

## Verification

- `uv run pytest`: 1197 passed, 1 skipped
- Live check against the current RUNNING baseline passes; appending a comment to `types.py` makes it fail with a clear message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)