### PR TITLE
docs: fill NFP probe pre-registration; recommend fee-marginal probe deletion

### DIFF
--- a/docs/evidence_portfolio/FEE_MARGINAL_PREREG.md
+++ b/docs/evidence_portfolio/FEE_MARGINAL_PREREG.md
@@ -15,11 +15,39 @@ probe is **deleted from the budget, not postponed**.
 
 Not admitted until exact family is named.
 
+**Recommendation (2026-07-07): DELETED_NOT_NAMED — no family qualifies.** Evidence
+review of the fee-marginal category found that every candidate was **already retested
+after #94 with the trend filter explicitly controlled in both states**, making #140 a
+non-event for these families (it fixed the config path; the 2026-06-18 rescreens set
+the filter directly and measured both cells):
+
+- `sol-4h-rsi-reversal`, `avax-4h-bollinger-strategy`, `eth-4h-range-reversion-bounded`
+  — closed-family cost-corrected rescreen (#97/#98), cells A (filter OFF) and B (filter
+  ON), **all 6 cells FAIL** the standard gate
+  (`research/closed-family-cost-rescreen/combined_results.json`,
+  `docs/reports/closed-family-cost-corrected-rescreen-2026-06-18.md`: "mean-reversion
+  family genuinely closed … the cost bug hid no deployable edge in fee-marginal /
+  trend-filter-confounded families").
+- `daily-trend-long` BTC/ETH/SOL and `sol-1h-dislocation-event` — cost-realism rerun,
+  legacy and realistic passes, **all FAIL**
+  (`research/cost-realism-rerun/combined_results.json`,
+  `docs/reports/cost-realism-rerun-2026-06-18.md`).
+- Dislocation cost isolation (#95): best cell still FAIL (WFO Sharpe 0.15 < 0.5,
+  concentration 79% > 50%) — "do not re-open the dislocation/fee-marginal family"
+  (`docs/reports/dislocation-cost-isolation-2026-06-18.md`).
+- Program-level verdict: "no closed lane revives at corrected costs"
+  (`docs/reports/research-consolidation-2026-06-19.md`).
+
+Naming any of the above would re-run a completed experiment with no changed input —
+exactly the relapse this document exists to block. Deletion stands unless the human
+names a fee-marginal family **not covered by the 2026-06-18 rescreens**.
+
 ## Family
 
 [Exact strategy/family name required. Must identify a specific family previously
-rejected under the broken cost model or config-deaf trend filter. If left blank at
-decision time, verdict = DELETED_NOT_NAMED.]
+rejected under the broken cost model or config-deaf trend filter, and NOT already
+covered by the 2026-06-18 corrected-cost rescreens listed above. If left blank at
+decision time (2026-07-10), verdict = DELETED_NOT_NAMED.]
 
 ## Thing that changed
 

--- a/docs/evidence_portfolio/NFP_PREREG.md
+++ b/docs/evidence_portfolio/NFP_PREREG.md
@@ -13,36 +13,55 @@ the rules below fixed before any data is viewed.
 
 ---
 
+> Parameters below were filled in on 2026-07-07 from the **in-sample report only**
+> (`docs/reports/macro-surprise-drift-probe-v0.md`); no OOS data was viewed. They become
+> locked when the human signs the line at the bottom of this file.
+
 ## Hypothesis
 
-[Placeholder: exact market behavior expected after NFP — e.g. direction and persistence
-of the move in the chosen instrument following a positive NFP surprise. Must be filled
-in before the probe runs.]
+Hot NFP surprises (actual > consensus, `z > 0`) are followed by **positive** BTCUSDT
+forward returns, and cold surprises by negative ones — "good news is good", the
+**opposite** of the ex-ante risk-off sign frozen in probe v0. In-sample basis (BTCUSDT,
+28 events, 2024-01 → 2026-05): hot mean +0.65% vs cold mean −1.09% at +24h, consistent
+across BTC/ETH/SOL and across +6h/+24h/+72h horizons.
 
 ## Market/instrument
 
-[Placeholder: exact instrument, venue, and timeframe.]
+BTCUSDT spot (Binance), 1h candles. BTCUSDT is the **only gated instrument**. ETHUSDT
+and SOLUSDT may be computed as consistency checks but carry no weight in the verdict.
 
 ## Event window
 
-[Placeholder: exact NFP release dates or release windows in scope, including the OOS
-date range boundaries.]
+**OOS = US NFP scheduled releases from 2021-01-08 through 2023-12-08 (36 releases)** —
+strictly before the in-sample archive (2024-01-05 → 2026-05-08), so no overlap with the
+data the hypothesis was formed on. NFP releases after 2026-05-08 may be appended as
+forward confirmation as they occur, but the verdict is decided on the 2021–2023 window.
+Releases where point-in-time consensus cannot be recovered are excluded and the
+exclusion count reported.
 
 ## Entry rule
 
-[Placeholder: deterministic entry condition and timing relative to the release.]
+At the close of the first 1h BTCUSDT candle at or after the release timestamp: if
+`z > 0` (hot, same standardized-surprise definition as
+`scripts/probe_macro_surprise_drift.py`), enter **long**. If `z ≤ 0`, no position.
+One entry per release, fixed notional.
 
 ## Exit rule
 
-[Placeholder: deterministic exit condition — time-based, level-based, or both.]
+Fixed time exit: close the position 24 hours after entry (first candle close at or
+after entry + 24h). No stop, no target, no discretionary exit.
 
 ## Data source
 
-[Placeholder: OHLCV/tick source and the NFP surprise data source (consensus vs actual).]
+- OHLCV: Binance via `scripts/download_historical.py` (BTCUSDT 1h, 2021-01 → 2024-01).
+- Surprises: BLS actuals + Investing.com Wayback-archived consensus, same method and
+  same point-in-time caveat as `data/macro_events/us_macro_surprises.csv`. Consensus is
+  collected for the OOS window **before** any return is computed.
 
 ## Cost assumptions
 
-[Placeholder: spread, commission, and slippage — fixed before running.]
+0.04%/side taker fee + 0.02%/side slippage = **0.12% round trip**, matching the
+post-#94 realistic backtest defaults. Spot only — no funding.
 
 ## Pass threshold
 
@@ -69,3 +88,7 @@ the data, verdict = **NO_PULSE**.
 **YES** or **NO_PULSE**
 
 Verdict: _[pending]_
+
+## Lock sign-off
+
+Parameters locked by: _[human signature + date required before the probe script runs]_


### PR DESCRIPTION
## Summary

Executes the two remaining decision-prep items from the evidence portfolio (#143):

### NFP_PREREG.md — parameters filled (pending human lock)
Filled from the in-sample report only (`docs/reports/macro-surprise-drift-probe-v0.md`); no OOS data viewed:
- **Instrument:** BTCUSDT spot 1h (only gated instrument; ETH/SOL non-gating consistency checks)
- **OOS window:** NFP releases **2021-01-08 → 2023-12-08 (36 releases)** — strictly before the in-sample archive (2024-01 → 2026-05), so zero overlap with the data the hypothesis was formed on; forward releases are confirmation-only
- **Entry:** long at first 1h close after release when `z > 0` (same z definition as probe v0); flat on cold
- **Exit:** fixed +24h time exit, no stop/target
- **Costs:** 0.04%/side fee + 0.02%/side slippage = 0.12% RT (post-#94 defaults)
- Pass/kill thresholds unchanged from the locked prereg. Human sign-off line added — the probe does not run until signed.

### FEE_MARGINAL_PREREG.md — recommendation: DELETED_NOT_NAMED
Evidence review found **no family qualifies**: every fee-marginal candidate was already retested post-#94 with the trend filter explicitly controlled in both states on 2026-06-18 (closed-family rescreen #97/#98: sol-rsi-reversal, avax-bollinger, eth-range-reversion — all 6 cells FAIL; cost-realism rerun: daily-trend-long ×3 + sol-dislocation — all FAIL; dislocation isolation #95: "do not re-open"). **#140 is a non-event for these families** — it fixed the config path, but the rescreens set the filter directly and measured both cells. Naming any of them would re-run a completed experiment with no changed input.

Deletion becomes final on 2026-07-10 unless a fee-marginal family **not covered by the 06-18 rescreens** is named.

Docs only — no code, no sweeps, no new lanes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)