### PR TITLE
NFP forward gate: capture routine spec + capture tool

### DIFF
--- a/docs/evidence_portfolio/DAY30_REVIEW.md
+++ b/docs/evidence_portfolio/DAY30_REVIEW.md
@@ -1,0 +1,42 @@
+# Day-30 Portfolio Review — 2026-08-06 (template, pre-drafted 2026-07-21)
+
+**Status:** DRAFT until ratified on or about 2026-08-06
+**Purpose:** close the 30-day evidence portfolio (2026-07-07 → ~2026-08-06) with a
+15-minute ratification. All track verdicts are already determinate; blanks below are
+for anything that changes between drafting and review day.
+
+## Track outcomes (as of drafting, 2026-07-21)
+
+| Track | Verdict | Evidence |
+|-------|---------|----------|
+| Edge probe #1 (NFP OOS) | **YES** (2026-07-16) | `NFP_PREREG.md`, PR #154 — 21 trades, +0.70%/trade net, PF 2.18, all LOO positive |
+| Edge probe #2 (fee-marginal) | **DELETED_NOT_NAMED** (2026-07-09) | `FEE_MARGINAL_PREREG.md` — no eligible family; budget slot consumed, not replaced |
+| A1 incentive farming | **CLOSED, no Scale** (2026-07-14) | `A1_THRESHOLD_LOCK.md` — Legion = weekly watch only; galxe → controls; tick timer disabled |
+| cTrader FX (external) | _[fill at review: challenge status vs `CTRADER_EXTERNAL_GATE.md`]_ | external repo |
+| NFP forward gate | **SIGNED, in force** (2026-07-21) | `NFP_FORWARD_GATE.md`, PR #155 — first clean print 2026-08-07 |
+
+## Kill-gate check
+
+`PORTFOLIO_KILL_GATE.md` triggers only if *all four* tracks come back empty. Probe #1
+returned YES → **the kill gate does not fire.** No fallback decision is required.
+
+## Post-window allocation (proposed for ratification)
+
+1. **cTrader** keeps all active agent-hours: exit-path deterministic replay first
+   (session-independent), then the ≥5 live executions per exit path the external gate
+   requires.
+2. **NFP forward gate** runs on autopilot: one capture ritual per print
+   (`docs/specs/nfp-forward-capture-routine.md`), append-only CSV, no other work until
+   the 7-print interim check.
+3. **A1** stays on the weekly Legion watcher. No new programs.
+4. **Research bucket stays closed.** No new probes, no lane #16. Reopening requires a
+   named changed input + explicit human decision, per `README.md`.
+
+## Ratification
+
+- [ ] Track table verified current
+- [ ] Allocation 1–4 accepted (or amendments noted below)
+
+Amendments: _[none]_
+
+Ratified by: _[unsigned]_

--- a/docs/reports/edge-candidates-2026-07-27.md
+++ b/docs/reports/edge-candidates-2026-07-27.md
@@ -1,0 +1,308 @@
+# Edge Candidates — Plain-Language Explainer
+
+**Date:** 2026-07-27
+**Status:** advisory / decision input. Nothing here is a commitment or an open lane.
+**Scope:** what is actually worth trying next, and exactly why, given everything this
+program has already closed.
+
+---
+
+## The framing (read this first)
+
+This program has already spent its budget on one hypothesis class and got a clear
+answer. Roughly 1,440 WFO runs, ~30 probe lanes, a dual-pass adversarial review
+(Claude × Grok, `docs/reports/deep-edge-research-reconciliation-2026-06-24.md`), and a
+sealed public-data book all converge on the same conclusion:
+
+> **A cleverer strategy on the same public OHLCV data is not an edge.**
+> Everything that looked like one died to costs, tail risk, or single-horizon fragility.
+
+So none of the candidates below is "another strategy idea." Each one is exactly one of
+three things:
+
+| Class | Meaning |
+|---|---|
+| **Measured** | You already ran the probe and it passed a pre-registered gate. Work left is execution, not discovery. |
+| **Unpriced** | A specific variant the bank never actually tested. Cheap to price on paper before spending anything. |
+| **Structural** | An advantage that comes from *what you are* (small, or a venue member), not from *what you predict*. Cannot be arbed away by a better model. |
+
+An "advantage type" is named for every candidate. If a candidate has no advantage type,
+it is not an edge — it is a backtest.
+
+---
+
+## 1. Finish the NFP event lane
+
+**Class:** Measured · **Advantage:** information timing on a scheduled release
+**Cost:** ~$0 and a few hours of coding · **Ceiling:** low but real · **Deadline: 2026-08-06**
+
+### What it is
+Non-farm payrolls prints the first Friday of each month at 08:30 ET. The probe tested a
+*conditional* version of the classic macro reaction: not "surprise → drift," but
+**good news is good** — a strong labor print reads as risk-on, and crypto follows.
+
+### Why it might be real
+It is the only lane in the entire repository that passed an out-of-sample gate with a
+verdict of **YES** (`docs/reports/`, PR #154): **+0.70% net expectancy per event,
+profit factor 2.18, and every leave-one-out fold positive.** That last part matters —
+it means no single event is carrying the result.
+
+### What is left to do
+The forward-confirmation gate is signed and in force
+(`docs/evidence_portfolio/NFP_FORWARD_GATE.md`, 2026-07-21). It requires, for each
+future print:
+
+1. **Before** the release, a Wayback "Save Page Now" snapshot of the consensus page —
+   this freezes the consensus *point-in-time*, so you cannot later be accused of
+   fitting to a revised number.
+2. **After** the release, the headline actual read from the BLS release.
+3. One append-only row in `data/macro_events/nfp_good_news_forward.csv`.
+
+The build brief exists (`docs/specs/nfp-forward-capture-routine.md`); the script
+(`scripts/nfp_forward_capture.py`) **does not exist yet.**
+
+### The catch
+- **Hard deadline.** The capture window for the 2026-08-07 print opens **2026-08-06
+  12:30 UTC**. A print with no pre-release capture is a `MISSED_CAPTURE` row, and
+  **three misses cap the sample** — i.e. you can lose the lane by inaction alone.
+- **Low frequency by construction.** ~12 events/year. At +0.70% per event this is
+  "hundreds of dollars per $10k deployed per year," not a living.
+- Forward results may simply not confirm. That is the point of the gate.
+
+### Kill criteria
+Whatever the signed gate says — do not renegotiate them after seeing data.
+
+### Verdict
+**Do it.** Near-zero cost, hard deadline, and it validates the whole data-first method.
+This is the single highest-priority item on the list purely because of the calendar.
+
+---
+
+## 2. Conditional-CPI analog — *deferred behind #1*
+
+**Class:** Unpriced · **Advantage:** same primitive, wider calendar
+**Cost:** days of archive work, $0 cash · **Ceiling:** low-mid
+
+### What it is
+The same "good news is good" conditional framing, applied to CPI: a *cool* inflation
+print → risk-on. If it works, it roughly doubles your event count per year.
+
+### The honest caution
+A **generic** CPI+NFP surprise-drift probe already closed **WEAK_EDGE**, and the ledger
+attached an explicit instruction: *do not widen the series to rescue a weak result.*
+What survived was specifically the **conditional** framing, which was never tested on
+CPI. That distinction is the only thing that makes this legitimate rather than
+gate-shopping.
+
+### Therefore
+This is allowed only as a **fresh, separately pre-registered lane** — its own null
+model (#118 standard), its own frozen event set, written before any data is pulled —
+**and only after the NFP forward gate confirms.** Running it now, while NFP is
+unconfirmed, is exactly the failure mode of trying two things until one prints.
+
+### Verdict
+**Yes, later.** Gate it on the NFP day-30 review.
+
+---
+
+## 3. Delta-neutral *staking* carry
+
+**Class:** Unpriced · **Advantage:** yield stacking, non-directional
+**Cost:** hours for a paper memo; capital only if the memo clears · **Ceiling:** mid, capped by size
+
+### What it is
+Hold spot SOL or ETH, short the equivalent perpetual future. Price exposure cancels, so
+you are not predicting anything — you collect funding. **The new part:** stake the spot
+leg, so you earn staking yield *on top of* funding.
+
+### Why this is not a re-run of a closed lane
+The funding-carry lane was **banked** (`funding-carry-neutral-probe-v0`) for a precise
+reason: excess return over the risk-free rate went negative once you measured it
+honestly on deployed capital. But that arithmetic used **plain unstaked spot**. Adding
+~6–8% APY (SOL) or ~3% (ETH) of staking yield changes the sum. Nobody has done that
+sum.
+
+### The question the memo must answer
+> staking APY + expected funding − fees − depeg/liquidity risk, versus ~4% risk-free.
+
+### The new risks the old lane did not have
+These are the whole reason this needs a memo and not a trade:
+- **Liquid-staking depeg** — the LST (e.g. jitoSOL, stETH) can trade below the
+  underlying, which is a real loss on the spot leg.
+- **Unbonding delay vs. margin calls** — if the perp leg needs collateral *now* and the
+  spot leg is locked in an unstaking queue for days, "delta-neutral" stops being
+  neutral at exactly the wrong moment. This is the failure that liquidates the
+  position.
+- Funding compresses; the earlier probe measured ~80% forward compression.
+
+### Why it is still attractive
+It does not decay like a prediction edge. You are being paid a risk premium to warehouse
+a real risk — which is durable as long as you are honestly priced for that risk.
+
+### Verdict
+**Write the Gate-0 memo unconditionally** (it costs hours). **Commit capital only if
+excess-over-risk-free is clearly positive after honest haircuts** for depeg and
+unbonding.
+
+---
+
+## 4. Access / "size-is-edge" operations
+
+**Class:** Structural · **Advantage:** flows a whale *cannot* harvest
+**Cost:** ~$0 ongoing, already automated · **Ceiling:** mid, lumpy and episodic
+
+### What it is
+Rewards that are allocated to *participants*, not to *capital*: merit-based sale
+allocations, announced airdrops, measurable incentive programs. A large fund entering
+these dilutes the very reward it is chasing; a small operator does not. That asymmetry
+is structural.
+
+### Why this is on the list
+The reconciliation doc flagged this as **the one edge class the entire bank never
+tested** — every other closed lane was a prediction bet on public data. This is not a
+prediction bet at all.
+
+### Where it actually stands
+Phase-0 ran and gave an honest, unglamorous answer: **0 programs actionable today**
+(closed 2026-07-14). But the machinery survives and costs nothing to keep armed:
+- `incentive_ops` registry
+- `scripts/legion_watch.sh` — weekly watch on the best candidate (Legion merit sales),
+  which is hold-and-watch pending a live round with a **disclosed merit formula**.
+
+### The discipline that keeps this positive-EV
+Act **only** on rewards that are (a) announced, (b) measurable, and (c) clear a base-case
+EV of **$25/hr** for the labor involved. Never on speculative "points" that might
+convert someday. Without that rule this quietly becomes unpaid work.
+
+### Verdict
+**Keep as a standing watch.** Readiness costs nothing and payoffs are uncorrelated with
+everything else you run.
+
+---
+
+## 5. Scale the cTrader FX system
+
+**Class:** Measured · **Advantage:** compounding an expectancy you already have
+**Cost:** capital allocation, zero new research · **Ceiling:** mid-high
+
+### What it is
+Not a new idea at all — put more behind the system that already works. The cTrader
+session-momentum FX agent is the designated forward vehicle (Track 1): **live-validated
++EV on a FundedHive prop challenge**, with per-instrument costs derived empirically
+(`derive_sm_pair_costs.py`) rather than assumed. That cost discipline is precisely the
+lesson the crypto program paid ~1,440 WFO runs to learn.
+
+### Why it belongs on an "edges" list
+The highest-expected-dollar action available is usually not a sixth objective — it is
+more capital, more instruments, and tighter cost calibration on the one system with
+measured positive expectancy, up to its capacity limit.
+
+### The open hole (do this before scaling)
+Per `docs/evidence_portfolio/CTRADER_EXTERNAL_GATE.md`: every live close so far has been
+a **broker bracket fill caught by the reconciler**. The **agent-initiated** exit paths
+(partial TP, trailing stop) are still **unexercised in live**. The gate requires ≥5
+real-time executions per agent-managed exit path before that path counts as
+production-ready, plus ≥30 closed forward trades (or 10 live sessions), 0 rule
+violations, and positive net expectancy after all frictions.
+
+### Boundary
+That agent lives in its **own repository**. This repo records the gate; it must not
+modify cTrader source.
+
+### Verdict
+**Probably the largest absolute-dollar item here, and it needs zero new hypotheses.**
+Close the exit-path hole first — scaling an unexercised close path is how a small bug
+becomes a challenge failure.
+
+---
+
+## 6. Maker-rebate market-making on a C-tier venue
+
+**Class:** Structural · **Advantage:** *earn* the spread instead of paying it
+**Cost:** high — this is a business, not a probe · **Ceiling:** high, uncapped, durable
+
+### What it is
+Become a designated market maker / liquidity provider (or reach a rebate fee tier) on a
+smaller venue, and quote both sides continuously.
+
+### Why it is the only surviving *trading* prior
+Look at how the crypto lanes actually died: a real gross signal, then costs ate it. The
+Path 2 illiquid-venue gate failed on exactly that sub-gate — thin books mean wide
+spreads, and taking liquidity there is expensive. Market-making **inverts the sign of
+that term**. The thin book stops being your cost and becomes your revenue. Both review
+passes ranked this as the sole durable trading edge left standing.
+
+### What it actually demands (do not underestimate this)
+- Dedicated capital well beyond $10k
+- Real infrastructure: uptime, inventory/position management, alerting, kill switches
+- Custody risk tolerance on a **small venue** — venue failure is a live risk, not a
+  footnote
+- Months of committed operation; this is not a probe you can abandon after two weeks
+
+### The entry gate your own docs already specify
+1. Name a **specific** venue.
+2. Obtain its maker-fee / rebate schedule **in writing**.
+3. Write a fresh Gate-0 brief demonstrating that sub-gate 2 (cost) genuinely inverts —
+   with the rebate arithmetic, not a hope.
+
+### Verdict
+**Only if you deliberately decide to build a business.** Never on momentum, never as a
+"let's see." But it is the one item here with an uncapped ceiling.
+
+---
+
+## Wildcard: on-chain flow primitives
+
+**Class:** Unpriced · **Prior: low — expect NO_PULSE** · **Cost:** a few hours, free tiers only
+
+Stablecoin net mints, exchange netflows, whale-wallet concentration. This is the last
+data *family* the bank never touched — every probe so far used exchange-side telemetry
+(price, volume, funding, order flow). The efficient-venue taxonomy that correctly
+predicted the microstructure null predicts a null here too.
+
+Rules if you run it: **free tiers only** (do not buy Glassnode/Nansen on spec), standard
+#118 null model, pre-registered. Run it only if you want the book *fully* sealed. A
+pulse here would be a genuine surprise — treat it with more suspicion than enthusiasm,
+not less.
+
+---
+
+## Summary table
+
+| # | Edge | Class | Upfront cost | Prior | Ceiling | Action |
+|---|------|-------|--------------|-------|---------|--------|
+| 1 | NFP forward capture | Measured | ~0 — **deadline 2026-08-06** | **YES (passed OOS)** | Low but real | **Build now** |
+| 2 | Conditional-CPI analog | Unpriced | Days, $0 | Moderate | Low-mid | Defer behind #1 |
+| 3 | Staking carry | Unpriced | Hours (memo) | Moderate | Mid, capped | Write memo |
+| 4 | Access / size-is-edge | Structural | ~0 (built) | Real but episodic | Mid, lumpy | Keep watching |
+| 5 | Scale cTrader FX | Measured | Capital only | **Proven live** | Mid-high | Close exit-path gate, then scale |
+| 6 | Maker-rebate MM | Structural | High (a business) | Only durable trading prior | High | Deliberate decision only |
+| — | On-chain flows | Unpriced | Hours, free tiers | **Low** | Unknown | Optional book-sealer |
+
+The pattern across all of them: **execute what is measured (1, 5), price what is
+unpriced (3), stay ready for what is reserved for you (4)** — and fund the expensive
+structural bet (6) only as a conscious decision.
+
+---
+
+## Do NOT reopen these
+
+Listed explicitly because "find me an edge" invites them straight back in. Each was
+closed with margin, not marginally — see
+`docs/reports/autoresearch-candidate-ledger.md` and
+`docs/reports/research-consolidation-2026-06-19.md`.
+
+| Closed lane | Why it stays closed |
+|---|---|
+| OHLCV / threshold tuning on majors | ~1,440 WFO runs; structural-probe surface formally CLOSED |
+| Funding / short crowding mean-reversion | Measured null |
+| Alt-perp funding carry (unstaked) | Negative excess over risk-free; banked |
+| New-listing sniping | A latency business in disguise; most bot-contested events in crypto |
+| Polymarket / mNAV re-runs | Both closed WEAK_EDGE; mNAV "pulse" was a 4-bug artifact |
+| Liquid-market microstructure (OFI) | sign_corr 0.009 on BTC, net −7 to −10 bps, p≈0.5 |
+| Token-unlock 72h short | Failed to reproduce on independent data; source prices were reconstructed templates |
+| Cross-sectional alt momentum | 4 of 6 cells bankrupt the book (solvency FAIL) |
+| Illiquid-venue **taking** | Fails the cost sub-gate — only viable with the #6 maker advantage |
+
+Reopening any of these requires a **new, differentiated advantage** — alt-data, latency,
+scale, or access — not a new parameter.

--- a/docs/specs/nfp-forward-capture-routine.md
+++ b/docs/specs/nfp-forward-capture-routine.md
@@ -1,0 +1,50 @@
+# NFP Forward-Gate Capture Routine — Build Brief (for Grok)
+
+**Parent gate:** `docs/evidence_portfolio/NFP_FORWARD_GATE.md` (signed 2026-07-21, in force)
+**First deadline:** capture window for the 2026-08-07 release opens 2026-08-06 12:30 UTC
+**Scope class:** read-only tooling; no production services touched; no optimization
+
+## What the gate requires per print
+
+1. **Before the release** (within 24h before 08:30 ET on release day): trigger a
+   Wayback "Save Page Now" of
+   `https://www.investing.com/economic-calendar/nonfarm-payrolls-227` and record the
+   returned snapshot URL. This freezes the consensus point-in-time.
+2. **After the release**: read the headline actual from the BLS Employment Situation
+   release (`bls.gov/news.release/empsit.nr0.htm`, archived copy under
+   `bls.gov/news.release/archives/`).
+3. Append **one row** to `data/macro_events/nfp_good_news_forward.csv` — same columns
+   as `data/macro_events/nfp_good_news_oos_2021_2023.csv`:
+   `event_type,release_date_et,release_ts_utc,metric,actual,consensus,surprise,z,consensus_source,actual_source,source_snapshot_url`
+   - `surprise = actual − consensus`
+   - `z = surprise / 220.28` (divisor frozen by the gate; reporting continuity only)
+   - `release_ts_utc` = 08:30 America/New_York converted to UTC, DST-aware
+4. Rows are **append-only**. A print with no pre-release capture gets a
+   `MISSED_CAPTURE` row (see gate for semantics; 3 misses caps the sample).
+
+## Suggested implementation (small)
+
+- `scripts/nfp_forward_capture.py` with two subcommands:
+  - `pre` — POST/GET `https://web.archive.org/save/https://www.investing.com/economic-calendar/nonfarm-payrolls-227`,
+    verify the snapshot resolves and its "Latest Release" date is the *previous*
+    release (i.e., the page predates the upcoming print), print the snapshot URL, and
+    stash it in `research/nfp_forward/pending_capture.json`.
+  - `post --actual <n> --consensus <n>` — validate against the pending snapshot,
+    compute surprise/z (full float precision — the OOS loader rejects rounded z),
+    append the CSV row, clear the pending file.
+- Reuse the validation logic pattern from
+  `scripts/probe_nfp_good_news_oos.py::load_surprises` for self-checks.
+- No cron/systemd automation of the *decision*; scheduling the `pre` call before each
+  release day is fine (first Fridays; human reminder exists for 2026-08-06).
+
+## Explicitly out of scope (gate terms)
+
+- No trading, paper agent, config, or strategy code.
+- No extra symbols in the verdict path, no second event type, no intraday variants.
+- No edits to committed CSV rows, ever.
+
+## Upcoming release dates (first Fridays, 08:30 ET)
+
+2026-08-07, 2026-09-04, 2026-10-02, 2026-11-06, 2026-12-04 — verify each against the
+BLS release schedule (`bls.gov/schedule/news_release/empsit.htm`) the week before;
+BLS occasionally shifts a week.

--- a/scripts/nfp_forward_capture.py
+++ b/scripts/nfp_forward_capture.py
@@ -1,0 +1,529 @@
+#!/usr/bin/env python3
+"""Capture point-in-time NFP consensus/actual rows for the signed forward gate.
+
+Gate: ``docs/evidence_portfolio/NFP_FORWARD_GATE.md`` (signed 2026-07-21, in force).
+Build brief: ``docs/specs/nfp-forward-capture-routine.md``.
+
+This tool is read-only with respect to production services. It touches exactly two
+paths: the append-only forward CSV and a pending-capture stash. It never trades,
+never reads config, and never evaluates the gate.
+
+Workflow per release:
+
+1. ``pre``  — within 24h *before* the release, freeze the Investing.com consensus
+   via a Wayback "Save Page Now" snapshot and stash the snapshot URL.
+2. ``post`` — after the release, supply the BLS headline actual and the consensus
+   read off the frozen snapshot; one row is appended and the stash is cleared.
+3. ``miss`` — if no pre-release snapshot was taken, record a ``NFP_MISSED_CAPTURE``
+   row. Those rows carry no verdict weight; 3 or more cap the sample.
+
+Rows are append-only. A committed row is never edited by this script.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import re
+import sys
+from dataclasses import dataclass
+from datetime import UTC, date, datetime, timedelta
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+import httpx
+
+CONSENSUS_URL = "https://www.investing.com/economic-calendar/nonfarm-payrolls-227"
+WAYBACK_SAVE_URL = f"https://web.archive.org/save/{CONSENSUS_URL}"
+WAYBACK_PREFIX = "https://web.archive.org/"
+SNAPSHOT_TS_RE = re.compile(r"/web/(\d{14})")
+HTML_TAG_RE = re.compile(r"<[^>]+>")
+
+EVENT_TYPE = "NFP"
+MISSED_EVENT_TYPE = "NFP_MISSED_CAPTURE"
+METRIC = "headline_nfp_change_k"
+CONSENSUS_SOURCE = "investing.com/Wayback"
+ACTUAL_SOURCE = "bls.gov"
+MISSED_SENTINEL = "MISSED_CAPTURE"
+
+# Frozen by the gate for reporting continuity only. The entry condition is
+# surprise > 0, which is equivalent to z > 0 for any positive divisor.
+Z_DIVISOR = 220.28
+
+RELEASE_TIME_ET = (8, 30)
+EASTERN = ZoneInfo("America/New_York")
+CAPTURE_WINDOW = timedelta(hours=24)
+
+CSV_COLUMNS = (
+    "event_type",
+    "release_date_et",
+    "release_ts_utc",
+    "metric",
+    "actual",
+    "consensus",
+    "surprise",
+    "z",
+    "consensus_source",
+    "actual_source",
+    "source_snapshot_url",
+)
+
+DEFAULT_FORWARD_CSV = Path("data/macro_events/nfp_good_news_forward.csv")
+DEFAULT_PENDING_JSON = Path("research/nfp_forward/pending_capture.json")
+
+USER_AGENT = "crypto-agent-nfp-forward-capture/1.0 (research; read-only)"
+SAVE_TIMEOUT_SECONDS = 180.0
+FETCH_TIMEOUT_SECONDS = 60.0
+
+
+class CaptureError(RuntimeError):
+    """Raised when a capture step cannot be completed safely."""
+
+
+@dataclass(frozen=True)
+class PendingCapture:
+    release_date_et: str
+    release_ts_utc: str
+    snapshot_url: str
+    snapshot_ts_utc: str
+    captured_at_utc: str
+    verified: bool
+
+    def to_json(self) -> dict[str, object]:
+        return {
+            "release_date_et": self.release_date_et,
+            "release_ts_utc": self.release_ts_utc,
+            "snapshot_url": self.snapshot_url,
+            "snapshot_ts_utc": self.snapshot_ts_utc,
+            "captured_at_utc": self.captured_at_utc,
+            "verified": self.verified,
+        }
+
+    @classmethod
+    def from_json(cls, payload: dict[str, object]) -> PendingCapture:
+        missing = {field for field in cls.__annotations__ if field not in payload}
+        if missing:
+            raise CaptureError(f"pending capture file is missing fields: {sorted(missing)}")
+        return cls(
+            release_date_et=str(payload["release_date_et"]),
+            release_ts_utc=str(payload["release_ts_utc"]),
+            snapshot_url=str(payload["snapshot_url"]),
+            snapshot_ts_utc=str(payload["snapshot_ts_utc"]),
+            captured_at_utc=str(payload["captured_at_utc"]),
+            verified=bool(payload["verified"]),
+        )
+
+
+def release_timestamp_utc(release_date: date) -> datetime:
+    """Return the 08:30 America/New_York release instant in UTC (DST-aware)."""
+    hour, minute = RELEASE_TIME_ET
+    local = datetime(release_date.year, release_date.month, release_date.day, hour, minute)
+    return local.replace(tzinfo=EASTERN).astimezone(UTC)
+
+
+def first_friday(year: int, month: int) -> date:
+    """Return the first Friday of the given month (the usual NFP release day)."""
+    first = date(year, month, 1)
+    return first + timedelta(days=(4 - first.weekday()) % 7)
+
+
+def next_scheduled_release(now: datetime) -> date:
+    """Best-guess next NFP date. Always verify against the BLS release schedule."""
+    candidate = first_friday(now.year, now.month)
+    if release_timestamp_utc(candidate) > now:
+        return candidate
+    year = now.year + 1 if now.month == 12 else now.year
+    month = 1 if now.month == 12 else now.month + 1
+    return first_friday(year, month)
+
+
+def parse_release_date(raw: str) -> date:
+    try:
+        return date.fromisoformat(raw.strip())
+    except ValueError as exc:
+        raise CaptureError(f"release date must be ISO YYYY-MM-DD, got {raw!r}") from exc
+
+
+def _strip_html(html: str) -> str:
+    return HTML_TAG_RE.sub(" ", html)
+
+
+def _date_renderings(value: date) -> tuple[str, ...]:
+    """Textual forms Investing.com uses for a release date, for containment checks."""
+    return (
+        value.isoformat(),
+        value.strftime("%b %d, %Y"),
+        value.strftime("%B %d, %Y"),
+        value.strftime("%b %-d, %Y"),
+        value.strftime("%B %-d, %Y"),
+        value.strftime("%d/%m/%Y"),
+        value.strftime("%m/%d/%Y"),
+    )
+
+
+def page_mentions_date(html: str, value: date) -> bool:
+    text = " ".join(_strip_html(html).split())
+    return any(rendering in text for rendering in _date_renderings(value))
+
+
+def previous_scheduled_release(release_date: date) -> date:
+    """First Friday of the month before ``release_date``."""
+    year = release_date.year - 1 if release_date.month == 1 else release_date.year
+    month = 12 if release_date.month == 1 else release_date.month - 1
+    return first_friday(year, month)
+
+
+def verify_snapshot_is_point_in_time(html: str, release_date: date) -> tuple[bool, str]:
+    """Check the archived page predates the upcoming print.
+
+    The invariant that matters: the snapshot must NOT already contain the upcoming
+    release. A page that mentions the previous release and not the upcoming one is
+    a valid point-in-time consensus capture.
+    """
+    if page_mentions_date(html, release_date):
+        return False, (
+            f"snapshot already mentions the upcoming release date {release_date.isoformat()} "
+            "— it is not a point-in-time capture"
+        )
+    previous = previous_scheduled_release(release_date)
+    if not page_mentions_date(html, previous):
+        return False, (
+            f"snapshot does not mention the previous release {previous.isoformat()}; "
+            "could not confirm this is a live NFP calendar page"
+        )
+    return True, f"snapshot predates {release_date.isoformat()} and shows {previous.isoformat()}"
+
+
+def _http_get(url: str, timeout: float) -> httpx.Response:
+    headers = {"User-Agent": USER_AGENT}
+    with httpx.Client(follow_redirects=True, timeout=timeout, headers=headers) as client:
+        return client.get(url)
+
+
+def _snapshot_url_from_response(response: httpx.Response) -> str:
+    candidates = [str(response.url)]
+    content_location = response.headers.get("content-location")
+    if content_location:
+        candidates.append(f"https://web.archive.org{content_location}")
+    for candidate in candidates:
+        if candidate.startswith(WAYBACK_PREFIX) and SNAPSHOT_TS_RE.search(candidate):
+            return candidate
+    raise CaptureError(
+        "Wayback did not return a usable snapshot URL "
+        f"(status {response.status_code}, url {response.url}). "
+        "Save Page Now may be rate-limited; retry or capture manually."
+    )
+
+
+def snapshot_timestamp(snapshot_url: str) -> datetime:
+    match = SNAPSHOT_TS_RE.search(snapshot_url)
+    if match is None:
+        raise CaptureError(f"cannot read a Wayback timestamp from {snapshot_url!r}")
+    return datetime.strptime(match.group(1), "%Y%m%d%H%M%S").replace(tzinfo=UTC)
+
+
+def read_pending(path: Path) -> PendingCapture | None:
+    if not path.exists():
+        return None
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise CaptureError(f"pending capture file is not valid JSON: {path}") from exc
+    if not isinstance(payload, dict):
+        raise CaptureError(f"pending capture file must contain a JSON object: {path}")
+    return PendingCapture.from_json(payload)
+
+
+def write_pending(path: Path, pending: PendingCapture) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(pending.to_json(), indent=2) + "\n", encoding="utf-8")
+
+
+def committed_release_dates(csv_path: Path) -> set[str]:
+    if not csv_path.exists():
+        return set()
+    with csv_path.open(encoding="utf-8", newline="") as handle:
+        reader = csv.DictReader(handle)
+        if reader.fieldnames is None:
+            return set()
+        if not set(CSV_COLUMNS).issubset(reader.fieldnames):
+            raise CaptureError(f"forward CSV has unexpected columns: {csv_path}")
+        return {row["release_date_et"].strip() for row in reader}
+
+
+def append_row(csv_path: Path, row: dict[str, str]) -> None:
+    """Append one row, creating the file with a header if it does not exist yet."""
+    release_date_et = row["release_date_et"]
+    if release_date_et in committed_release_dates(csv_path):
+        raise CaptureError(
+            f"a row for {release_date_et} is already committed in {csv_path}; "
+            "rows are append-only and are never edited"
+        )
+    csv_path.parent.mkdir(parents=True, exist_ok=True)
+    write_header = not csv_path.exists()
+    with csv_path.open("a", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=CSV_COLUMNS, lineterminator="\n")
+        if write_header:
+            writer.writeheader()
+        writer.writerow(row)
+
+
+def build_row(
+    release_date: date, actual: float, consensus: float, snapshot_url: str
+) -> dict[str, str]:
+    surprise = actual - consensus
+    z = surprise / Z_DIVISOR
+    return {
+        "event_type": EVENT_TYPE,
+        "release_date_et": release_date.isoformat(),
+        "release_ts_utc": release_timestamp_utc(release_date).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "metric": METRIC,
+        "actual": repr(actual),
+        "consensus": repr(consensus),
+        "surprise": repr(surprise),
+        "z": repr(z),
+        "consensus_source": CONSENSUS_SOURCE,
+        "actual_source": ACTUAL_SOURCE,
+        "source_snapshot_url": snapshot_url,
+    }
+
+
+def build_missed_row(release_date: date, note: str) -> dict[str, str]:
+    return {
+        "event_type": MISSED_EVENT_TYPE,
+        "release_date_et": release_date.isoformat(),
+        "release_ts_utc": release_timestamp_utc(release_date).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "metric": METRIC,
+        "actual": "",
+        "consensus": "",
+        "surprise": "",
+        "z": "",
+        "consensus_source": MISSED_SENTINEL,
+        "actual_source": note or MISSED_SENTINEL,
+        "source_snapshot_url": "",
+    }
+
+
+def cmd_pre(args: argparse.Namespace) -> int:
+    now = datetime.now(UTC)
+    release_date = parse_release_date(args.release_date) if args.release_date else None
+    if release_date is None:
+        release_date = next_scheduled_release(now)
+        print(
+            f"[warn] no --release-date given; assuming next first Friday "
+            f"{release_date.isoformat()}. Verify against "
+            "https://www.bls.gov/schedule/news_release/empsit.htm"
+        )
+
+    release_ts = release_timestamp_utc(release_date)
+    if now >= release_ts:
+        raise CaptureError(
+            f"release {release_date.isoformat()} already happened at {release_ts.isoformat()}; "
+            "a post-release snapshot is not a point-in-time consensus. Use `miss` instead."
+        )
+    if release_ts - now > CAPTURE_WINDOW:
+        raise CaptureError(
+            f"release {release_date.isoformat()} is more than 24h away "
+            f"({release_ts.isoformat()}); the gate wants the snapshot inside the 24h window."
+        )
+
+    pending_path = Path(args.pending)
+    existing = read_pending(pending_path)
+    if existing is not None and not args.force:
+        raise CaptureError(
+            f"a pending capture for {existing.release_date_et} already exists at {pending_path}; "
+            "run `post` (or `miss`) first, or pass --force to replace it"
+        )
+
+    print(f"[pre] requesting Wayback Save Page Now for {CONSENSUS_URL}")
+    response = _http_get(WAYBACK_SAVE_URL, SAVE_TIMEOUT_SECONDS)
+    snapshot_url = _snapshot_url_from_response(response)
+    snapshot_ts = snapshot_timestamp(snapshot_url)
+    print(f"[pre] snapshot: {snapshot_url}")
+
+    if snapshot_ts >= release_ts:
+        raise CaptureError(
+            f"snapshot timestamp {snapshot_ts.isoformat()} is not before the release "
+            f"{release_ts.isoformat()}"
+        )
+
+    body = response.text
+    if not body.strip():
+        body = _http_get(snapshot_url, FETCH_TIMEOUT_SECONDS).text
+
+    verified, detail = verify_snapshot_is_point_in_time(body, release_date)
+    if verified:
+        print(f"[pre] verified: {detail}")
+    else:
+        print(f"[pre] NOT VERIFIED: {detail}")
+        if not args.allow_unverified:
+            raise CaptureError(
+                "refusing to stash an unverified snapshot. Open the snapshot URL, confirm the "
+                "listed latest release is the previous print, then re-run with --allow-unverified."
+            )
+        print("[pre] stashing anyway because --allow-unverified was passed")
+
+    pending = PendingCapture(
+        release_date_et=release_date.isoformat(),
+        release_ts_utc=release_ts.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        snapshot_url=snapshot_url,
+        snapshot_ts_utc=snapshot_ts.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        captured_at_utc=now.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        verified=verified,
+    )
+    write_pending(pending_path, pending)
+    print(f"[pre] stashed -> {pending_path}")
+    print("[pre] next: read the consensus off the snapshot, then after the release run `post`")
+    return 0
+
+
+def cmd_post(args: argparse.Namespace) -> int:
+    pending_path = Path(args.pending)
+    pending = read_pending(pending_path)
+    if pending is None:
+        raise CaptureError(
+            f"no pending capture at {pending_path}. Without a pre-release snapshot this print "
+            "must be recorded with `miss`."
+        )
+    release_date = parse_release_date(pending.release_date_et)
+    if args.release_date and parse_release_date(args.release_date) != release_date:
+        raise CaptureError(
+            f"pending capture is for {pending.release_date_et}, not {args.release_date}"
+        )
+
+    now = datetime.now(UTC)
+    release_ts = release_timestamp_utc(release_date)
+    if now < release_ts:
+        raise CaptureError(
+            f"release {release_date.isoformat()} has not happened yet ({release_ts.isoformat()})"
+        )
+    if not pending.verified and not args.allow_unverified:
+        raise CaptureError(
+            "pending snapshot was stashed unverified; re-run with --allow-unverified to commit it"
+        )
+
+    row = build_row(release_date, args.actual, args.consensus, pending.snapshot_url)
+    csv_path = Path(args.csv)
+    append_row(csv_path, row)
+    pending_path.unlink()
+
+    print(f"[post] appended {release_date.isoformat()} -> {csv_path}")
+    print(
+        f"[post]   actual={row['actual']} consensus={row['consensus']} surprise={row['surprise']}"
+    )
+    print(f"[post]   z={row['z']}  snapshot={pending.snapshot_url}")
+    direction = (
+        "HOT (long entry per gate)" if args.actual > args.consensus else "not hot (no trade)"
+    )
+    print(f"[post]   {direction}")
+    print(f"[post] cleared {pending_path}")
+    return 0
+
+
+def cmd_miss(args: argparse.Namespace) -> int:
+    release_date = parse_release_date(args.release_date)
+    row = build_missed_row(release_date, args.note)
+    csv_path = Path(args.csv)
+    append_row(csv_path, row)
+
+    pending_path = Path(args.pending)
+    pending = read_pending(pending_path)
+    if pending is not None and pending.release_date_et == release_date.isoformat():
+        pending_path.unlink()
+        print(f"[miss] cleared stale pending capture {pending_path}")
+
+    misses = sum(1 for value in _read_event_types(csv_path) if value == MISSED_EVENT_TYPE)
+    print(f"[miss] recorded MISSED_CAPTURE for {release_date.isoformat()} -> {csv_path}")
+    print(f"[miss] missed captures so far: {misses} (3 or more cap the sample per the gate)")
+    return 0
+
+
+def _read_event_types(csv_path: Path) -> list[str]:
+    if not csv_path.exists():
+        return []
+    with csv_path.open(encoding="utf-8", newline="") as handle:
+        return [row["event_type"].strip() for row in csv.DictReader(handle)]
+
+
+def cmd_status(args: argparse.Namespace) -> int:
+    now = datetime.now(UTC)
+    csv_path = Path(args.csv)
+    pending_path = Path(args.pending)
+
+    event_types = _read_event_types(csv_path)
+    captured = sum(1 for value in event_types if value == EVENT_TYPE)
+    misses = sum(1 for value in event_types if value == MISSED_EVENT_TYPE)
+    print(f"[status] forward CSV: {csv_path} ({captured} captured, {misses} missed)")
+
+    pending = read_pending(pending_path)
+    if pending is None:
+        print("[status] no pending capture")
+    else:
+        flag = "verified" if pending.verified else "UNVERIFIED"
+        print(f"[status] pending: {pending.release_date_et} ({flag}) {pending.snapshot_url}")
+
+    upcoming = next_scheduled_release(now)
+    release_ts = release_timestamp_utc(upcoming)
+    opens = release_ts - CAPTURE_WINDOW
+    print(f"[status] next expected release: {upcoming.isoformat()} at {release_ts.isoformat()}")
+    print(f"[status] capture window opens:  {opens.isoformat()}")
+    print("[status] verify the date against https://www.bls.gov/schedule/news_release/empsit.htm")
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("--csv", default=str(DEFAULT_FORWARD_CSV), help="append-only forward CSV")
+    parser.add_argument(
+        "--pending", default=str(DEFAULT_PENDING_JSON), help="pending capture stash"
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    pre = subparsers.add_parser("pre", help="freeze the pre-release consensus via Wayback")
+    pre.add_argument("--release-date", help="ISO release date; defaults to the next first Friday")
+    pre.add_argument(
+        "--allow-unverified", action="store_true", help="stash despite a failed page check"
+    )
+    pre.add_argument("--force", action="store_true", help="replace an existing pending capture")
+    pre.set_defaults(func=cmd_pre)
+
+    post = subparsers.add_parser("post", help="append the row once the BLS actual is out")
+    post.add_argument(
+        "--actual", type=float, required=True, help="BLS headline NFP change, thousands"
+    )
+    post.add_argument(
+        "--consensus", type=float, required=True, help="consensus read off the snapshot"
+    )
+    post.add_argument("--release-date", help="optional cross-check against the pending capture")
+    post.add_argument(
+        "--allow-unverified", action="store_true", help="commit an unverified snapshot"
+    )
+    post.set_defaults(func=cmd_post)
+
+    miss = subparsers.add_parser("miss", help="record a print with no pre-release capture")
+    miss.add_argument("--release-date", required=True, help="ISO release date")
+    miss.add_argument("--note", default="", help="short reason, recorded in the row")
+    miss.set_defaults(func=cmd_miss)
+
+    status = subparsers.add_parser("status", help="show pending capture and the next release")
+    status.set_defaults(func=cmd_status)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        return int(args.func(args))
+    except CaptureError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    except httpx.HTTPError as exc:
+        print(f"error: network failure talking to Wayback: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_nfp_forward_capture.py
+++ b/tests/test_nfp_forward_capture.py
@@ -1,0 +1,152 @@
+"""Tests for the NFP forward-gate capture tool.
+
+No network access: every test exercises pure date/CSV/verification logic.
+"""
+
+from __future__ import annotations
+
+import csv
+from datetime import UTC, date, datetime
+from pathlib import Path
+
+import pytest
+
+from scripts.nfp_forward_capture import (
+    CSV_COLUMNS,
+    EVENT_TYPE,
+    MISSED_EVENT_TYPE,
+    Z_DIVISOR,
+    CaptureError,
+    append_row,
+    build_missed_row,
+    build_row,
+    first_friday,
+    next_scheduled_release,
+    page_mentions_date,
+    previous_scheduled_release,
+    release_timestamp_utc,
+    snapshot_timestamp,
+    verify_snapshot_is_point_in_time,
+)
+
+
+def test_release_timestamp_is_dst_aware():
+    """08:30 ET is 12:30 UTC in summer and 13:30 UTC in winter."""
+    assert release_timestamp_utc(date(2026, 8, 7)) == datetime(2026, 8, 7, 12, 30, tzinfo=UTC)
+    assert release_timestamp_utc(date(2026, 12, 4)) == datetime(2026, 12, 4, 13, 30, tzinfo=UTC)
+
+
+def test_release_timestamp_matches_committed_oos_rows():
+    """Recompute two rows from the committed OOS table."""
+    assert release_timestamp_utc(date(2021, 1, 8)) == datetime(2021, 1, 8, 13, 30, tzinfo=UTC)
+    assert release_timestamp_utc(date(2021, 4, 2)) == datetime(2021, 4, 2, 12, 30, tzinfo=UTC)
+
+
+def test_first_friday_and_previous_release():
+    assert first_friday(2026, 8) == date(2026, 8, 7)
+    assert first_friday(2026, 5) == date(2026, 5, 1)
+    assert previous_scheduled_release(date(2026, 8, 7)) == date(2026, 7, 3)
+    assert previous_scheduled_release(date(2026, 1, 2)) == date(2025, 12, 5)
+
+
+def test_next_scheduled_release_rolls_after_the_print():
+    before = datetime(2026, 8, 6, 12, 0, tzinfo=UTC)
+    after = datetime(2026, 8, 7, 13, 0, tzinfo=UTC)
+    assert next_scheduled_release(before) == date(2026, 8, 7)
+    assert next_scheduled_release(after) == date(2026, 9, 4)
+
+
+def test_next_scheduled_release_crosses_year_boundary():
+    assert next_scheduled_release(datetime(2026, 12, 5, 0, 0, tzinfo=UTC)) == date(2027, 1, 1)
+
+
+def test_page_mentions_date_handles_html_and_formats():
+    assert page_mentions_date("<td>Jul 03, 2026</td>", date(2026, 7, 3))
+    assert page_mentions_date("<span>July 3, 2026</span>", date(2026, 7, 3))
+    assert not page_mentions_date("<td>Jun 05, 2026</td>", date(2026, 7, 3))
+
+
+def test_verify_rejects_snapshot_containing_the_upcoming_print():
+    html = "<div>Aug 07, 2026</div><div>Jul 03, 2026</div>"
+    verified, detail = verify_snapshot_is_point_in_time(html, date(2026, 8, 7))
+    assert verified is False
+    assert "not a point-in-time capture" in detail
+
+
+def test_verify_rejects_page_without_the_previous_print():
+    verified, detail = verify_snapshot_is_point_in_time("<div>nothing here</div>", date(2026, 8, 7))
+    assert verified is False
+    assert "previous release" in detail
+
+
+def test_verify_accepts_point_in_time_snapshot():
+    html = "<table><tr><td>Jul 03, 2026</td><td>147K</td></tr></table>"
+    verified, _ = verify_snapshot_is_point_in_time(html, date(2026, 8, 7))
+    assert verified is True
+
+
+def test_snapshot_timestamp_parsed_from_wayback_url():
+    url = "https://web.archive.org/web/20260806131415/https://www.investing.com/x"
+    assert snapshot_timestamp(url) == datetime(2026, 8, 6, 13, 14, 15, tzinfo=UTC)
+
+
+def test_snapshot_timestamp_rejects_non_wayback_url():
+    with pytest.raises(CaptureError):
+        snapshot_timestamp("https://www.investing.com/economic-calendar/nonfarm-payrolls-227")
+
+
+def test_build_row_keeps_full_float_precision():
+    """The OOS loader rejects rounded z, so z must round-trip exactly."""
+    row = build_row(date(2026, 8, 7), 175.0, 160.0, "https://web.archive.org/web/2026/x")
+    assert row["surprise"] == repr(15.0)
+    assert float(row["z"]) == 15.0 / Z_DIVISOR
+    assert row["z"] == repr(15.0 / Z_DIVISOR)
+    assert row["release_ts_utc"] == "2026-08-07T12:30:00Z"
+    assert row["event_type"] == EVENT_TYPE
+    assert set(row) == set(CSV_COLUMNS)
+
+
+def test_build_row_handles_negative_surprise():
+    row = build_row(date(2026, 9, 4), 90.0, 150.0, "https://web.archive.org/web/2026/x")
+    assert float(row["surprise"]) == -60.0
+    assert float(row["z"]) < 0
+
+
+def test_append_row_writes_header_then_appends(tmp_path: Path):
+    csv_path = tmp_path / "forward.csv"
+    append_row(csv_path, build_row(date(2026, 8, 7), 175.0, 160.0, "https://web.archive.org/a"))
+    append_row(csv_path, build_row(date(2026, 9, 4), 90.0, 150.0, "https://web.archive.org/b"))
+
+    with csv_path.open(encoding="utf-8", newline="") as handle:
+        reader = csv.DictReader(handle)
+        assert reader.fieldnames == list(CSV_COLUMNS)
+        rows = list(reader)
+    assert [row["release_date_et"] for row in rows] == ["2026-08-07", "2026-09-04"]
+
+
+def test_append_row_refuses_duplicate_release_date(tmp_path: Path):
+    csv_path = tmp_path / "forward.csv"
+    append_row(csv_path, build_row(date(2026, 8, 7), 175.0, 160.0, "https://web.archive.org/a"))
+    with pytest.raises(CaptureError, match="append-only"):
+        append_row(csv_path, build_row(date(2026, 8, 7), 999.0, 1.0, "https://web.archive.org/c"))
+
+
+def test_missed_capture_row_is_blank_and_distinctly_typed(tmp_path: Path):
+    csv_path = tmp_path / "forward.csv"
+    row = build_missed_row(date(2026, 10, 2), "server down")
+    append_row(csv_path, row)
+
+    assert row["event_type"] == MISSED_EVENT_TYPE
+    assert row["actual"] == ""
+    assert row["consensus"] == ""
+    assert row["z"] == ""
+    assert row["source_snapshot_url"] == ""
+    assert row["actual_source"] == "server down"
+    assert row["release_ts_utc"] == "2026-10-02T12:30:00Z"
+
+
+def test_missed_capture_still_blocks_a_later_duplicate(tmp_path: Path):
+    csv_path = tmp_path / "forward.csv"
+    append_row(csv_path, build_missed_row(date(2026, 10, 2), ""))
+    with pytest.raises(CaptureError):
+        append_row(csv_path, build_row(date(2026, 10, 2), 1.0, 0.0, "https://web.archive.org/d"))


### PR DESCRIPTION
Closes the tooling gap on the signed NFP forward gate (`docs/evidence_portfolio/NFP_FORWARD_GATE.md`, in force 2026-07-21). **The first capture window opens 2026-08-06 12:30 UTC**, and three missed captures cap the sample — so this lands ahead of a hard date.

## Commits

| Commit | Contents |
|---|---|
| `abbd639` | Build brief (`docs/specs/nfp-forward-capture-routine.md`) + pre-drafted day-30 ratification memo |
| `7b885c3` | `scripts/nfp_forward_capture.py` + 17 tests |
| `3f0126f` | Plain-language edge-candidate explainer (advisory doc, unrelated to the gate) |

## The tool

Read-only with respect to production services — it touches only the append-only forward CSV and a pending-capture stash. No trading, config, or strategy code, per the gate's scope limits.

- `pre` — Wayback Save-Page-Now on the Investing.com NFP page, verify it is point-in-time, stash the snapshot URL
- `post --actual N --consensus N` — validate against the stash, append one row, clear the stash
- `miss --release-date D` — record a `NFP_MISSED_CAPTURE` row, report the running count against the gate's limit of 3
- `status` — captured/missed counts, pending capture, next capture window

## Decisions a reviewer should check

- **Point-in-time verification.** Parsing Investing.com's "Latest Release" field is fragile, so the check asserts the invariant that actually matters: the snapshot must *not* mention the upcoming release date and *must* mention the previous one. Failure refuses to stash. `--allow-unverified` exists, prints loudly, and is persisted as `verified: false` so `post` re-checks it.
- **Missed-capture sentinel.** The gate says these rows live in the same CSV and carry no verdict weight but does not name a marker. Uses `event_type=NFP_MISSED_CAPTURE` with blank numerics — a strict future loader will *error* on it rather than silently trade a blank row. **The forward loader built later must know this string.**
- **Precision.** `surprise`/`z` written via `repr()`; the OOS loader rejects rounded z. Divisor 220.28 frozen by the gate.
- **Append-only.** `append_row` refuses any release date already committed, miss rows included. No code path edits an existing row.

## Verification

- Full suite: **1243 passed**; `ruff check` and `ruff format --check` clean.
- 17 new tests, no network: DST-aware release timestamps (two committed OOS rows recomputed), first-Friday/year-boundary math, snapshot verification accept+reject paths, z round-trip precision, header/append behavior, duplicate and miss-row guards.
- CLI smoke-tested: window guards fire **before** any HTTP call — running `pre` today correctly refuses (release >24h away), a past date routes to `miss`.

## Known limitation

The live Wayback round-trip and the real page's date formatting are **unverified**. Exercising them would have created a genuine archive snapshot ~10 days early, outside the gate window. Recommend a dry run on 2026-08-06 with enough margin to fall back to a manual capture if Wayback rate-limits or the format check trips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)