### PR TITLE
docs: reconcile checklist status

### DIFF
--- a/docs/AI_TRADING_AGENT_NEXT_STEPS.md
+++ b/docs/AI_TRADING_AGENT_NEXT_STEPS.md
@@ -1,5 +1,9 @@
 # Manual Next Steps (Human-Only Actions)
 
+> Status checked on 2026-07-08. This is an early bootstrap checklist, not the
+> current production runbook. Use `CLAUDE.md`, `AGENTS.md`, `docs/DEPLOYMENT.md`,
+> and `docker-compose.prod.yml` for current repo and deploy behavior.
+
 This file lists **manual** steps that must be performed outside the codebase. Each item explains **why** it matters, **what to do**, and **how to verify**.
 
 ---
@@ -180,18 +184,29 @@ This file lists **manual** steps that must be performed outside the codebase. Ea
 
 ## Quick Checklist
 
-- [ ] `.env` filled with real secrets
-- [ ] DB migration files created and applied
-- [ ] Persistence mode decision documented
-- [ ] Monitoring secured with auth
-- [ ] Production compose file + health checks
-- [ ] Config validation policy set
-- [ ] Metrics label policy defined
-- [ ] Risk rules enforced
-- [ ] Binance private auth plan decided
-- [ ] Async HTTP upgrade decision made
-- [ ] Tests expanded + coverage target met
-- [ ] Deployment runbook created
+- [ ] `.env` filled with real secrets. Runtime-only; don't mark this in git
+  without checking the deployed host.
+- [x] DB migration files created and applied locally. The repo has migrations
+  `000` through `007`; production application still needs live DB verification.
+- [x] Persistence mode decision documented. The current architecture uses
+  TimescaleDB; no SQLite fallback is part of the active runtime path.
+- [ ] Monitoring secured with auth. Nginx auth config exists, but live exposure
+  and credentials need production verification.
+- [x] Production compose file + health checks. `docker-compose.prod.yml` exists.
+- [x] Config validation policy set. Current loading and validation live in
+  `src/main.py`.
+- [x] Metrics label policy defined. Label validation lives in
+  `src/ingest/metrics.py`.
+- [x] Risk rules enforced. Execution paths use risk guards/managers; live behavior
+  still needs runtime checks before any promotion.
+- [x] Binance private auth plan decided. Private auth is env-driven and documented
+  in the current execution/deployment docs.
+- [x] Async HTTP upgrade decision made. The codebase is async-first and uses
+  `aiohttp`.
+- [ ] Tests expanded + coverage target met. Test coverage is broad, but this
+  item should only be checked with a current CI or local test run.
+- [x] Deployment runbook created. Current deploy guidance exists in
+  `docs/DEPLOYMENT.md`, `AGENTS.md`, and `CLAUDE.md`.
 
 ---
 

--- a/docs/INDICATORS.md
+++ b/docs/INDICATORS.md
@@ -366,14 +366,22 @@ The `indicators` table is a TimescaleDB hypertable for:
 - All operations are async to avoid blocking
 - Separate metrics for each symbol
 
-## Future Enhancements
+## Current gaps
 
-- [ ] Support for custom indicator periods
-- [ ] Multi-timeframe indicators (1m, 5m, 15m, 1h, 4h, 1d)
-- [ ] Indicator alerts (RSI crossovers, MACD signals)
-- [ ] Real-time indicator streaming via WebSocket
-- [ ] Backtest strategies using historical indicators
-- [ ] ML model training pipeline integration
+Status checked on 2026-07-08 against the local tree.
+
+- [ ] Support for custom indicator periods. Indicator periods are still fixed in
+  `src/features/technical.py`.
+- [x] Multi-timeframe indicators. Runtime and backtest paths fetch the declared
+  strategy timeframes, and MTF reader/engine coverage exists.
+- [ ] Indicator alerts. Telegram trade alerts exist, but there is no dedicated
+  RSI/MACD crossover alert pipeline.
+- [ ] Real-time indicator streaming via WebSocket. OHLCV WebSocket ingestion
+  exists, but indicator values are computed and stored on the scheduled pipeline.
+- [x] Backtest strategies using historical indicators. `BacktestEngine` reads
+  historical indicator ranges through `IndicatorReader`.
+- [ ] ML model training pipeline integration. RL research code exists, but there
+  is no production training pipeline wired to the indicator store.
 
 ## References
 

--- a/docs/ISOLATION_MODEL.md
+++ b/docs/ISOLATION_MODEL.md
@@ -142,10 +142,16 @@ strategy:
 
 ## Verification Checklist
 
-- [ ] All production agents use unique agent_ids
-- [ ] No two agents share symbol without timeframe distinction
-- [ ] Position queries show expected isolation
-- [ ] Cross-agent contamination test passes
+Status checked on 2026-07-08. Local config and tests can only prove part of this;
+production DB state still needs live verification.
+
+- [ ] All production agents use unique agent_ids. Check `docker-compose.prod.yml`
+  and the running containers before marking done.
+- [ ] No two agents share symbol without timeframe distinction. Check active
+  configs and runtime `AGENT_ID` values before marking done.
+- [ ] Position queries show expected isolation. Requires live TimescaleDB queries.
+- [ ] Cross-agent contamination test passes. `scripts/validate_agent_isolation.py`
+  exists; run it against the current production DB before marking done.
 
 ## Notes
 

--- a/docs/evidence_portfolio/CTRADER_EXTERNAL_GATE.md
+++ b/docs/evidence_portfolio/CTRADER_EXTERNAL_GATE.md
@@ -51,15 +51,12 @@ challenge (or funded) capital.
 
 ---
 
-## External follow-up checklist (work belongs to the cTrader repository)
+## External follow-up ownership
 
-- [ ] Deterministic replay harness covers every agent-managed exit path
-- [ ] Partial TP: ≥5 real-time executions observed and reconciled
-- [ ] Trailing stop: ≥5 real-time executions observed and reconciled
-- [ ] Break-even move: ≥5 real-time executions observed and reconciled
-- [ ] Forced close / emergency exit: ≥5 real-time executions observed and reconciled
-- [ ] Broker SL and TP handling re-verified under the current reconciler
-- [ ] Forward sample reaches ≥30 closed trades or ≥10 live sessions (whichever later)
-- [ ] Net expectancy recomputed after all costs on the forward sample
-- [ ] Drawdown check: < 50% of challenge allowance across the validation window
-- [ ] Zero-violation audit of challenge rules over the full validation window
+Status checked on 2026-07-08. All cTrader execution, reconciliation, forward
+validation, and funded-challenge gates are owned by the `ctrader-trading-agent`
+repository. Do not implement, validate, or close those tasks in `crypto-agent`.
+
+This file is only a boundary note so `crypto-agent` agents do not mistake the
+cTrader gate for local work. The canonical checklist and evidence must live in
+`ctrader-trading-agent`.

--- a/docs/issues/STRATEGY_DROUGHT_REMEDIATION_PLAN.md
+++ b/docs/issues/STRATEGY_DROUGHT_REMEDIATION_PLAN.md
@@ -211,6 +211,10 @@ decision.
 
 ## Verification Checklist (Post-Implementation)
 
+Status checked on 2026-07-08. These gates require current production evidence:
+paper entries, backtest output, service logs, and Prometheus/Grafana scrape
+state. Don't mark them done from local config alone.
+
 - [ ] `sol_1h_overlay`: at least 3 paper entries in 7 days at new threshold
 - [ ] `sol_1h_overlay`: backtest shows positive expectancy at new threshold
 - [ ] `sentiment_macro`: regime-conditional backtest identifies the edge boundary

--- a/docs/reports/SENTIMENT_MACRO_IMPROVEMENT_PLAN.md
+++ b/docs/reports/SENTIMENT_MACRO_IMPROVEMENT_PLAN.md
@@ -3,6 +3,13 @@
 **Created:** 2026-03-25
 **Goal:** Optimize the SentimentMeanReversion strategy using autoresearch + WFO
 
+> Status checked on 2026-07-08. This is a dated execution plan. Treat the
+> unchecked checklist below as historical unless current runtime data confirms
+> the same work is still needed. More recent sentiment-macro evidence lives in
+> `docs/reports/sentiment-macro-decision-gate-20260413.md`,
+> `docs/reports/sentiment-macro-live-bleed-investigation-2026-06-01.md`, and
+> `docs/reports/sol-sparse-dryness-diagnosis-2026-07-06.md`.
+
 ---
 
 ## Current State
@@ -299,6 +306,10 @@ strategy:
 ---
 
 ## Execution Checklist
+
+This checklist is retained as historical planning context. Don't check items off
+from local code alone; verify current DB coverage, backtest artifacts, deployed
+config, and production logs first.
 
 ### Prerequisites
 - [ ] Local TimescaleDB running with indicator data

--- a/docs/reports/autoresearch-next-candidate-path-2026-06-04.md
+++ b/docs/reports/autoresearch-next-candidate-path-2026-06-04.md
@@ -353,6 +353,11 @@ available.
 
 Before adding any new tracked config:
 
+Status checked on 2026-07-08. This is still a reusable promotion gate for future
+candidate configs. Mark individual items only from the candidate ledger, WFO
+artifacts, overlap report, and exact config/risk/compose files for that
+candidate.
+
 - [ ] Standard gate passed at bootstrap=100.
 - [ ] `eligible_for_bootstrap_1000=true`.
 - [ ] bootstrap=1000 passed.

--- a/docs/reports/sentiment-macro-decision-gate-20260413.md
+++ b/docs/reports/sentiment-macro-decision-gate-20260413.md
@@ -5,6 +5,10 @@
 **Analysis window**: 2026-03-19 → 2026-04-13 (25 days, post P&L sizing fix)
 **Gate context**: 100-trade decision gate from project memory
 
+> Status checked on 2026-07-08. This report is a point-in-time decision gate.
+> The unchecked criteria below should be re-evaluated from current production
+> trade history before marking any item done or changing the strategy.
+
 ---
 
 ## TL;DR

--- a/docs/reviews/THERMONUCLEAR-REVIEW-BRIEF.md
+++ b/docs/reviews/THERMONUCLEAR-REVIEW-BRIEF.md
@@ -110,12 +110,16 @@ Conventional Commits, scoped per `CLAUDE.md`. Co-author line:
 
 ## Acceptance criteria
 
-- [ ] `uv run pytest -v` green; `ruff check` + `ruff format --check` clean.
-- [ ] No changes under `tools/incentive_ops/**`; no `src/` module relocations; no prod Docker/config path changes.
-- [ ] Root artifact files (`wfo_results.csv`, stray logs, `.coverage`, `.venv_new`) gone and gitignored.
-- [ ] Root markdown reduced to the 7 agent-instruction files + `README.md`; the rest live under `docs/` with references updated.
+Status checked on 2026-07-08 against the local tree. `uv run pytest -v`,
+`uv run ruff check .`, `uv run ruff format --check .`, and `git diff --check`
+passed. The current diff is docs-only.
+
+- [x] `uv run pytest -v` green; `ruff check` + `ruff format --check` clean.
+- [x] No changes under `tools/incentive_ops/**`; no `src/` module relocations; no prod Docker/config path changes.
+- [x] Root artifact files (`wfo_results.csv`, stray logs, `.coverage`, `.venv_new`) gone and gitignored.
+- [x] Root markdown reduced to the 7 agent-instruction files + `README.md`; the rest live under `docs/` with references updated.
 - [ ] Every deleted symbol verified unreferenced (grep evidence in the PR description or commit body).
-- [ ] Diff is reviewable: small, purpose-scoped commits — not one giant blob.
+- [x] Diff is reviewable: small, purpose-scoped commits — not one giant blob.
 
 ## Out of scope (explicitly)
 - Behavior changes to any strategy, risk, or execution logic.

--- a/docs/specs/session-liquidity-router-implementation-brief-v0.md
+++ b/docs/specs/session-liquidity-router-implementation-brief-v0.md
@@ -253,13 +253,17 @@ live overlay via config promotion later.
 
 ## Engineering checklist
 
-- [ ] `src/strategy/session_liquidity.py` + tests
-- [ ] Engine + backtest BUY gate
-- [ ] `main.py` config parsing
-- [ ] `settings.sol_1h_trend_pullback_overlay_paper_americas_gate.yaml`
-- [ ] Phase 2 A/B script or documented `run_backtest.py` commands
-- [ ] Ledger row after Phase 2 (PASS / REJECT)
-- [ ] Probe import refactor (dedupe `DEFAULT_WINDOWS`)
+Status checked on 2026-07-08 against the local tree. This lane remains
+**CLOSED / REJECT**; completed implementation items are kept only as historical
+evidence.
+
+- [x] `src/strategy/session_liquidity.py` + tests
+- [x] Engine + backtest BUY gate
+- [x] `main.py` config parsing
+- [x] `settings.sol_1h_trend_pullback_overlay_paper_americas_gate.yaml`
+- [x] Phase 2 A/B script or documented `run_backtest.py` commands
+- [x] Ledger row after Phase 2 (PASS / REJECT)
+- [x] Probe import refactor (dedupe `DEFAULT_WINDOWS`)
 
 **Explicitly not in v1 checklist:**
 


### PR DESCRIPTION
## Summary
- categorize remaining checklist items as local evidence, runtime-gated, reusable, or historical
- remove actionable cTrader follow-up from crypto-agent and point ownership to ctrader-trading-agent
- mark locally verified cleanup/session-liquidity/indicator items complete while leaving production gates open

## Validation
- uv run ruff check .
- uv run ruff format --check .
- uv run pytest -v (1203 passed)
- uv run ruff format --check docs (no Python files under docs)
- git diff --check
- scripts/validate_agent_isolation.py via uv run python: passed with default settings.yaml warning

Task: T058