### PR TITLE
docs(backtest): NFP forward-capture build brief + day-30 review memo

### DIFF
--- a/docs/evidence_portfolio/DAY30_REVIEW.md
+++ b/docs/evidence_portfolio/DAY30_REVIEW.md
@@ -1,0 +1,42 @@
+# Day-30 Portfolio Review — 2026-08-06 (template, pre-drafted 2026-07-21)
+
+**Status:** DRAFT until ratified on or about 2026-08-06
+**Purpose:** close the 30-day evidence portfolio (2026-07-07 → ~2026-08-06) with a
+15-minute ratification. All track verdicts are already determinate; blanks below are
+for anything that changes between drafting and review day.
+
+## Track outcomes (as of drafting, 2026-07-21)
+
+| Track | Verdict | Evidence |
+|-------|---------|----------|
+| Edge probe #1 (NFP OOS) | **YES** (2026-07-16) | `NFP_PREREG.md`, PR #154 — 21 trades, +0.70%/trade net, PF 2.18, all LOO positive |
+| Edge probe #2 (fee-marginal) | **DELETED_NOT_NAMED** (2026-07-09) | `FEE_MARGINAL_PREREG.md` — no eligible family; budget slot consumed, not replaced |
+| A1 incentive farming | **CLOSED, no Scale** (2026-07-14) | `A1_THRESHOLD_LOCK.md` — Legion = weekly watch only; galxe → controls; tick timer disabled |
+| cTrader FX (external) | _[fill at review: challenge status vs `CTRADER_EXTERNAL_GATE.md`]_ | external repo |
+| NFP forward gate | **SIGNED, in force** (2026-07-21) | `NFP_FORWARD_GATE.md`, PR #155 — first clean print 2026-08-07 |
+
+## Kill-gate check
+
+`PORTFOLIO_KILL_GATE.md` triggers only if *all four* tracks come back empty. Probe #1
+returned YES → **the kill gate does not fire.** No fallback decision is required.
+
+## Post-window allocation (proposed for ratification)
+
+1. **cTrader** keeps all active agent-hours: exit-path deterministic replay first
+   (session-independent), then the ≥5 live executions per exit path the external gate
+   requires.
+2. **NFP forward gate** runs on autopilot: one capture ritual per print
+   (`docs/specs/nfp-forward-capture-routine.md`), append-only CSV, no other work until
+   the 7-print interim check.
+3. **A1** stays on the weekly Legion watcher. No new programs.
+4. **Research bucket stays closed.** No new probes, no lane #16. Reopening requires a
+   named changed input + explicit human decision, per `README.md`.
+
+## Ratification
+
+- [ ] Track table verified current
+- [ ] Allocation 1–4 accepted (or amendments noted below)
+
+Amendments: _[none]_
+
+Ratified by: _[unsigned]_

--- a/docs/specs/nfp-forward-capture-routine.md
+++ b/docs/specs/nfp-forward-capture-routine.md
@@ -1,0 +1,50 @@
+# NFP Forward-Gate Capture Routine — Build Brief (for Grok)
+
+**Parent gate:** `docs/evidence_portfolio/NFP_FORWARD_GATE.md` (signed 2026-07-21, in force)
+**First deadline:** capture window for the 2026-08-07 release opens 2026-08-06 12:30 UTC
+**Scope class:** read-only tooling; no production services touched; no optimization
+
+## What the gate requires per print
+
+1. **Before the release** (within 24h before 08:30 ET on release day): trigger a
+   Wayback "Save Page Now" of
+   `https://www.investing.com/economic-calendar/nonfarm-payrolls-227` and record the
+   returned snapshot URL. This freezes the consensus point-in-time.
+2. **After the release**: read the headline actual from the BLS Employment Situation
+   release (`bls.gov/news.release/empsit.nr0.htm`, archived copy under
+   `bls.gov/news.release/archives/`).
+3. Append **one row** to `data/macro_events/nfp_good_news_forward.csv` — same columns
+   as `data/macro_events/nfp_good_news_oos_2021_2023.csv`:
+   `event_type,release_date_et,release_ts_utc,metric,actual,consensus,surprise,z,consensus_source,actual_source,source_snapshot_url`
+   - `surprise = actual − consensus`
+   - `z = surprise / 220.28` (divisor frozen by the gate; reporting continuity only)
+   - `release_ts_utc` = 08:30 America/New_York converted to UTC, DST-aware
+4. Rows are **append-only**. A print with no pre-release capture gets a
+   `MISSED_CAPTURE` row (see gate for semantics; 3 misses caps the sample).
+
+## Suggested implementation (small)
+
+- `scripts/nfp_forward_capture.py` with two subcommands:
+  - `pre` — POST/GET `https://web.archive.org/save/https://www.investing.com/economic-calendar/nonfarm-payrolls-227`,
+    verify the snapshot resolves and its "Latest Release" date is the *previous*
+    release (i.e., the page predates the upcoming print), print the snapshot URL, and
+    stash it in `research/nfp_forward/pending_capture.json`.
+  - `post --actual <n> --consensus <n>` — validate against the pending snapshot,
+    compute surprise/z (full float precision — the OOS loader rejects rounded z),
+    append the CSV row, clear the pending file.
+- Reuse the validation logic pattern from
+  `scripts/probe_nfp_good_news_oos.py::load_surprises` for self-checks.
+- No cron/systemd automation of the *decision*; scheduling the `pre` call before each
+  release day is fine (first Fridays; human reminder exists for 2026-08-06).
+
+## Explicitly out of scope (gate terms)
+
+- No trading, paper agent, config, or strategy code.
+- No extra symbols in the verdict path, no second event type, no intraday variants.
+- No edits to committed CSV rows, ever.
+
+## Upcoming release dates (first Fridays, 08:30 ET)
+
+2026-08-07, 2026-09-04, 2026-10-02, 2026-11-06, 2026-12-04 — verify each against the
+BLS release schedule (`bls.gov/schedule/news_release/empsit.htm`) the week before;
+BLS occasionally shifts a week.


### PR DESCRIPTION
## Summary
- `docs/specs/nfp-forward-capture-routine.md` — build brief for Grok: the read-only per-print capture routine required by the signed forward gate (#155). Pre-release Wayback Save-Page-Now + BLS actual + append-only `nfp_good_news_forward.csv`. **First capture window opens 2026-08-06 12:30 UTC.**
- `docs/evidence_portfolio/DAY30_REVIEW.md` — pre-drafted day-30 ratification memo (review ~2026-08-06). Kill gate does not fire (probe #1 = YES); memo proposes the post-window allocation: cTrader gets active hours, NFP forward on autopilot, A1 on the Legion watcher, research bucket stays closed.

Docs only, no code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)