### PR TITLE
Record cTrader exit-path measurement; close staking-carry candidate

### DIFF
--- a/docs/evidence_portfolio/CTRADER_EXTERNAL_GATE.md
+++ b/docs/evidence_portfolio/CTRADER_EXTERNAL_GATE.md
@@ -94,17 +94,43 @@ unexercised. The journal shows 20 partial-TP and 13 trailing-stop live closes da
 - Rows carry real commissions, and `exit_price` ≠ `filled_exit_price` (modeled trigger
   vs actual fill).
 
-**Open human decision (not made by tooling):** whether those 33 retroactively-identified
-executions count as gate evidence, or whether the ≥5 threshold must be met with
-write-time-tagged rows from here on. Two paths clear the threshold on the inferred
-evidence; `time_stop`, `stale_exit`, and `weekend_flatten` remain genuinely unexercised
-live either way. Going forward the ambiguity is gone — every new exit is tagged.
+### Decision 1 (2026-07-27): inferred executions accepted, replay still required
 
-**Taxonomy mismatch to resolve:** the "Exit paths to validate" list above does not map
-1:1 onto the code's `ExitReason` values. `time_stop` and `stale_exit` are real exit
-reasons absent from the list; "break-even move" is not a distinct exit reason; and
-"broker SL/TP handling" / "reconciliation after fill" are broker-side paths, not
-agent-managed ones. The gate should be restated against the actual taxonomy.
+The 33 retroactively-identified executions **count toward the ≥5 execution threshold**.
+Each path must **still pass deterministic replay** before it is production-ready —
+execution count alone does not make a path ready.
 
-Deciding and restating both points belongs in `ctrader-trading-agent` per the ownership
-rule above; this entry only records the measurement.
+Reported by `scripts/exit_path_gate_report.py --accept-inferred` (opt-in, so the strict
+reading remains the default view). Going forward the ambiguity is gone: every new exit is
+tagged at write time.
+
+### Decision 2 (2026-07-27): exit paths restated against the code taxonomy
+
+The original "Exit paths to validate" list did not map onto the code's `ExitReason`
+values. It is superseded by the following. **Agent-managed** (what the ≥5 threshold and
+the replay requirement apply to):
+
+| path | live executions | deterministic replay | ready? |
+|---|---:|---|---|
+| `partial_tp` | 20 ✅ | dedicated parity test ✅ | **yes** |
+| `trailing_stop` | 13 ✅ | only incidental, inside the partial_tp scenario ⚠️ | no — needs its own scenario |
+| `time_stop` | 0 ❌ | none ❌ | no |
+| `stale_exit` | 0 ❌ | none ❌ | no |
+| `weekend_flatten` | 0 ❌ | none — `flatten_all` is mocked, never replayed ❌ | no |
+
+**Broker-side paths** (not agent-managed; the threshold does not apply): broker SL
+handling, broker TP handling, reconciliation after fill. Reconciliation emits these with
+a `"(broker)"` suffix, which is what keeps them out of the agent-managed counts.
+
+**Dropped:** "break-even move" — not a distinct exit reason in the code.
+
+**Replay coverage is thinner than assumed.** `tests/test_backtest_paper_tracker_parity.py`
+contains a single test (`test_backtest_and_paper_tracker_agree_on_partial_tp_bar_exit_count`).
+That file exists because of the 2026-04-08 shelving, caused by silent drift between two
+re-implementations of exit logic — so the missing scenarios are guarding against a failure
+mode that has already happened once. Writing parity scenarios for `trailing_stop`,
+`time_stop`, `stale_exit`, and `weekend_flatten` is outstanding work in
+`ctrader-trading-agent`.
+
+Implementation and remaining work belong in `ctrader-trading-agent` per the ownership rule
+above; this entry records the measurement and the two decisions.

--- a/docs/evidence_portfolio/CTRADER_EXTERNAL_GATE.md
+++ b/docs/evidence_portfolio/CTRADER_EXTERNAL_GATE.md
@@ -60,3 +60,51 @@ repository. Do not implement, validate, or close those tasks in `crypto-agent`.
 This file is only a boundary note so `crypto-agent` agents do not mistake the
 cTrader gate for local work. The canonical checklist and evidence must live in
 `ctrader-trading-agent`.
+
+---
+
+## Update 2026-07-27 — the "unexercised" premise is stale
+
+Exit-path telemetry was built in `ctrader-trading-agent`
+(PR #48, `feat/exit-path-gate-telemetry`): exits are now tagged at write time with
+`execution` (live/paper) and `agent_initiated`, aggregated by
+`PaperPnLLog.get_exit_path_stats()`, and reported by
+`scripts/exit_path_gate_report.py`. Until this existed the gate was **unmeasurable**
+without hand-grepping the P&L journal — nothing aggregated exit reasons.
+
+Run against a read-only copy of the production journal (146 exits):
+
+| path | live (tagged) | inferred live | paper | status |
+|---|---:|---:|---:|---|
+| partial_tp | 0 | **20** | 26 | SHORT |
+| trailing_stop | 0 | **13** | 25 | SHORT |
+| time_stop | 0 | 0 | 3 | UNEXERCISED |
+| stale_exit | 0 | 0 | 7 | UNEXERCISED |
+| weekend_flatten | 0 | 0 | 1 | UNEXERCISED |
+
+**This contradicts the boundary note above**, which records that every live close has
+been a broker bracket fill caught by the reconciler and that agent-initiated paths are
+unexercised. The journal shows 20 partial-TP and 13 trailing-stop live closes dated
+**2026-06-09 → 2026-07-27**. Verified, not assumed:
+
+- `apply_live_fill` — the only writer of `filled_exit_price` — is called at exactly two
+  sites, both agent-initiated live paths (`cli.py:1815`, `cli.py:1956`).
+- Reconciliation **suffixes** its reasons `"(broker)"`, so a bare `partial_tp` /
+  `trailing_stop` cannot originate there.
+- Rows carry real commissions, and `exit_price` ≠ `filled_exit_price` (modeled trigger
+  vs actual fill).
+
+**Open human decision (not made by tooling):** whether those 33 retroactively-identified
+executions count as gate evidence, or whether the ≥5 threshold must be met with
+write-time-tagged rows from here on. Two paths clear the threshold on the inferred
+evidence; `time_stop`, `stale_exit`, and `weekend_flatten` remain genuinely unexercised
+live either way. Going forward the ambiguity is gone — every new exit is tagged.
+
+**Taxonomy mismatch to resolve:** the "Exit paths to validate" list above does not map
+1:1 onto the code's `ExitReason` values. `time_stop` and `stale_exit` are real exit
+reasons absent from the list; "break-even move" is not a distinct exit reason; and
+"broker SL/TP handling" / "reconciliation after fill" are broker-side paths, not
+agent-managed ones. The gate should be restated against the actual taxonomy.
+
+Deciding and restating both points belongs in `ctrader-trading-agent` per the ownership
+rule above; this entry only records the measurement.

--- a/docs/evidence_portfolio/CTRADER_EXTERNAL_GATE.md
+++ b/docs/evidence_portfolio/CTRADER_EXTERNAL_GATE.md
@@ -100,9 +100,9 @@ The 33 retroactively-identified executions **count toward the ≥5 execution thr
 Each path must **still pass deterministic replay** before it is production-ready —
 execution count alone does not make a path ready.
 
-Reported by `scripts/exit_path_gate_report.py --accept-inferred` (opt-in, so the strict
-reading remains the default view). Going forward the ambiguity is gone: every new exit is
-tagged at write time.
+Going forward the ambiguity is gone: every new exit is tagged at write time. (The
+`--accept-inferred` flag this originally added was removed on 07-28 — once paper
+executions count, inferred rows are included either way.)
 
 ### Decision 2 (2026-07-27): exit paths restated against the code taxonomy
 
@@ -128,9 +128,63 @@ a `"(broker)"` suffix, which is what keeps them out of the agent-managed counts.
 contains a single test (`test_backtest_and_paper_tracker_agree_on_partial_tp_bar_exit_count`).
 That file exists because of the 2026-04-08 shelving, caused by silent drift between two
 re-implementations of exit logic — so the missing scenarios are guarding against a failure
-mode that has already happened once. Writing parity scenarios for `trailing_stop`,
-`time_stop`, `stale_exit`, and `weekend_flatten` is outstanding work in
-`ctrader-trading-agent`.
+mode that has already happened once. *(Resolved 07-28: scenarios added for all four
+uncovered paths.)*
+
+---
+
+## Update 2026-07-28 — why the paths were unexercised, and the gate restated
+
+The 07-27 table above is **superseded**. Diagnosing *why* three paths read UNEXERCISED
+found that the gate, as written and as first implemented, **could not be satisfied by
+waiting** — two paths are effectively unreachable in live:
+
+- **Max live `bars_held` is 9** across 64 live exits, while `time_stop_hours` and
+  `stale_exit_bars` both default to **10**. No live position has ever survived long enough
+  for either branch to be evaluated; live positions close at 2–4 bars in practice.
+- **`broker_managed_protection` landed 2026-07-14** (`571f7dc`) and disables the agent's
+  own TP/SL/trailing checks in live. Live bare `trailing_stop` exits run 2026-06-09 →
+  **2026-07-14 and stop dead**; they now arrive via reconciliation as
+  `"trailing_stop (broker)"`. Live `partial_tp` continues through 2026-07-27.
+
+### Decision 3 (2026-07-28): paper and demo executions count
+
+Per this file's own Important rule — *"Demo, paper, or micro-live testing can satisfy the
+exit-path validation gate in parallel"* — the ≥5 threshold counts executions in **live or
+paper**. The initial live-only implementation contradicted that rule.
+
+### Decision 4 (2026-07-28): `trailing_stop` reclassified as broker-side
+
+It joins `tp`/`sl` as broker-managed, because that is what the code does since 07-14. Its
+13 pre-07-14 agent-initiated live executions stand in the record as history; the current
+architecture cannot produce more.
+
+### Current state
+
+| path | executions (live + paper) | deterministic replay | ready? |
+|---|---:|---|---|
+| `partial_tp` | **46** (20 + 26) ✅ | dedicated parity test ✅ | **yes** |
+| `stale_exit` | **7** (0 + 7) ✅ | single-engine ✅ | **yes** |
+| `time_stop` | 3 (0 + 3) ❌ | single-engine ✅ | needs 2 more |
+| `weekend_flatten` | 1 (0 + 1) ❌ | single-engine ✅ | needs 4 more |
+| ~~`trailing_stop`~~ | — | parity test ✅ | reclassified broker-side |
+
+Two replay caveats: `stale_exit`'s backtest branch lives in the walk-forward loop rather
+than `_advance_position`, so it cannot be driven cross-engine; and `weekend_flatten` has
+**no** cross-engine parity available at all, since `backtest.py` models no weekend or
+session calendar. For those, deterministic replay means deterministic unit behaviour.
+
+### Open items
+
+- **Ordering divergence, undecided.** When a losing position hits both thresholds on one
+  bar, the tracker reports `time_stop` (section D before E) and the backtest reports
+  `stale_exit` (~504 before ~530). Reachable at stock settings — both thresholds default
+  to 10. P&L is identical, the recorded reason is not, which splits exit-path attribution
+  between the engines. Pinned by `TestTimeStopStaleExitOrdering`; picking a winner is a
+  behaviour decision.
+- **Deploy after merge.** Provenance tagging only applies to exits written by deployed
+  code.
+- Remaining accrual: 2 × `time_stop`, 4 × `weekend_flatten`, both of which accrue in paper.
 
 Implementation and remaining work belong in `ctrader-trading-agent` per the ownership rule
-above; this entry records the measurement and the two decisions.
+above; this entry records the measurements and decisions.

--- a/docs/reports/edge-candidates-2026-07-27.md
+++ b/docs/reports/edge-candidates-2026-07-27.md
@@ -139,10 +139,28 @@ These are the whole reason this needs a memo and not a trade:
 It does not decay like a prediction edge. You are being paid a risk premium to warehouse
 a real risk — which is durable as long as you are honestly priced for that risk.
 
-### Verdict
-**Write the Gate-0 memo unconditionally** (it costs hours). **Commit capital only if
-excess-over-risk-free is clearly positive after honest haircuts** for depeg and
-unbonding.
+### Verdict — CLOSED same day, no memo written
+Checking staking yield against the banked v1 durability table
+(`docs/specs/funding-carry-neutral-probe-v0.md`, "v1 durability result") answered the
+question without a memo. Staking does **not** rescue forward excess over risk-free:
+
+| Symbol | Fwd excess vs RF (v1) | Cap factor | Generous staking, on capital | **Fwd excess + staking** |
+|---|---:|---:|---:|---:|
+| ETH | −3.69% | 1.43 | 3% ÷ 1.43 = +2.10% | **−1.59%** |
+| SOL | −6.39% | 1.42 | 7% ÷ 1.42 = +4.93% | **−1.46%** |
+| BTC | −3.27% | 1.25 | no staking exists | **−3.27%** |
+
+Even 8% on SOL only reaches −0.76%, against a gate requiring **+1.0%**. Full-period
+numbers do flip positive (ETH +1.45%, SOL +2.72%) — but forward was the decisive cut in
+v1, and forward still fails. Note also that the deepest, most liquid leg (BTC) has no
+staking yield at all, so the variant only exists on the two assets with worse forward
+carry.
+
+**If ever revisited:** treat unbonding-vs-margin-call as a **Gate-0 disqualifier
+sub-gate**, in the style of the Path 2 sub-gates. v1's margin stress found worst 72h
+adverse up-moves of 23–43%; the short leg needs cash on that timescale while a staked
+spot leg sits in an unstaking queue for days. That mismatch can kill the lane on its own,
+independent of any yield arithmetic.
 
 ---
 
@@ -273,7 +291,7 @@ not less.
 |---|------|-------|--------------|-------|---------|--------|
 | 1 | NFP forward capture | Measured | ~0 — **deadline 2026-08-06** | **YES (passed OOS)** | Low but real | **Build now** |
 | 2 | Conditional-CPI analog | Unpriced | Days, $0 | Moderate | Low-mid | Defer behind #1 |
-| 3 | Staking carry | Unpriced | Hours (memo) | Moderate | Mid, capped | Write memo |
+| 3 | Staking carry | Unpriced | &mdash; | **CLOSED 07-27** | &mdash; | Forward excess still negative |
 | 4 | Access / size-is-edge | Structural | ~0 (built) | Real but episodic | Mid, lumpy | Keep watching |
 | 5 | Scale cTrader FX | Measured | Capital only | **Proven live** | Mid-high | Close exit-path gate, then scale |
 | 6 | Maker-rebate MM | Structural | High (a business) | Only durable trading prior | High | Deliberate decision only |


### PR DESCRIPTION
Docs-only. Two unrelated records that both came out of the same session.

## 1. `CTRADER_EXTERNAL_GATE.md` — the "unexercised" premise is stale

Exit-path telemetry now exists in `ctrader-trading-agent` ([PR #48](https://github.com/Trujillofa/ctrader-trading-agent/pull/48)). Until it did, the gate was **unmeasurable** without hand-grepping the P&L journal — nothing aggregated exit reasons.

Run against a read-only copy of the production journal (146 exits), it contradicts what this file records:

| path | live (tagged) | inferred live | paper | status |
|---|---:|---:|---:|---|
| partial_tp | 0 | **20** | 26 | SHORT |
| trailing_stop | 0 | **13** | 25 | SHORT |
| time_stop | 0 | 0 | 3 | UNEXERCISED |
| stale_exit | 0 | 0 | 7 | UNEXERCISED |
| weekend_flatten | 0 | 0 | 1 | UNEXERCISED |

The file says every live close has been a broker bracket fill caught by the reconciler. The journal shows 20 partial-TP and 13 trailing-stop live closes dated **2026-06-09 → 2026-07-27**. Verified via `apply_live_fill`'s two call sites (both agent-initiated live paths) and the `"(broker)"` suffix reconciliation puts on its reasons.

**Two open items recorded, neither decided here** — both owned by `ctrader-trading-agent` per this file's own boundary rule:
- whether the 33 retroactively-identified executions count as gate evidence, or the ≥5 threshold must be met with write-time-tagged rows
- a taxonomy mismatch: the "Exit paths to validate" list omits `time_stop`/`stale_exit`, includes "break-even move" which is not a distinct exit reason, and lists broker-side paths alongside agent-managed ones

## 2. Edge candidate #3 (staking carry) — closed, no memo written

Checking staking yield against the banked v1 durability table answered it without the memo:

| Symbol | Fwd excess vs RF | Cap factor | Generous staking, on capital | Fwd excess + staking |
|---|---:|---:|---:|---:|
| ETH | −3.69% | 1.43 | +2.10% | **−1.59%** |
| SOL | −6.39% | 1.42 | +4.93% | **−1.46%** |
| BTC | −3.27% | 1.25 | none exists | **−3.27%** |

Even 8% on SOL reaches only −0.76% against a +1.0% gate. Full-period flips positive, but forward was the decisive cut in v1. Unbonding-vs-margin-call is recorded as a Gate-0 disqualifier sub-gate if it is ever revisited — v1's margin stress found worst 72h adverse moves of 23–43%, which the short leg must fund while a staked spot leg sits in an unstaking queue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)