### PR TITLE
docs: mark drought-plan Tracks A/B superseded by pre-registered sweeps

### DIFF
--- a/docs/issues/STRATEGY_DROUGHT_REMEDIATION_PLAN.md
+++ b/docs/issues/STRATEGY_DROUGHT_REMEDIATION_PLAN.md
@@ -1,8 +1,41 @@
 # Strategy Drought Remediation Plan
 
 **Date:** 2026-07-05
-**Status:** Proposed — awaiting approval before any changes
+**Status:** SUPERSEDED (Tracks A & B) — see counter-evidence below. Track C remains open, blocked on a capital decision.
 **Scope:** `sol_1h_trend_pullback_overlay_live`, `sentiment_macro`, `sol_trend_pullback_sparse`
+
+---
+
+## ⚠️ Counter-Evidence — Do Not Execute Tracks A or B (added 2026-07-06)
+
+This plan's diagnosis is correct (no malfunction; the overlay's `buy_threshold` exceeds
+what one strategy vote can produce), but Tracks A and B re-open decisions that were
+already settled by pre-registered experiments this plan does not cite:
+
+- **Track A (lower overlay `buy_threshold`) was falsified on 2026-06-18.**
+  [`overlay-threshold-sweep-2026-06-18.md`](../reports/overlay-threshold-sweep-2026-06-18.md)
+  swept exactly the proposed region (0.5–1.27) on the production-mirror config at
+  corrected costs (#94), WFO 2024-01 → 2026-02: every threshold with tradeable frequency
+  loses (0.80 → −17.5%, 0.90 → fails gates at 77% max DD, 1.00 → −21.6%), and the
+  deployed 1.07/1.27 fail the pre-registered ≥2 trades/mo floor. Lowering the threshold
+  is not "pure upside" — it converts a dormant agent into a measured losing one. Note the
+  overlay's original WFO pass predates the cost fix (#94) and was established under ~3×
+  overcharged costs; the >1.0 confluence gate is part of what made it pass.
+- **Track B (tighten sentiment_macro gates) was swept on 2026-06-19** (#101,
+  [`sentiment-vol-filter-sweep`](../reports/sentiment-vol-filter-sweep-2026-06-19.md)):
+  no setting both trades and holds an edge.
+- **Both verdicts were consolidated in**
+  [`research-consolidation-2026-06-19.md`](../reports/research-consolidation-2026-06-19.md):
+  overlay — "Not viable — untradeable gate, no edge beneath it"; sentiment-macro —
+  "Not viable". A 7–14 day paper run or a 3-month replay (~17 trades at threshold 0.85)
+  cannot overturn a 2-year corrected-cost WFO and should not be run against live capital.
+
+**Resolution:** both agents were disarmed to paper (execution flags off, containers and
+data feeds kept) rather than left live-armed and dormant — this plan itself is the
+demonstration that a dormant live agent invites exactly the config change the sweep
+falsified. Track C (`sol_sparse` funding) stays a human capital decision; note its
+"demonstrated edge" is 8 lifetime trades and it has also been dry in paper mode since
+2026-05-05, so diagnose the dryness before funding anything.
 
 ---
 


### PR DESCRIPTION
PR #135's remediation plan proposes lowering the overlay `buy_threshold` (Track A) and tightening sentiment_macro gates (Track B). Both were already tested and rejected by pre-registered experiments the plan doesn't cite:

- **Track A**: [`overlay-threshold-sweep-2026-06-18.md`](docs/reports/overlay-threshold-sweep-2026-06-18.md) swept 0.5–1.27 at corrected costs on the production-mirror config — every tradeable threshold loses (0.80 → −17.5% WFO, 0.90 fails gates at 77% max DD). "Pure upside" is measured downside.
- **Track B**: sentiment vol-filter sweep (#101) — no setting both trades and holds an edge.
- Both consolidated as **Not viable** in [`research-consolidation-2026-06-19.md`](docs/reports/research-consolidation-2026-06-19.md).

This amendment marks Tracks A/B superseded in place (with links), so the plan isn't executed by the next agent that finds it. Track C (sol_sparse funding) remains open as a human capital decision, with a note that its 8-trade sample and 2-month paper dryness warrant diagnosis before funding.

Companion PR disarms the two dormant live agents to paper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)