### PR TITLE
chore(config): disarm overlay + sentiment_macro to paper (monitor only)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -481,8 +481,8 @@ The system supports running multiple isolated trading agents simultaneously. The
 
 | Agent | Config | Description |
 |-------|--------|-------------|
-| `agent_sol_1h_trend_pullback_overlay_live` | `config/settings.sol_1h_trend_pullback_overlay_live.yaml` | **Only deployable technical agent** — SOL 1h trend-pullback overlay, Phase 0 forward validation in progress |
-| `agent_sentiment_macro` | `config/settings.sentiment_macro.yaml` | SOL-only sentiment mean reversion, live futures routing |
+| `agent_sol_1h_trend_pullback_overlay_live` | `config/settings.sol_1h_trend_pullback_overlay_live.yaml` | **Disarmed to paper 2026-07-06** (monitor only) — threshold sweep 2026-06-18 found no tradeable buy_threshold with an edge at corrected costs; do not re-arm without a new pre-registered WFO pass |
+| `agent_sentiment_macro` | `config/settings.sentiment_macro.yaml` | **Disarmed to paper 2026-07-06** (kept for xAI sentiment feed recording) — vol-filter sweep #101 found no setting that trades AND holds an edge; last 15 live trades 2W/13L |
 | `agent_sol_sparse` | `config/settings.sol_trend_pullback_sparse.yaml` | SOL trend pullback (paper) |
 | `agent_sol_panic_block_paper` | `config/settings.sol_4h_panic_block_paper.yaml` | SOL panic-block paper validation |
 

--- a/config/settings.sentiment_macro.yaml
+++ b/config/settings.sentiment_macro.yaml
@@ -10,7 +10,13 @@ display_name: sentiment-macro-1h-multiasset
 # spot's 3 entries / 0 round-trips / -$0.51 realized. Futures track record is the edge.
 # Budget: $22/trade notional, default_leverage 3x, isolated margin, one-way mode.
 # Note: $22 minimum needed — Binance LOT_SIZE truncation can drop $20 order to $18.73.
-mode: live
+#
+# DISARMED to paper 2026-07-06: vol-filter sweep #101 (2026-06-19) found no setting that
+# both trades and holds an edge; consolidation 2026-06-19 ruled sentiment-macro not a
+# viable forward vehicle (last 15 live trades: 2W/13L, all longs into a downtrend).
+# Container kept running so the xAI sentiment feed keeps recording observations.
+# Do NOT re-arm without a new pre-registered validation at corrected costs.
+mode: paper
 
 trading:
   pairs:
@@ -27,7 +33,8 @@ ai:
   fallback_model: deepseek-v4-pro
 
 trading_execution:
-  test_mode: false
+  enabled: false
+  test_mode: true
   use_atr_sizing: false
   order_size_usdt: 22.0
   # Widened SL from 1.5 to 2.0 ATR — old 1.5x was getting clipped by 1h noise.
@@ -39,8 +46,11 @@ trading_execution:
     backtest_use_executor_exit_model: true
 
 futures:
+  # enabled stays true so the paper simulator keeps futures signal semantics
+  # (mode: paper above never constructs live executors); test_mode: true means
+  # even a mode flip would land on the Binance testnet, not real funds.
   enabled: true
-  test_mode: false
+  test_mode: true
   default_leverage: 3
   max_leverage: 10
   margin_mode: isolated

--- a/config/settings.sentiment_macro.yaml
+++ b/config/settings.sentiment_macro.yaml
@@ -5,11 +5,11 @@ reconciliation:
   periodic_interval_seconds: 300  # re-check every 5 min while running
 display_name: sentiment-macro-1h-multiasset
 
-# Live trading: rolled back to futures on 2026-04-20 (was spot-only Stage D Apr 16-20).
-# Rationale: futures had 95 live trades, 70% WR, +$727 PnL (Mar 13 - Apr 16) vs
-# spot's 3 entries / 0 round-trips / -$0.51 realized. Futures track record is the edge.
-# Budget: $22/trade notional, default_leverage 3x, isolated margin, one-way mode.
-# Note: $22 minimum needed — Binance LOT_SIZE truncation can drop $20 order to $18.73.
+# History: rolled back to futures on 2026-04-20 (was spot-only Stage D Apr 16-20) on the
+# strength of the Mar 13 - Apr 16 futures run (95 trades, 70% WR, +$727). That apparent
+# edge did NOT persist — May ran 2W/13L — and later sweeps falsified it (see below).
+# Sizing history: $22/trade notional, 3x isolated, one-way; $22 minimum because Binance
+# LOT_SIZE truncation can drop a $20 order to $18.73.
 #
 # DISARMED to paper 2026-07-06: vol-filter sweep #101 (2026-06-19) found no setting that
 # both trades and holds an edge; consolidation 2026-06-19 ruled sentiment-macro not a

--- a/config/settings.sol_1h_trend_pullback_overlay_live.yaml
+++ b/config/settings.sol_1h_trend_pullback_overlay_live.yaml
@@ -1,6 +1,11 @@
 agent_id: sol-1h-trend-pullback-overlay-live
 display_name: sol-1h-trend-pullback-overlay-live
-mode: live
+# DISARMED to paper 2026-07-06: the 2026-06-18 threshold sweep
+# (docs/reports/overlay-threshold-sweep-2026-06-18.md) found no buy_threshold that both
+# trades >=2/mo and survives corrected costs; consolidation 2026-06-19 ruled the overlay
+# not a viable forward vehicle. Container kept as monitor only. Do NOT re-arm or lower
+# buy_threshold without a new pre-registered WFO pass at corrected costs.
+mode: paper
 
 trading:
   pairs:
@@ -14,8 +19,8 @@ telegram:
   daily_summary_enabled: true
 
 trading_execution:
-  enabled: true
-  test_mode: false
+  enabled: false
+  test_mode: true
   use_atr_sizing: false
   order_size_usdt: 22.0
   sl_atr_multiplier: 2.38
@@ -26,8 +31,11 @@ trading_execution:
     backtest_use_executor_exit_model: true
 
 futures:
+  # enabled stays true so the paper simulator keeps futures signal semantics
+  # (mode: paper above never constructs live executors); test_mode: true means
+  # even a mode flip would land on the Binance testnet, not real funds.
   enabled: true
-  test_mode: false
+  test_mode: true
   default_leverage: 3
   max_leverage: 3
   margin_mode: isolated

--- a/tests/test_config_merge.py
+++ b/tests/test_config_merge.py
@@ -107,7 +107,7 @@ reconciliation:
 """
 
 _ORIGINAL_SENTIMENT_MACRO = """
-mode: live
+mode: paper
 agent_id: sentiment-macro-bot
 display_name: sentiment-macro-1h-multiasset
 log_level: INFO
@@ -150,10 +150,10 @@ prometheus:
   port: 8000
 
 trading_execution:
-  enabled: true
+  enabled: false
   api_key: ""
   api_secret: ""
-  test_mode: false
+  test_mode: true
   order_size_usdt: 22.0
   stop_loss_pct: 0.02
   take_profit_pct: 0.05
@@ -175,7 +175,7 @@ futures:
   max_leverage: 10
   margin_mode: isolated
   position_mode: one-way
-  test_mode: false
+  test_mode: true
   liquidation_buffer_pct: 5.0
 
 strategy:


### PR DESCRIPTION
## Why

Both agents run live futures execution ($22/trade, test_mode: false) but have no validated edge:

- **overlay**: 0 fills ever (buy_threshold 1.07/1.27 exceeds the single-vote cap); the [2026-06-18 threshold sweep](docs/reports/overlay-threshold-sweep-2026-06-18.md) found every tradeable threshold loses at corrected costs. Leaving it live-armed invited exactly the fix the sweep falsified — PR #135's Track A proposed lowering the threshold into the measured-losing region (see companion PR #138).
- **sentiment_macro**: 2W/13L on its last 15 live trades; vol-filter sweep #101 found no setting that both trades and holds an edge.

Both were ruled **not viable** in [research-consolidation-2026-06-19.md](docs/reports/research-consolidation-2026-06-19.md) with "keep service as monitor only" — this PR makes the monitor-only state real in config instead of relying on dormancy.

## What

- `mode: paper` — master disarm; `load_settings` forces test_mode and `src/main.py` only constructs the PaperExecutor (no live executors, no Binance execution API).
- `futures.enabled` stays `true`: in paper mode it only feeds the paper simulator's futures symbols/leverage, preserving signal semantics for monitoring; `test_mode: true` means even a future `mode: live` flip lands on testnet, not real funds.
- `trading_execution.enabled: false` explicitly (base.yaml otherwise supplies `true` to sentiment_macro).
- Config headers document the disarm + do-not-re-arm condition; CLAUDE.md agent table updated; test_config_merge snapshot updated.
- `config_doctor`: 0 errors on both configs. Full suite: 1189 passed.

## Deploy note

Prod bakes config at build time — after merge this needs the standard rebuild cycle on the server to take effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)