### PR TITLE
chore(config): enforce zero-TODO convention via ruff FIX rules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -172,13 +172,14 @@ Automate only after the process is refined and proven:
 
 - Keep changes **minimal and surgical**. Do not refactor unrelated code.
 - No unused imports, no dead code, no commented-out blocks.
+- No `TODO`/`FIXME`/`HACK`/`XXX` comments — `ruff check` fails on them (FIX rules). Track deferred work in `docs/specs/`, the candidate ledger, or RBI manifests instead.
 - Use `snake_case` for functions/variables, `PascalCase` for classes.
 - Line length: 100 characters (configured in `pyproject.toml`).
 
 ### Linting & Formatting
 
 - **Formatter**: `ruff format` (canonical)
-- **Linter**: `ruff check` (pycodestyle, pyflakes, isort, bugbear, comprehensions, pyupgrade)
+- **Linter**: `ruff check` (pycodestyle, pyflakes, isort, bugbear, comprehensions, pyupgrade, fixme)
 - **Type checker**: `mypy` (optional, not part of CI)
 - **Pre-commit hooks**: ruff (with auto-fix), ruff-format, trailing-whitespace, end-of-file-fixer, check-yaml, check-json, check-added-large-files, debug-statements, check-merge-conflict
 - CI runs `uv run ruff check .`, `uv run ruff format --check .`, and `uv run pytest -v`.

--- a/codex-instructions.md
+++ b/codex-instructions.md
@@ -37,6 +37,7 @@ See `CLAUDE.md` for the full protocol. Key points:
 - Branch for non-trivial work: `feat/<short-description>`
 - Stage specific files, not `git add -A`.
 - All tests must pass before committing.
+- No `TODO`/`FIXME` comments — `ruff check` fails on them. Track deferred work in `docs/specs/` instead.
 
 ## Module map
 

--- a/copilot-instructions.md
+++ b/copilot-instructions.md
@@ -45,6 +45,7 @@ See `CLAUDE.md` for the full protocol. Key points:
 - Branch for non-trivial work: `feat/<short-description>`
 - Stage specific files, not `git add -A`.
 - All tests must pass before committing.
+- No `TODO`/`FIXME` comments — `ruff check` fails on them. Track deferred work in `docs/specs/` instead.
 
 ## Coding conventions
 

--- a/gemini-instructions.md
+++ b/gemini-instructions.md
@@ -29,6 +29,7 @@ See `CLAUDE.md` for the full protocol. Key points:
 - Branch for non-trivial work: `feat/<short-description>`
 - Stage specific files, not `git add -A`.
 - All tests must pass before committing.
+- No `TODO`/`FIXME` comments — `ruff check` fails on them. Track deferred work in `docs/specs/` instead.
 
 ## Module map
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ select = [
     "B",   # flake8-bugbear
     "C4",  # flake8-comprehensions
     "UP",  # pyupgrade
+    "FIX", # flake8-fixme — no TODO/FIXME/HACK/XXX comments; track work in docs/specs instead
 ]
 ignore = [
     "E501",  # line too long (handled by formatter)

--- a/sisyphus-instructions.md
+++ b/sisyphus-instructions.md
@@ -38,6 +38,7 @@ See `CLAUDE.md` for the full protocol. Key points:
 - Branch for non-trivial work: `feat/<short-description>`
 - Stage specific files, not `git add -A`.
 - All tests must pass before committing.
+- No `TODO`/`FIXME` comments — `ruff check` fails on them. Track deferred work in `docs/specs/` instead.
 
 ## Module map
 


### PR DESCRIPTION
## Summary

Converts the repo's zero-TODO convention from a social rule into a mechanical CI gate, and documents it for every agent:

- **`pyproject.toml`**: enable `FIX` (flake8-fixme) in ruff's rule selection, so any `TODO`/`FIXME`/`HACK`/`XXX` comment fails `ruff check` — which already runs in CI and pre-commit.
- **`CLAUDE.md`**: authoritative rule added to the Code Style section; Linting section updated to list the fixme rule family.
- **`copilot-instructions.md` / `codex-instructions.md` / `gemini-instructions.md` / `sisyphus-instructions.md`**: one-line bullet in each protocol summary so no agent discovers the gate via a red CI run. Deferred work belongs in `docs/specs/`, the candidate ledger, or RBI manifests.

The codebase already holds this convention at zero occurrences, so nothing needed fixing to make lint pass.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring
- [x] Documentation update
- [ ] Tests

(Plus a one-line lint configuration change.)

## Testing

- [x] Tests pass locally: `pytest` (1203 passed)
- [x] Lint passes: `ruff check .` (all 357 files, with FIX rules enabled)
- [x] Format check: `ruff format --check .` (repo's canonical formatter per CLAUDE.md)

Also verified the gate actually fires: a sample `# TODO` comment fails with `FIX002` and exit code 1.

## Checklist

- [x] Code follows project style
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [ ] Tests added/updated (if needed) — no runtime behavior changed

## Notes

Follow-up to #142, which implemented the repo's last TODO-shaped item (a permanently-skipped empty test stub). This locks in the resulting clean state. Trade-off to be aware of: even short-lived `TODO` comments during development will now fail lint, so work-in-progress notes must live outside code comments — which is the intended behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011L95ecRsbzduFWQpBU9b7Z

---
_Generated by [Claude Code](https://claude.ai/code/session_011L95ecRsbzduFWQpBU9b7Z)_