### PR TITLE
docs: convert reusable checklist gates

### DIFF
--- a/docs/ADD_AGENT.md
+++ b/docs/ADD_AGENT.md
@@ -36,7 +36,8 @@ Co-Authored-By: Agent Name <email@domain.com>
 **Commit trailer:**
 `Co-Authored-By: Sisyphus <clio-agent@sisyphuslabs.ai>`
 
-## Verification
-- [ ] Agent appears in `AGENTS.md`
-- [ ] Instruction file follows the naming convention
-- [ ] Co-Authored-By format matches existing agents
+## Verification requirements
+
+- Agent appears in `AGENTS.md`.
+- Instruction file follows the naming convention.
+- `Co-Authored-By` format matches existing agents.

--- a/docs/RESEARCH_FRAMEWORK.md
+++ b/docs/RESEARCH_FRAMEWORK.md
@@ -201,14 +201,15 @@ Stop iterating if:
 - The strategy needs 5+ filters to be profitable
 - Each "improvement" only changes one cherry-picked metric
 
-### Iteration checklist
+### Iteration questions
 
 Before each iteration round:
 
-- [ ] What specifically failed in the last validation?
-- [ ] Is the failure a parameter issue or a logic issue?
-- [ ] If logic: does the fix still match the original hypothesis?
-- [ ] After the fix: re-run the full Phase 3 scorecard
+- Identify what specifically failed in the last validation.
+- Decide whether the failure is a parameter issue or a logic issue.
+- If the failure is logic-related, confirm the fix still matches the original
+  hypothesis.
+- After the fix, re-run the full Phase 3 scorecard.
 
 ### Kill criterion (stop iterating, abandon strategy)
 

--- a/docs/SERVER_ACCESS.md
+++ b/docs/SERVER_ACCESS.md
@@ -207,9 +207,9 @@ ssh -L 25432:127.0.0.1:25432 \
 
 ---
 
-## Security Checklist
+## Security requirements
 
-- [ ] Rotate Hetzner API token after any session where it was shared
-- [ ] Rotate Tailscale auth keys after use
-- [ ] Update UFW allowlist if corporate IP changes
-- [ ] Never commit API tokens, SSH keys, or passwords to git
+- Rotate the Hetzner API token after any session where it was shared.
+- Rotate Tailscale auth keys after use.
+- Update the UFW allowlist if the corporate IP changes.
+- Never commit API tokens, SSH keys, or passwords to git.

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -461,21 +461,21 @@ The system tracks funding costs in position PnL. High funding costs can erode pr
 
 ## Production Deployment
 
-### Reusable pre-flight checklist
+### Reusable pre-flight requirements
 
 Before going live with a new deployment or promotion, verify these items against
-the current target environment. Leave this checklist unchecked in the docs; use
-a dated release or deployment note to record a specific run.
+the current target environment. Use a dated release or deployment note to record
+a specific run.
 
-- [ ] All tests pass (`pytest`)
-- [ ] Paper trading tested thoroughly
-- [ ] Test mode validated with small amounts
-- [ ] Risk limits reviewed and adjusted
-- [ ] Grafana dashboards configured
-- [ ] Telegram alerts tested
-- [ ] Binance API keys have IP restrictions
-- [ ] Server has adequate resources (CPU, RAM, disk)
-- [ ] Monitoring and alerting set up
+- All tests pass (`pytest`).
+- Paper trading has been tested thoroughly.
+- Test mode has been validated with small amounts.
+- Risk limits have been reviewed and adjusted.
+- Grafana dashboards are configured.
+- Telegram alerts are tested.
+- Binance API keys have IP restrictions.
+- Server resources are adequate: CPU, RAM, and disk.
+- Monitoring and alerting are set up.
 
 ### Step-by-Step Production Deployment
 

--- a/docs/reports/autoresearch-next-candidate-path-2026-06-04.md
+++ b/docs/reports/autoresearch-next-candidate-path-2026-06-04.md
@@ -349,27 +349,26 @@ available.
 
 ---
 
-## Candidate Acceptance Checklist
+## Candidate acceptance requirements
 
 Before adding any new tracked config:
 
 Status checked on 2026-07-08. This is still a reusable promotion gate for future
-candidate configs. Mark individual items only from the candidate ledger, WFO
-artifacts, overlap report, and exact config/risk/compose files for that
-candidate.
+candidate configs. Record a dated candidate-specific run in the candidate
+ledger, WFO artifacts, overlap report, and exact config/risk/compose files.
 
-- [ ] Standard gate passed at bootstrap=100.
-- [ ] `eligible_for_bootstrap_1000=true`.
-- [ ] bootstrap=1000 passed.
-- [ ] Entry overlap checked versus:
+- Standard gate passed at bootstrap=100.
+- `eligible_for_bootstrap_1000=true`.
+- bootstrap=1000 passed.
+- Entry overlap checked versus:
   - `agent_sol_1h_trend_pullback_overlay_live`,
   - `agent_sentiment_macro`,
   - any other active promoted agent.
-- [ ] Profit concentration is not single-window dominated.
-- [ ] Runtime/backtest parity fields are explicit in config.
-- [ ] Risk file exists for the exact `agent_id`.
-- [ ] Compose service and Prometheus target are added only after promotion.
-- [ ] Live notional starts small; no scaling before forward evidence.
+- Profit concentration is not single-window dominated.
+- Runtime/backtest parity fields are explicit in config.
+- Risk file exists for the exact `agent_id`.
+- Compose service and Prometheus target are added only after promotion.
+- Live notional starts small; no scaling before forward evidence.
 
 ---
 


### PR DESCRIPTION
## Summary
- convert reusable process/security/deployment gates from unchecked checklists to requirement lists
- preserve research iteration, server access, agent-addition, deployment, and autoresearch promotion requirements
- reduce active checklist noise so remaining unchecked items are actual feature, runtime, or trading gates

## Checklist impact
- removes reusable checklist blocks from the active unchecked inventory
- keeps the requirements visible for future per-run evidence notes

## Validation
- uv run ruff format --check docs (no Python files under docs)
- git diff --check

Task: T061