### PR TITLE
fix(reporting): include sentiment paper agent

### DIFF
--- a/docs/PAPER_VALIDATION_REPORT.md
+++ b/docs/PAPER_VALIDATION_REPORT.md
@@ -22,6 +22,7 @@ Current monitored paper agents:
 
 - `agent_sol_sparse`
 - `agent_sol_panic_block_paper`
+- `agent_sentiment_macro`
 
 Optional probe agents are not included until their compose services are explicitly
 enabled and added to `config/prometheus/agents.json`. As of 2026-06-03,
@@ -29,7 +30,8 @@ enabled and added to `config/prometheus/agents.json`. As of 2026-06-03,
 probe because it passed the `probe_1h` gate but missed the standard WFO trade
 count gate.
 
-`agent_sentiment_macro` is intentionally excluded because it routes live SOL futures orders.
+`agent_sentiment_macro` is included because `config/settings.sentiment_macro.yaml` is disarmed
+to paper mode with real execution disabled.
 `agent_avax` is disabled because its prior walk-forward edge did not persist in live trading.
 
 ## Manual Run

--- a/src/utils/paper_validation_report.py
+++ b/src/utils/paper_validation_report.py
@@ -98,6 +98,16 @@ DEFAULT_PAPER_AGENTS: tuple[PaperAgentSpec, ...] = (
         min_review_days=28,
         min_review_trades=10,
     ),
+    PaperAgentSpec(
+        agent_id="sentiment-macro-bot",
+        service="agent_sentiment_macro",
+        config_path="config/settings.sentiment_macro.yaml",
+        symbols=("SOLUSDT",),
+        timeframe="1h",
+        validation_started_at="2026-07-06T00:00:00Z",
+        min_review_days=28,
+        min_review_trades=10,
+    ),
 )
 
 

--- a/tests/test_paper_validation_report.py
+++ b/tests/test_paper_validation_report.py
@@ -40,6 +40,7 @@ def test_default_paper_agents_match_active_paper_services() -> None:
     assert [spec.service for spec in DEFAULT_PAPER_AGENTS] == [
         "agent_sol_sparse",
         "agent_sol_panic_block_paper",
+        "agent_sentiment_macro",
     ]
     assert all(spec.symbols == ("SOLUSDT",) for spec in DEFAULT_PAPER_AGENTS)
 


### PR DESCRIPTION
## Summary
- add the disarmed sentiment-macro service to daily paper validation reports
- update the paper validation runbook so it no longer says sentiment-macro is excluded as live-only
- keep AVAX excluded because its paper sidecar remains disabled

## Validation
- uv run pytest tests/test_paper_validation_report.py tests/test_settings_integration.py::test_sentiment_macro_config_resolves_sentiment_strategy_only -v
- uv run ruff check src/utils/paper_validation_report.py tests/test_paper_validation_report.py
- uv run ruff format --check src/utils/paper_validation_report.py tests/test_paper_validation_report.py
- git diff --check

Task: T025