### PR TITLE
fix(backtest): respect config global_trend_filter_enabled (mirror live)

### DIFF
--- a/scripts/experiment_autopilot.py
+++ b/scripts/experiment_autopilot.py
@@ -156,6 +156,12 @@ def _resolve_global_trend_filter(
         return cost_profile.apply_global_trend_filter, "cost_profile_override", config_explicit
     if disable_trend_filter:
         return False, "cli_override", config_explicit
+    # Mirror live behavior (src/main.py): the strategy config decides; the
+    # engine default only applies when the config is silent. Previously the
+    # config value was recorded for audit but ignored, so a backtest of a
+    # filter-off config still silently blocked below-trend buys.
+    if config_explicit is not None:
+        return config_explicit, "config", config_explicit
     return True, "engine_default", config_explicit
 
 

--- a/scripts/run_backtest.py
+++ b/scripts/run_backtest.py
@@ -11,6 +11,7 @@ sys.path.append(os.getcwd())
 
 import yaml
 
+from scripts.experiment_autopilot import _resolve_global_trend_filter
 from src.backtest.engine import BacktestConfig, BacktestEngine
 from src.db import close_pool, init_pool
 from src.features.reader import IndicatorReader
@@ -118,12 +119,11 @@ async def main():
     strategy_section = raw_config.get("strategy", {})
     if not isinstance(strategy_section, dict):
         strategy_section = {}
-    config_trend_filter = (
-        bool(strategy_section["global_trend_filter_enabled"])
-        if "global_trend_filter_enabled" in strategy_section
-        else None
+    apply_trend_filter, trend_filter_source, config_trend_filter = _resolve_global_trend_filter(
+        raw_config=raw_config,
+        disable_trend_filter=args.disable_trend_filter,
+        cost_profile=None,
     )
-    trend_filter_source = "cli_override" if args.disable_trend_filter else "engine_default"
 
     config = BacktestConfig(
         symbol=args.symbol,
@@ -141,7 +141,7 @@ async def main():
         use_atr_sizing=settings.trading_execution.use_atr_sizing,
         atr_multiplier=settings.trading_execution.atr_multiplier,
         risk_per_trade=settings.trading_execution.risk_per_trade_pct,
-        apply_global_trend_filter=not args.disable_trend_filter,
+        apply_global_trend_filter=apply_trend_filter,
         global_trend_filter_buffer_pct=float(
             strategy_section.get("global_trend_filter_buffer_pct", 0.05)
         ),

--- a/tests/test_trend_filter_audit.py
+++ b/tests/test_trend_filter_audit.py
@@ -56,6 +56,40 @@ def test_resolve_trend_filter_engine_default() -> None:
     assert explicit is None
 
 
+def test_resolve_trend_filter_respects_config_false() -> None:
+    """A filter-off config must actually turn the filter off (mirrors live)."""
+    apply, source, explicit = _resolve_global_trend_filter(
+        raw_config=_base_raw_config(trend_filter_enabled=False),
+        disable_trend_filter=False,
+        cost_profile=None,
+    )
+    assert apply is False
+    assert source == "config"
+    assert explicit is False
+
+
+def test_resolve_trend_filter_respects_config_true() -> None:
+    apply, source, explicit = _resolve_global_trend_filter(
+        raw_config=_base_raw_config(trend_filter_enabled=True),
+        disable_trend_filter=False,
+        cost_profile=None,
+    )
+    assert apply is True
+    assert source == "config"
+    assert explicit is True
+
+
+def test_resolve_trend_filter_cli_beats_config() -> None:
+    apply, source, explicit = _resolve_global_trend_filter(
+        raw_config=_base_raw_config(trend_filter_enabled=True),
+        disable_trend_filter=True,
+        cost_profile=None,
+    )
+    assert apply is False
+    assert source == "cli_override"
+    assert explicit is True
+
+
 def test_resolve_trend_filter_cost_profile_override() -> None:
     apply, source, explicit = _resolve_global_trend_filter(
         raw_config=_base_raw_config(trend_filter_enabled=True),


### PR DESCRIPTION
Closes the last open item from the [backtest engine integrity audit](docs/reports/backtest-engine-integrity-audit-2026-06-18.md) (item C — "hidden global trend filter mutates signals by default"). Fees, slippage, and 8h funding cadence were already fixed in #94; the trend filter was still config-deaf.

## Bug

`_resolve_global_trend_filter` captured the config's `strategy.global_trend_filter_enabled` for the audit payload but never used it in the decision — a backtest of a filter-off config still silently applied the EMA200 filter. `run_backtest.py` had a second, divergent inline version of the same logic (`not args.disable_trend_filter`), so WFO runs (which subprocess through it) were affected too.

## Fix

One shared resolver with live's precedence (`src/main.py` semantics): CLI / cost-profile override → strategy config → engine default (on). New `"config"` value for `global_trend_filter_source` makes the resolution visible in the audit payload. Engine default stays **on** deliberately — live defaults on, and backtests should mirror production when the config is silent.

## Tests

Three new resolver cases (config-false wins, config-true explicit, CLI beats config); full suite 1202 passed.

## Why it matters

Per the audit, the always-on filter (combined with the old 3× cost overcharge) suppressed fee-marginal lanes — dislocation flipped to +EV once measured under corrected physics. This makes future re-screens trustworthy without per-run workarounds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)