### PR TITLE
feat: arm Sep-4 NFP pre, refresh Day-30, label DeepSeek fallback

### DIFF
--- a/docs/evidence_portfolio/DAY30_REVIEW.md
+++ b/docs/evidence_portfolio/DAY30_REVIEW.md
@@ -1,11 +1,11 @@
 # Day-30 Portfolio Review — 2026-08-06 (template, pre-drafted 2026-07-21)
 
-**Status:** DRAFT until ratified on or about 2026-08-06
+**Status:** DRAFT — NFP row refreshed 2026-08-13; awaiting human ratification
 **Purpose:** close the 30-day evidence portfolio (2026-07-07 → ~2026-08-06) with a
 15-minute ratification. All track verdicts are already determinate; blanks below are
 for anything that changes between drafting and review day.
 
-## Track outcomes (as of drafting, 2026-07-21)
+## Track outcomes (refreshed 2026-08-13; originally drafted 2026-07-21)
 
 | Track | Verdict | Evidence |
 |-------|---------|----------|
@@ -13,7 +13,7 @@ for anything that changes between drafting and review day.
 | Edge probe #2 (fee-marginal) | **DELETED_NOT_NAMED** (2026-07-09) | `FEE_MARGINAL_PREREG.md` — no eligible family; budget slot consumed, not replaced |
 | A1 incentive farming | **CLOSED, no Scale** (2026-07-14) | `A1_THRESHOLD_LOCK.md` — Legion = weekly watch only; galxe → controls; tick timer disabled |
 | cTrader FX (external) | _[fill at review: challenge status vs `CTRADER_EXTERNAL_GATE.md`]_ | external repo |
-| NFP forward gate | **SIGNED, in force** (2026-07-21) | `NFP_FORWARD_GATE.md`, PR #155 — first clean print 2026-08-07 |
+| NFP forward gate | **SIGNED, in force** (2026-07-21) | `NFP_FORWARD_GATE.md`, PR #155 — first print 2026-08-07 = `MISSED_CAPTURE` (1/3); booked in `data/macro_events/nfp_good_news_forward.csv` (commit `6860d13`). Next print 2026-09-04. |
 
 ## Kill-gate check
 

--- a/docs/specs/nfp-forward-capture-routine.md
+++ b/docs/specs/nfp-forward-capture-routine.md
@@ -25,13 +25,18 @@
 ## Suggested implementation (small)
 
 - `scripts/nfp_forward_capture.py` with two subcommands:
-  - `pre` — POST/GET `https://web.archive.org/save/https://www.investing.com/economic-calendar/nonfarm-payrolls-227`,
-    verify the snapshot resolves and its "Latest Release" date is the *previous*
-    release (i.e., the page predates the upcoming print), print the snapshot URL, and
-    stash it in `research/nfp_forward/pending_capture.json`.
+  - `pre` — GET `https://web.archive.org/save/...` with bounded retries (transient
+    network failures such as `ECONNRESET`), verify the snapshot resolves and its
+    "Latest Release" date is the *previous* release (i.e., the page predates the
+    upcoming print), print the snapshot URL, and stash it in
+    `research/nfp_forward/pending_capture.json`. If Save Page Now still fails,
+    capture a PIT mirror manually and pass `--snapshot-url <url>` (Wayback or
+    archive.ph); verification still runs.
   - `post --actual <n> --consensus <n>` — validate against the pending snapshot,
     compute surprise/z (full float precision — the OOS loader rejects rounded z),
     append the CSV row, clear the pending file.
+- Per-print checklist + portable runner under `research/nfp_forward/`
+  (`CHECKLIST_YYYY-MM-DD.md`, `run_pre_YYYY-MM-DD.sh`).
 - Reuse the validation logic pattern from
   `scripts/probe_nfp_good_news_oos.py::load_surprises` for self-checks.
 - No cron/systemd automation of the *decision*; scheduling the `pre` call before each

--- a/research/nfp_forward/CHECKLIST_2026-09-04.md
+++ b/research/nfp_forward/CHECKLIST_2026-09-04.md
@@ -1,0 +1,56 @@
+# NFP forward capture — 2026-09-04
+
+**Gate:** `docs/evidence_portfolio/NFP_FORWARD_GATE.md`
+**Tool:** `scripts/nfp_forward_capture.py`
+**Prior:** 2026-08-07 booked as `NFP_MISSED_CAPTURE` (1 of 3) after Wayback SPN
+`Connection reset by peer`. Capture tool now retries SPN and accepts `--snapshot-url`.
+
+## Verify before the window (human)
+
+- [ ] BLS Employment Situation schedule confirms **Friday, September 4, 2026, 08:30 ET**
+  (12:30 UTC): https://www.bls.gov/schedule/news_release/empsit.htm
+- [ ] Investing.com NFP page lists **Sep 04, 2026** (or equivalent).
+- [ ] Smoke-test Wayback Save Page Now *before* the window (or have archive.ph /
+  manual SPN ready for `--snapshot-url`).
+- Capture window: **2026-09-03T12:30:00Z → 2026-09-04T12:30:00Z**.
+
+## Automated pre
+
+- Runner: `research/nfp_forward/run_pre_2026-09-04.sh`
+- Target fire: **2026-09-03 12:32 UTC** (2 min after window open)
+- Log: `research/nfp_forward/pre-2026-09-04.log`
+- Pending stash (after success): `research/nfp_forward/pending_capture.json`
+
+If SPN still fails after retries, capture a PIT mirror manually (Wayback UI or
+archive.ph), then:
+
+```bash
+uv run python scripts/nfp_forward_capture.py pre \
+  --release-date 2026-09-04 \
+  --snapshot-url '<frozen-url>'
+```
+
+## Human after release (2026-09-04 ~12:30 UTC+)
+
+1. Open the snapshot URL from pending JSON.
+2. Read **consensus** (forecast) from that frozen page.
+3. Read **actual** headline NFP change (thousands) from BLS Employment Situation.
+4. Run:
+
+```bash
+uv run python scripts/nfp_forward_capture.py post \
+  --actual <n> \
+  --consensus <n>
+```
+
+5. Commit the new row in `data/macro_events/nfp_good_news_forward.csv` when ready.
+
+## If pre fails / missed
+
+```bash
+uv run python scripts/nfp_forward_capture.py miss \
+  --release-date 2026-09-04 \
+  --note 'reason'
+```
+
+Three misses cap the sample — do not use miss lightly. Current budget used: **1/3**.

--- a/research/nfp_forward/run_pre_2026-09-04.sh
+++ b/research/nfp_forward/run_pre_2026-09-04.sh
@@ -1,17 +1,16 @@
 #!/usr/bin/env bash
-# Gate-compliant NFP pre-capture for 2026-08-07 print.
-# Only valid inside 2026-08-06 12:30 UTC → 2026-08-07 12:30 UTC.
-# Window is closed; kept as the failure artifact + template for later prints.
+# Gate-compliant NFP pre-capture for 2026-09-04 print.
+# Only valid inside 2026-09-03 12:30 UTC → 2026-09-04 12:30 UTC.
 set -euo pipefail
 REPO="$(cd "$(dirname "$0")/../.." && pwd)"
 LOG_DIR="$REPO/research/nfp_forward"
-LOG="$LOG_DIR/pre-2026-08-07.log"
+LOG="$LOG_DIR/pre-2026-09-04.log"
 cd "$REPO"
 {
   echo "=== NFP pre start $(date -u -Iseconds) ==="
   uv run python scripts/nfp_forward_capture.py status
   set +e
-  uv run python scripts/nfp_forward_capture.py pre --release-date 2026-08-07
+  uv run python scripts/nfp_forward_capture.py pre --release-date 2026-09-04
   pre_rc=$?
   set -e
   echo "=== NFP pre exit ${pre_rc} at $(date -u -Iseconds) ==="

--- a/scripts/nfp_forward_capture.py
+++ b/scripts/nfp_forward_capture.py
@@ -27,6 +27,7 @@ import csv
 import json
 import re
 import sys
+import time
 from dataclasses import dataclass
 from datetime import UTC, date, datetime, timedelta
 from pathlib import Path
@@ -75,6 +76,9 @@ DEFAULT_PENDING_JSON = Path("research/nfp_forward/pending_capture.json")
 USER_AGENT = "crypto-agent-nfp-forward-capture/1.0 (research; read-only)"
 SAVE_TIMEOUT_SECONDS = 180.0
 FETCH_TIMEOUT_SECONDS = 60.0
+SAVE_MAX_ATTEMPTS = 3
+# Delays after attempt 1 and 2 (Aug-7 miss was a single ECONNRESET with no retry).
+SAVE_RETRY_DELAYS_SECONDS = (2.0, 5.0)
 
 
 class CaptureError(RuntimeError):
@@ -201,6 +205,32 @@ def _http_get(url: str, timeout: float) -> httpx.Response:
         return client.get(url)
 
 
+def _http_get_with_retries(
+    url: str,
+    timeout: float,
+    *,
+    attempts: int = SAVE_MAX_ATTEMPTS,
+    label: str = "request",
+) -> httpx.Response:
+    """GET with bounded retries for transient network failures (e.g. ECONNRESET)."""
+    last_exc: httpx.HTTPError | None = None
+    for attempt in range(attempts):
+        try:
+            return _http_get(url, timeout)
+        except httpx.HTTPError as exc:
+            last_exc = exc
+            if attempt >= attempts - 1:
+                break
+            delay = SAVE_RETRY_DELAYS_SECONDS[min(attempt, len(SAVE_RETRY_DELAYS_SECONDS) - 1)]
+            print(
+                f"[pre] {label} failed (attempt {attempt + 1}/{attempts}): {exc}; "
+                f"retrying in {delay:.0f}s"
+            )
+            time.sleep(delay)
+    assert last_exc is not None
+    raise last_exc
+
+
 def _snapshot_url_from_response(response: httpx.Response) -> str:
     candidates = [str(response.url)]
     content_location = response.headers.get("content-location")
@@ -221,6 +251,19 @@ def snapshot_timestamp(snapshot_url: str) -> datetime:
     if match is None:
         raise CaptureError(f"cannot read a Wayback timestamp from {snapshot_url!r}")
     return datetime.strptime(match.group(1), "%Y%m%d%H%M%S").replace(tzinfo=UTC)
+
+
+def resolve_snapshot_timestamp(snapshot_url: str, *, captured_at: datetime) -> datetime:
+    """Wayback URLs yield the archive timestamp; other PIT URLs use capture time."""
+    if SNAPSHOT_TS_RE.search(snapshot_url):
+        return snapshot_timestamp(snapshot_url)
+    if not snapshot_url.startswith(("http://", "https://")):
+        raise CaptureError(f"snapshot URL must be http(s): {snapshot_url!r}")
+    print(
+        "[pre] snapshot URL is not a Wayback /web/<ts>/ URL; "
+        f"using capture time {captured_at.strftime('%Y-%m-%dT%H:%M:%SZ')} as snapshot timestamp"
+    )
+    return captured_at.astimezone(UTC)
 
 
 def read_pending(path: Path) -> PendingCapture | None:
@@ -336,21 +379,40 @@ def cmd_pre(args: argparse.Namespace) -> int:
             "run `post` (or `miss`) first, or pass --force to replace it"
         )
 
-    print(f"[pre] requesting Wayback Save Page Now for {CONSENSUS_URL}")
-    response = _http_get(WAYBACK_SAVE_URL, SAVE_TIMEOUT_SECONDS)
-    snapshot_url = _snapshot_url_from_response(response)
-    snapshot_ts = snapshot_timestamp(snapshot_url)
-    print(f"[pre] snapshot: {snapshot_url}")
+    body = ""
+    if args.snapshot_url:
+        snapshot_url = str(args.snapshot_url).strip()
+        print("[pre] using manual --snapshot-url (skipped Wayback Save Page Now)")
+        print(f"[pre] snapshot: {snapshot_url}")
+        snapshot_ts = resolve_snapshot_timestamp(snapshot_url, captured_at=now)
+        body = _http_get_with_retries(
+            snapshot_url,
+            FETCH_TIMEOUT_SECONDS,
+            label="snapshot fetch",
+        ).text
+    else:
+        print(f"[pre] requesting Wayback Save Page Now for {CONSENSUS_URL}")
+        response = _http_get_with_retries(
+            WAYBACK_SAVE_URL,
+            SAVE_TIMEOUT_SECONDS,
+            label="Wayback Save Page Now",
+        )
+        snapshot_url = _snapshot_url_from_response(response)
+        snapshot_ts = resolve_snapshot_timestamp(snapshot_url, captured_at=now)
+        print(f"[pre] snapshot: {snapshot_url}")
+        body = response.text
+        if not body.strip():
+            body = _http_get_with_retries(
+                snapshot_url,
+                FETCH_TIMEOUT_SECONDS,
+                label="snapshot fetch",
+            ).text
 
     if snapshot_ts >= release_ts:
         raise CaptureError(
             f"snapshot timestamp {snapshot_ts.isoformat()} is not before the release "
             f"{release_ts.isoformat()}"
         )
-
-    body = response.text
-    if not body.strip():
-        body = _http_get(snapshot_url, FETCH_TIMEOUT_SECONDS).text
 
     verified, detail = verify_snapshot_is_point_in_time(body, release_date)
     if verified:
@@ -484,6 +546,13 @@ def build_parser() -> argparse.ArgumentParser:
 
     pre = subparsers.add_parser("pre", help="freeze the pre-release consensus via Wayback")
     pre.add_argument("--release-date", help="ISO release date; defaults to the next first Friday")
+    pre.add_argument(
+        "--snapshot-url",
+        help=(
+            "skip Save Page Now and stash this already-captured PIT URL "
+            "(Wayback or archive.ph / manual mirror); still verifies the page"
+        ),
+    )
     pre.add_argument(
         "--allow-unverified", action="store_true", help="stash despite a failed page check"
     )

--- a/src/main.py
+++ b/src/main.py
@@ -831,9 +831,16 @@ def _wire_optional_strategy_dependencies(
     async def _record_sentiment_observation(payload: dict[str, object]) -> None:
         if event_log is None:
             return
+        source = str(payload.get("source", ""))
+        if source == "deepseek_fallback":
+            provider = "deepseek"
+        elif source.startswith("xai") or source == "neutral_fallback":
+            provider = "xai" if xai_client is not None else "none"
+        else:
+            provider = "xai" if xai_client is not None else "none"
         enriched_payload = {
             **payload,
-            "provider": "xai" if xai_client is not None else "none",
+            "provider": provider,
             "model": ai_model,
         }
         await event_log.log("sentiment_score", enriched_payload)

--- a/src/overseer/__init__.py
+++ b/src/overseer/__init__.py
@@ -1,4 +1,4 @@
 from src.overseer.agent import OverseerAgent
-from src.overseer.xai import XAIClient
+from src.overseer.xai import ChatResult, XAIClient
 
-__all__ = ["OverseerAgent", "XAIClient"]
+__all__ = ["ChatResult", "OverseerAgent", "XAIClient"]

--- a/src/overseer/agent.py
+++ b/src/overseer/agent.py
@@ -272,11 +272,12 @@ class OverseerAgent:
         ]
 
         try:
-            answer = await self._xai_client.chat(messages)
+            result = await self._xai_client.chat(messages)
         except Exception as exc:
             self._logger.error("xAI request failed: %s", exc)
             return "AI request failed. Try again in a few seconds."
 
+        answer = result.content if hasattr(result, "content") else str(result)
         self._append_history(chat_id, "user", query)
         self._append_history(chat_id, "assistant", answer)
         return answer

--- a/src/overseer/xai.py
+++ b/src/overseer/xai.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Sequence
+from dataclasses import dataclass
 
 import openai
 from openai import AsyncOpenAI
@@ -14,7 +15,19 @@ _RETRYABLE_ERRORS = (
     openai.APIConnectionError,
     openai.APITimeoutError,
 )
+_AUTH_ERRORS = (
+    openai.AuthenticationError,
+    openai.PermissionDeniedError,
+)
 _MAX_ATTEMPTS = 3
+
+
+@dataclass(frozen=True)
+class ChatResult:
+    """LLM reply plus which provider actually answered."""
+
+    content: str
+    provider: str  # "xai" | "deepseek"
 
 
 class XAIClient:
@@ -45,24 +58,34 @@ class XAIClient:
             )
         self._logger = get_logger(self.__class__.__name__)
 
-    async def chat(self, messages: Sequence[dict[str, str]]) -> str:
+    async def chat(self, messages: Sequence[dict[str, str]]) -> ChatResult:
         try:
-            return await self._chat_with_client(
+            content = await self._chat_with_client(
                 self._client,
                 self._model,
                 messages,
                 provider_name="xAI",
             )
+            return ChatResult(content=content, provider="xai")
+        except _AUTH_ERRORS as exc:
+            if self._fallback_client is None:
+                raise
+            self._logger.warning(
+                "xAI auth/permission denied (%s); trying DeepSeek fallback",
+                exc,
+            )
         except Exception:
             if self._fallback_client is None:
                 raise
             self._logger.warning("xAI unavailable after retries; trying DeepSeek fallback")
-            return await self._chat_with_client(
-                self._fallback_client,
-                self._fallback_model,
-                messages,
-                provider_name="DeepSeek",
-            )
+
+        content = await self._chat_with_client(
+            self._fallback_client,
+            self._fallback_model,
+            messages,
+            provider_name="DeepSeek",
+        )
+        return ChatResult(content=content, provider="deepseek")
 
     async def _chat_with_client(
         self,

--- a/src/strategy/sentiment_mean_reversion.py
+++ b/src/strategy/sentiment_mean_reversion.py
@@ -79,9 +79,10 @@ class SentimentScorer:
             return score
 
         try:
-            score = await self._query_llm(symbol)
+            score, provider = await self._query_llm(symbol)
             self._cache[symbol] = (now, score)
-            await self._record_observation(symbol, score, source="xai_live")
+            source = "deepseek_fallback" if provider == "deepseek" else "xai_live"
+            await self._record_observation(symbol, score, source=source)
             return score
         except Exception as exc:
             self._logger.warning("Sentiment query failed for %s: %s", symbol, exc)
@@ -159,8 +160,12 @@ class SentimentScorer:
         except Exception as exc:  # noqa: BLE001
             self._logger.warning("Degradation alert failed: %s", exc)
 
-    async def _query_llm(self, symbol: str) -> float:
-        """Query xAI/Grok for sentiment analysis."""
+    async def _query_llm(self, symbol: str) -> tuple[float, str]:
+        """Query the configured LLM for sentiment analysis.
+
+        Returns ``(score, provider)`` where provider is ``xai`` or ``deepseek``.
+        Test doubles that return a bare string are treated as ``xai``.
+        """
         base_asset = symbol.replace("USDT", "").replace("BUSD", "")
         prompt = (
             f"Analyze the current market sentiment for {base_asset} ({symbol}) cryptocurrency. "
@@ -176,15 +181,21 @@ class SentimentScorer:
             {"role": "user", "content": prompt},
         ]
 
-        response = await self._xai_client.chat(messages)  # type: ignore[union-attr]
+        result = await self._xai_client.chat(messages)  # type: ignore[union-attr]
+        if hasattr(result, "content") and hasattr(result, "provider"):
+            response = str(result.content)
+            provider = str(result.provider)
+        else:
+            response = str(result)
+            provider = "xai"
 
         try:
             data = json.loads(response)
             score = float(data.get("score", 50))
-            return max(0.0, min(100.0, score))
+            return max(0.0, min(100.0, score)), provider
         except (json.JSONDecodeError, ValueError, TypeError):
             self._logger.warning("Could not parse sentiment response: %s", response[:200])
-            return 50.0
+            return 50.0, provider
 
 
 class SentimentMeanReversionStrategy(BaseStrategy):

--- a/tests/test_nfp_forward_capture.py
+++ b/tests/test_nfp_forward_capture.py
@@ -9,6 +9,7 @@ import csv
 from datetime import UTC, date, datetime
 from pathlib import Path
 
+import httpx
 import pytest
 
 from scripts.nfp_forward_capture import (
@@ -25,6 +26,7 @@ from scripts.nfp_forward_capture import (
     page_mentions_date,
     previous_scheduled_release,
     release_timestamp_utc,
+    resolve_snapshot_timestamp,
     snapshot_timestamp,
     verify_snapshot_is_point_in_time,
 )
@@ -93,6 +95,58 @@ def test_snapshot_timestamp_parsed_from_wayback_url():
 def test_snapshot_timestamp_rejects_non_wayback_url():
     with pytest.raises(CaptureError):
         snapshot_timestamp("https://www.investing.com/economic-calendar/nonfarm-payrolls-227")
+
+
+def test_resolve_snapshot_timestamp_uses_wayback_ts_when_present():
+    url = "https://web.archive.org/web/20260903124500/https://www.investing.com/x"
+    captured = datetime(2026, 9, 3, 12, 50, tzinfo=UTC)
+    assert resolve_snapshot_timestamp(url, captured_at=captured) == datetime(
+        2026, 9, 3, 12, 45, tzinfo=UTC
+    )
+
+
+def test_resolve_snapshot_timestamp_falls_back_to_capture_time_for_manual_mirrors(
+    capsys: pytest.CaptureFixture[str],
+):
+    url = "https://archive.ph/abcd1234"
+    captured = datetime(2026, 9, 3, 13, 0, tzinfo=UTC)
+    assert resolve_snapshot_timestamp(url, captured_at=captured) == captured
+    assert "not a Wayback" in capsys.readouterr().out
+
+
+def test_http_get_with_retries_retries_then_succeeds(monkeypatch: pytest.MonkeyPatch):
+    from scripts import nfp_forward_capture as mod
+
+    calls = {"n": 0}
+
+    def flaky(_url: str, _timeout: float):
+        calls["n"] += 1
+        if calls["n"] < 3:
+            raise httpx.ConnectError("Connection reset by peer")
+        return httpx.Response(200, text="ok")
+
+    sleeps: list[float] = []
+    monkeypatch.setattr(mod, "_http_get", flaky)
+    monkeypatch.setattr(mod.time, "sleep", sleeps.append)
+
+    response = mod._http_get_with_retries("https://example.test", 1.0, label="Wayback")
+    assert response.text == "ok"
+    assert calls["n"] == 3
+    assert sleeps == [2.0, 5.0]
+
+
+def test_http_get_with_retries_raises_after_exhaustion(monkeypatch: pytest.MonkeyPatch):
+    from scripts import nfp_forward_capture as mod
+
+    monkeypatch.setattr(
+        mod,
+        "_http_get",
+        lambda _url, _timeout: (_ for _ in ()).throw(httpx.ConnectError("boom")),
+    )
+    monkeypatch.setattr(mod.time, "sleep", lambda _delay: None)
+
+    with pytest.raises(httpx.ConnectError, match="boom"):
+        mod._http_get_with_retries("https://example.test", 1.0, attempts=2)
 
 
 def test_build_row_keeps_full_float_precision():

--- a/tests/test_sentiment_mean_reversion.py
+++ b/tests/test_sentiment_mean_reversion.py
@@ -300,6 +300,39 @@ class TestSentimentScorer:
             }
         ]
 
+    @pytest.mark.asyncio
+    async def test_records_deepseek_fallback_when_provider_is_deepseek(self):
+        """DeepSeek answers must not be mislabeled as xai_live."""
+        from src.overseer.xai import ChatResult
+
+        class FallbackClient:
+            async def chat(self, messages):
+                return ChatResult(
+                    content='{"score": 55, "reason": "deepseek path"}',
+                    provider="deepseek",
+                )
+
+        observations: list[dict[str, object]] = []
+
+        async def recorder(payload: dict[str, object]) -> None:
+            observations.append(payload)
+
+        scorer = SentimentScorer(
+            xai_client=FallbackClient(),
+            observation_recorder=recorder,
+        )
+
+        score = await scorer.get_score("SOLUSDT")
+
+        assert score == 55.0
+        assert observations == [
+            {
+                "symbol": "SOLUSDT",
+                "score": 55.0,
+                "source": "deepseek_fallback",
+            }
+        ]
+
 
 class TestDegradationAlert:
     @pytest.mark.asyncio

--- a/tests/test_xai_client.py
+++ b/tests/test_xai_client.py
@@ -4,7 +4,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import openai
 import pytest
 
-from src.overseer.xai import XAIClient
+from src.overseer.xai import ChatResult, XAIClient
 
 
 def _make_completion(content: str) -> SimpleNamespace:
@@ -13,6 +13,13 @@ def _make_completion(content: str) -> SimpleNamespace:
 
 def _make_connection_error() -> openai.APIConnectionError:
     return openai.APIConnectionError(request=MagicMock())
+
+
+def _make_permission_denied() -> openai.PermissionDeniedError:
+    mock_response = MagicMock()
+    mock_response.status_code = 403
+    mock_response.headers = {}
+    return openai.PermissionDeniedError("forbidden", response=mock_response, body=None)
 
 
 @pytest.mark.asyncio
@@ -35,7 +42,7 @@ async def test_chat_returns_trimmed_content() -> None:
         messages=[{"role": "user", "content": "status?"}],
         temperature=0.2,
     )
-    assert response == "market regime stable"
+    assert response == ChatResult(content="market regime stable", provider="xai")
 
 
 @pytest.mark.asyncio
@@ -48,7 +55,10 @@ async def test_chat_returns_fallback_when_content_missing() -> None:
         client = XAIClient(api_key="test-key", model="grok-3")
         response = await client.chat([{"role": "user", "content": "status?"}])
 
-    assert response == "No response content returned by xAI API."
+    assert response == ChatResult(
+        content="No response content returned by xAI API.",
+        provider="xai",
+    )
 
 
 @pytest.mark.asyncio
@@ -62,7 +72,7 @@ async def test_chat_retries_on_transient_error_then_succeeds() -> None:
             client = XAIClient(api_key="test-key", model="grok-3")
             response = await client.chat([{"role": "user", "content": "ping"}])
 
-    assert response == "recovered"
+    assert response == ChatResult(content="recovered", provider="xai")
     assert create.await_count == 2
     mock_sleep.assert_awaited_once_with(1)  # 2**0 = 1s after first failure
 
@@ -115,7 +125,7 @@ async def test_chat_uses_fallback_provider_after_xai_retries_exhausted() -> None
             )
             response = await client.chat([{"role": "user", "content": "ping"}])
 
-    assert response == "fallback-ok"
+    assert response == ChatResult(content="fallback-ok", provider="deepseek")
     assert primary_create.await_count == 3
     fallback_create.assert_awaited_once()
     assert mock_openai.call_count == 2
@@ -140,4 +150,34 @@ async def test_chat_does_not_retry_on_auth_error() -> None:
                 await client.chat([{"role": "user", "content": "ping"}])
 
     assert create.await_count == 1
+    mock_sleep.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_chat_falls_back_on_permission_denied_without_retry() -> None:
+    """403 PermissionDenied is not retried; DeepSeek fallback is used when configured."""
+    primary_create = AsyncMock(side_effect=_make_permission_denied())
+    primary_client = SimpleNamespace(
+        chat=SimpleNamespace(completions=SimpleNamespace(create=primary_create))
+    )
+    fallback_create = AsyncMock(return_value=_make_completion("deepseek-ok"))
+    fallback_client = SimpleNamespace(
+        chat=SimpleNamespace(completions=SimpleNamespace(create=fallback_create))
+    )
+
+    with patch(
+        "src.overseer.xai.AsyncOpenAI",
+        side_effect=[primary_client, fallback_client],
+    ):
+        with patch("src.overseer.xai.asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+            client = XAIClient(
+                api_key="xai-key",
+                model="grok-3",
+                fallback_api_key="deepseek-key",
+            )
+            response = await client.chat([{"role": "user", "content": "ping"}])
+
+    assert response == ChatResult(content="deepseek-ok", provider="deepseek")
+    assert primary_create.await_count == 1
+    fallback_create.assert_awaited_once()
     mock_sleep.assert_not_awaited()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements the Aug-12 audit next steps that are in-repo actionable (default C+2):

1. **NFP Sep-4 prep** — portable checklist/runner; Wayback Save Page Now retries after Aug-7 `ECONNRESET`; `--snapshot-url` for manual PIT mirrors (Wayback / archive.ph).
2. **Day-30 refresh** — NFP track row updated for booked `MISSED_CAPTURE` (1/3). `Ratified by:` left blank for human signature.
3. **Sentiment recording honesty** — `XAIClient.chat` returns `ChatResult`; DeepSeek answers record as `deepseek_fallback` (not `xai_live`); 403 logged distinctly. Does **not** rotate `XAI_API_KEY` (ops).

## Type of Change

- [x] New feature
- [x] Bug fix
- [x] Documentation update
- [x] Tests

## Testing

- [x] Tests pass locally: `uv run pytest` — **1257 passed**
- [x] Lint passes: `uv run ruff check` on touched files
- [x] Format check: `uv run ruff format`

## Checklist

- [x] Code follows project style
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [x] Tests added/updated (if needed)

## Notes

- Human still must: verify BLS Sep-4 date, schedule `run_pre_2026-09-04.sh` for 2026-09-03 12:32 UTC, sign Day-30, fix/rotate xAI key on Hetzner if primary feed is required.
- Locked gate docs (`NFP_FORWARD_GATE.md`) untouched.
- No live trading / settings changes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ff82c-b6de-7f97-b4ff-326b2371fbde?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ff82c-b6de-7f97-b4ff-326b2371fbde&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

