### PR TITLE
feat(backtest): in-memory reader so the synthetic-path gate has a producer

### DIFF
--- a/scripts/experiment_autopilot.py
+++ b/scripts/experiment_autopilot.py
@@ -36,6 +36,7 @@ from src.backtest.factory import (
     resolve_global_trend_filter,
 )
 from src.backtest.models import ExecutionProfile
+from src.backtest.synthetic_eval import evaluate_synthetic_pass_rate
 from src.db import close_pool, get_pool, init_pool  # noqa: E402
 from src.features.reader import IndicatorReader  # noqa: E402
 from src.main import _resolve_strategy_config, load_settings  # noqa: E402
@@ -275,6 +276,7 @@ def _render_markdown(
     lines.append(f"| Mean OOS Sharpe | {summary.wfo_mean_sharpe:.2f} |")
     lines.append(f"| Compound OOS return | {summary.wfo_total_return_pct:.2f}% |")
     lines.append(f"| Bootstrap P(loss) | {summary.bootstrap_p_loss_pct:.2f}% |")
+    lines.append(f"| Synthetic pass rate | {summary.synthetic_pass_rate_pct:.2f}% |")
     lines.append(f"| Profit concentration | {summary.profit_concentration_pct:.2f}% |")
     lines.append(f"| Blocked BUY (session router) | {summary.blocked_buy_count} |")
     lines.append(f"| Blocked BUY (basis filter) | {summary.basis_blocked_buy_count} |")
@@ -472,6 +474,8 @@ async def run_experiment_evaluation(
             seed=seed,
         )
 
+        synthetic_rate = await evaluate_synthetic_pass_rate(base_config, seed=seed)
+
         oos_returns = [window.total_return_pct for window in window_results]
         oos_sharpes = [window.sharpe_ratio for window in window_results]
         wfo_total_trades = sum(window.total_trades for window in window_results)
@@ -493,6 +497,7 @@ async def run_experiment_evaluation(
             bootstrap_p_loss_pct=path_metrics["p_loss_pct"],
             mc_drawdown_p95_pct=path_metrics["drawdown_p95_pct"],
             mc_drawdown_p50_pct=path_metrics["drawdown_p50_pct"],
+            synthetic_pass_rate_pct=synthetic_rate,
             profit_concentration_pct=profit_concentration_pct(oos_returns),
             blocked_buy_count=baseline.blocked_buy_count,
             basis_blocked_buy_count=baseline.basis_blocked_buy_count,

--- a/src/backtest/synthetic_eval.py
+++ b/src/backtest/synthetic_eval.py
@@ -1,0 +1,108 @@
+"""Run the real backtest engine over seeded synthetic paths and score pass rate."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import replace
+
+from src.backtest.engine import BacktestEngine
+from src.backtest.experiment_autopilot import compound_returns_pct, max_drawdown_from_returns
+from src.backtest.models import BacktestConfig
+from src.backtest.synthetic import (
+    RegimeParams,
+    generate_regime_path,
+    generate_stress_path,
+    synthetic_pass_rate_pct,
+)
+from src.backtest.synthetic_reader import DEFAULT_WARMUP_BARS, SyntheticIndicatorReader
+from src.ingest.models import Ohlcv
+
+DEFAULT_EVAL_BARS = 240
+DEFAULT_REGIME_PARAMS = RegimeParams(
+    mu_calm=0.0,
+    sigma_calm=0.008,
+    mu_stress=-0.001,
+    sigma_stress=0.025,
+    p_calm_to_stress=0.08,
+    p_stress_to_calm=0.2,
+    p_start_stress=0.15,
+)
+STRESS_SCENARIOS = ("march_2020_gap", "funding_blowout", "flat_wide_spread")
+
+
+def path_passes(
+    trade_returns_pct: Sequence[float],
+    *,
+    max_drawdown_pct: float = 10.0,
+    min_return_pct: float = 0.0,
+) -> bool:
+    """Empty (no-trade) paths fail. Otherwise require return and drawdown floors."""
+    if not trade_returns_pct:
+        return False
+    returns = list(trade_returns_pct)
+    return (
+        compound_returns_pct(returns) >= min_return_pct
+        and max_drawdown_from_returns(returns) <= max_drawdown_pct
+    )
+
+
+def _config_for_window(config: BacktestConfig, start: str, end: str) -> BacktestConfig:
+    return replace(config, start_date=start, end_date=end)
+
+
+async def _run_path(
+    config: BacktestConfig,
+    candles: Sequence[Ohlcv],
+    warmup_bars: int,
+) -> list[float]:
+    reader = SyntheticIndicatorReader(candles, warmup_bars=warmup_bars)
+    cfg = _config_for_window(config, reader.eval_start.isoformat(), reader.eval_end.isoformat())
+    result = await BacktestEngine(cfg, reader).run()
+    return [trade.return_pct for trade in result.trades]
+
+
+async def evaluate_synthetic_pass_rate(
+    config: BacktestConfig,
+    *,
+    n_regime_paths: int = 3,
+    include_stress: bool = True,
+    warmup_bars: int = DEFAULT_WARMUP_BARS,
+    eval_bars: int = DEFAULT_EVAL_BARS,
+    seed: int = 42,
+    start_price: float = 100.0,
+    regime_params: RegimeParams | None = None,
+    max_drawdown_pct: float = 10.0,
+    min_return_pct: float = 0.0,
+) -> float:
+    """Percent of synthetic paths that pass return/drawdown checks. Computes only."""
+    params = regime_params if regime_params is not None else DEFAULT_REGIME_PARAMS
+    n_bars = warmup_bars + eval_bars
+    path_returns: list[list[float]] = []
+
+    for i in range(n_regime_paths):
+        candles, _states = generate_regime_path(
+            params,
+            n_bars=n_bars,
+            start_price=start_price,
+            seed=seed + i,
+        )
+        path_returns.append(await _run_path(config, candles, warmup_bars))
+
+    if include_stress:
+        for j, scenario in enumerate(STRESS_SCENARIOS):
+            candles = generate_stress_path(
+                scenario,
+                n_bars=n_bars,
+                start_price=start_price,
+                seed=seed + 100 + j,
+            )
+            path_returns.append(await _run_path(config, candles, warmup_bars))
+
+    return synthetic_pass_rate_pct(
+        path_returns,
+        lambda returns: path_passes(
+            returns,
+            max_drawdown_pct=max_drawdown_pct,
+            min_return_pct=min_return_pct,
+        ),
+    )

--- a/src/backtest/synthetic_reader.py
+++ b/src/backtest/synthetic_reader.py
@@ -1,0 +1,229 @@
+"""In-memory indicator reader over seeded synthetic OHLCV.
+
+Duck-types the three ``IndicatorReader`` methods the engine calls. Does not
+inherit from ``IndicatorReader`` (that constructor wants DB config). Joins
+reuse ``IndicatorReader._join_timeframes`` so lookahead rules stay identical.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import asdict
+from datetime import UTC, datetime, timedelta
+from typing import cast
+
+from src.features.reader import FundingSettlement, IndicatorReader
+from src.features.technical import OhlcvSeries, TechnicalIndicators, compute_indicators
+from src.ingest.models import Ohlcv
+
+DEFAULT_WARMUP_BARS = 200
+MIN_INDICATOR_BARS = 30
+
+
+def _bar_delta(timeframe: str) -> timedelta:
+    if timeframe == "4h":
+        return timedelta(hours=4)
+    if timeframe == "1d":
+        return timedelta(days=1)
+    return timedelta(hours=1)
+
+
+def _parse_dt(val: str | datetime) -> datetime:
+    if isinstance(val, str):
+        val = datetime.fromisoformat(val)
+    if val.tzinfo is None:
+        return val.replace(tzinfo=UTC)
+    return val
+
+
+def aggregate_ohlcv(candles: Sequence[Ohlcv], target_timeframe: str) -> list[Ohlcv]:
+    """Resample non-overlapping target bars. Drops a trailing incomplete group."""
+    if not candles:
+        return []
+    source_delta = _bar_delta(candles[0].timeframe)
+    target_delta = _bar_delta(target_timeframe)
+    ratio_float = target_delta / source_delta
+    ratio = int(ratio_float)
+    if ratio < 1 or float(ratio) != ratio_float:
+        raise ValueError(f"cannot aggregate {candles[0].timeframe} to {target_timeframe}")
+
+    out: list[Ohlcv] = []
+    n = len(candles)
+    i = 0
+    while i + ratio <= n:
+        group = candles[i : i + ratio]
+        last = group[-1]
+        out.append(
+            Ohlcv(
+                symbol=last.symbol,
+                timeframe=target_timeframe,
+                open_time=group[0].open_time,
+                close_time=last.close_time,
+                open_price=group[0].open_price,
+                high_price=max(candle.high_price for candle in group),
+                low_price=min(candle.low_price for candle in group),
+                close_price=last.close_price,
+                volume=sum(candle.volume for candle in group),
+            )
+        )
+        i += ratio
+    return out
+
+
+def _series(candles: Sequence[Ohlcv]) -> OhlcvSeries:
+    return cast(
+        OhlcvSeries,
+        {
+            "close": [candle.close_price for candle in candles],
+            "high": [candle.high_price for candle in candles],
+            "low": [candle.low_price for candle in candles],
+            "volume": [candle.volume for candle in candles],
+        },
+    )
+
+
+def _row_from(
+    candle: Ohlcv,
+    indicators: TechnicalIndicators,
+    settlement: FundingSettlement | None = None,
+) -> dict[str, object]:
+    payload = asdict(indicators)
+    ema_12 = payload["ema_12"]
+    ema_26 = payload["ema_26"]
+    row: dict[str, object] = {
+        "time": candle.open_time,
+        "open_price": candle.open_price,
+        "close_price": candle.close_price,
+        "high_price": candle.high_price,
+        "low_price": candle.low_price,
+        **payload,
+        "ema_12": 0.0 if ema_12 is None else ema_12,
+        "ema_26": 0.0 if ema_26 is None else ema_26,
+    }
+    if settlement is not None:
+        row["funding_rate"] = settlement.funding_rate
+    return row
+
+
+def candles_to_indicator_rows(candles: Sequence[Ohlcv]) -> list[dict[str, object]]:
+    """One indicator row per candle with at least ``MIN_INDICATOR_BARS`` of history."""
+    rows: list[dict[str, object]] = []
+    for i in range(len(candles)):
+        if i + 1 < MIN_INDICATOR_BARS:
+            continue
+        indicators = compute_indicators(_series(candles[: i + 1]))
+        rows.append(_row_from(candles[i], indicators))
+    return rows
+
+
+def _apply_funding_rates(
+    rows: list[dict[str, object]],
+    funding: Sequence[FundingSettlement],
+) -> None:
+    ordered = sorted(funding, key=lambda item: item.funding_time)
+    idx = 0
+    last: FundingSettlement | None = None
+    for row in rows:
+        bar_time = _parse_dt(row["time"])  # type: ignore[arg-type]
+        while idx < len(ordered) and ordered[idx].funding_time <= bar_time:
+            last = ordered[idx]
+            idx += 1
+        if last is not None:
+            row["funding_rate"] = last.funding_rate
+
+
+class SyntheticIndicatorReader:
+    """Duck-typed ``IndicatorReader`` over a generated OHLCV path."""
+
+    def __init__(
+        self,
+        candles: Sequence[Ohlcv],
+        *,
+        warmup_bars: int = DEFAULT_WARMUP_BARS,
+        regime_candles: Sequence[Ohlcv] | None = None,
+        funding: Sequence[FundingSettlement] | None = None,
+    ) -> None:
+        if warmup_bars < MIN_INDICATOR_BARS:
+            raise ValueError(f"warmup_bars must be >= {MIN_INDICATOR_BARS}, got {warmup_bars}")
+        if len(candles) <= warmup_bars:
+            raise ValueError(
+                f"need more than warmup_bars ({warmup_bars}) candles, got {len(candles)}"
+            )
+
+        self._warmup_bars = warmup_bars
+        self._eval_candles = list(candles[warmup_bars:])
+        self._funding = list(funding) if funding is not None else []
+
+        computed = candles_to_indicator_rows(candles)
+        skip = MIN_INDICATOR_BARS - 1
+        self._rows = computed[warmup_bars - skip :]
+        if self._funding:
+            _apply_funding_rates(self._rows, self._funding)
+
+        if regime_candles is None:
+            regime_candles = aggregate_ohlcv(candles, "4h")
+        # Full regime series: join enforces no-lookahead via close-time.
+        self._regime_rows = candles_to_indicator_rows(regime_candles)
+
+    @property
+    def warmup_bars(self) -> int:
+        return self._warmup_bars
+
+    @property
+    def eval_start(self) -> datetime:
+        return self._eval_candles[0].open_time
+
+    @property
+    def eval_end(self) -> datetime:
+        return self._eval_candles[-1].open_time
+
+    async def fetch_range(
+        self,
+        symbol: str,
+        timeframe: str,
+        start_time: str | datetime,
+        end_time: str | datetime,
+    ) -> list[dict[str, object]]:
+        """Return exposed rows with ``time`` in ``[start, end]`` inclusive. Oldest-first."""
+        del symbol, timeframe
+        start = _parse_dt(start_time)
+        end = _parse_dt(end_time)
+        return [
+            dict(row)
+            for row in self._rows
+            if start <= _parse_dt(row["time"]) <= end  # type: ignore[arg-type]
+        ]
+
+    async def fetch_multi_timeframe(
+        self,
+        *,
+        symbol: str,
+        entry_timeframe: str,
+        regime_timeframe: str,
+        start_time: str | datetime,
+        end_time: str | datetime,
+    ) -> list[dict[str, object]]:
+        start = _parse_dt(start_time)
+        end = _parse_dt(end_time)
+        entry_rows = await self.fetch_range(symbol, entry_timeframe, start, end)
+        regime_start = start - timedelta(hours=24)
+        regime_rows = [
+            dict(row)
+            for row in self._regime_rows
+            if regime_start <= _parse_dt(row["time"]) <= end  # type: ignore[arg-type]
+        ]
+        joined = IndicatorReader._join_timeframes(entry_rows, regime_rows, regime_timeframe)
+        return cast(list[dict[str, object]], joined)
+
+    async def fetch_funding_settlements(
+        self,
+        symbol: str,
+        start_time: str | datetime,
+        end_time: str | datetime,
+    ) -> list[FundingSettlement]:
+        del symbol
+        if not self._funding:
+            return []
+        start = _parse_dt(start_time)
+        end = _parse_dt(end_time)
+        return [item for item in self._funding if start < _parse_dt(item.funding_time) <= end]

--- a/tests/test_synthetic_reader.py
+++ b/tests/test_synthetic_reader.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from src.backtest.models import BacktestConfig
+from src.backtest.synthetic import RegimeParams, generate_regime_path
+from src.backtest.synthetic_eval import evaluate_synthetic_pass_rate, path_passes
+from src.backtest.synthetic_reader import (
+    SyntheticIndicatorReader,
+    aggregate_ohlcv,
+    candles_to_indicator_rows,
+)
+from src.strategy.simple_ma import SimpleMACrossoverStrategy
+
+
+def _regime_params() -> RegimeParams:
+    return RegimeParams(
+        mu_calm=0.0,
+        sigma_calm=0.008,
+        mu_stress=-0.001,
+        sigma_stress=0.025,
+        p_calm_to_stress=0.08,
+        p_stress_to_calm=0.2,
+        p_start_stress=0.15,
+    )
+
+
+def _wide_window() -> tuple[datetime, datetime]:
+    return datetime(1990, 1, 1, tzinfo=UTC), datetime(2100, 1, 1, tzinfo=UTC)
+
+
+async def test_mtf_join_has_no_lookahead() -> None:
+    warmup = 200
+    candles, _states = generate_regime_path(
+        _regime_params(),
+        n_bars=warmup + 48,
+        start_price=100.0,
+        seed=1,
+    )
+    reader = SyntheticIndicatorReader(candles, warmup_bars=warmup)
+    regime_4h = aggregate_ohlcv(candles, "4h")
+    expected_by_open = {row["time"]: row for row in candles_to_indicator_rows(regime_4h)}
+
+    joined = await reader.fetch_multi_timeframe(
+        symbol="SYNTH",
+        entry_timeframe="1h",
+        regime_timeframe="4h",
+        start_time=reader.eval_start,
+        end_time=reader.eval_end,
+    )
+
+    for row in joined:
+        entry_time = row["time"]
+        assert isinstance(entry_time, datetime)
+        completed = [bar for bar in regime_4h if bar.close_time <= entry_time]
+        for key in row:
+            if key.endswith("_4h"):
+                assert completed, f"{key} present at {entry_time} with no completed 4h bar"
+                assert completed[-1].open_time < entry_time
+                assert completed[-1].close_time <= entry_time
+
+        if not completed:
+            continue
+
+        latest = completed[-1]
+        expected = expected_by_open.get(latest.open_time)
+        next_idx = regime_4h.index(latest) + 1
+        next_expected = (
+            expected_by_open.get(regime_4h[next_idx].open_time)
+            if next_idx < len(regime_4h)
+            else None
+        )
+
+        for field in ("ema_slope_50", "rsi_14"):
+            joined_key = f"{field}_4h"
+            if joined_key not in row or row[joined_key] is None:
+                continue
+            assert expected is not None
+            assert row[joined_key] == expected[field]
+            if next_expected is not None and next_expected[field] != expected[field]:
+                assert row[joined_key] != next_expected[field]
+
+
+async def test_warmup_rows_not_exposed_and_first_row_formed() -> None:
+    warmup = 200
+    candles, _states = generate_regime_path(
+        _regime_params(),
+        n_bars=250,
+        start_price=100.0,
+        seed=1,
+    )
+    reader = SyntheticIndicatorReader(candles, warmup_bars=warmup)
+    start, end = _wide_window()
+    rows = await reader.fetch_range("SYNTH", "1h", start, end)
+
+    assert len(rows) == 50
+    assert rows[0]["time"] == candles[200].open_time
+    assert all(row["time"] >= candles[200].open_time for row in rows)
+    assert rows[0]["ema_200"] is not None
+    assert rows[0]["sma_200"] is not None
+    assert rows[0]["trend_consistency"] is not None
+
+
+async def test_reader_seed_determinism() -> None:
+    params = _regime_params()
+    candles_a, _ = generate_regime_path(params, n_bars=250, start_price=100.0, seed=1)
+    candles_b, _ = generate_regime_path(params, n_bars=250, start_price=100.0, seed=1)
+    candles_c, _ = generate_regime_path(params, n_bars=250, start_price=100.0, seed=2)
+    start, end = _wide_window()
+
+    rows_a = await SyntheticIndicatorReader(candles_a, warmup_bars=200).fetch_range(
+        "SYNTH", "1h", start, end
+    )
+    rows_b = await SyntheticIndicatorReader(candles_b, warmup_bars=200).fetch_range(
+        "SYNTH", "1h", start, end
+    )
+    rows_c = await SyntheticIndicatorReader(candles_c, warmup_bars=200).fetch_range(
+        "SYNTH", "1h", start, end
+    )
+
+    assert [row["close_price"] for row in rows_a] == [row["close_price"] for row in rows_b]
+    assert [row["ema_50"] for row in rows_a] == [row["ema_50"] for row in rows_b]
+    assert [row["close_price"] for row in rows_a] != [row["close_price"] for row in rows_c]
+    assert [row["ema_50"] for row in rows_a] != [row["ema_50"] for row in rows_c]
+
+
+async def test_engine_yields_pass_rate() -> None:
+    config = BacktestConfig(
+        symbol="SYNTH",
+        timeframe="1h",
+        start_date="2020-01-01T00:00:00+00:00",
+        end_date="2020-02-01T00:00:00+00:00",
+        strategy_classes=[SimpleMACrossoverStrategy],
+        strategy_configs=[None],
+        apply_global_trend_filter=False,
+        initial_capital=10000,
+    )
+    rate = await evaluate_synthetic_pass_rate(
+        config,
+        n_regime_paths=2,
+        include_stress=True,
+        warmup_bars=200,
+        eval_bars=80,
+        seed=7,
+    )
+    assert isinstance(rate, float)
+    assert 0.0 <= rate <= 100.0
+
+
+def test_path_passes_empty_is_false() -> None:
+    assert path_passes([]) is False
+
+
+def test_path_passes_known_sequence() -> None:
+    assert path_passes([1.0, 1.0, 1.0]) is True
+    assert path_passes([-20.0], max_drawdown_pct=10.0) is False
+
+
+async def test_fetch_funding_settlements_empty_by_default() -> None:
+    candles, _states = generate_regime_path(
+        _regime_params(),
+        n_bars=250,
+        start_price=100.0,
+        seed=1,
+    )
+    reader = SyntheticIndicatorReader(candles, warmup_bars=200)
+    start, end = _wide_window()
+    assert await reader.fetch_funding_settlements("SYNTH", start, end) == []


### PR DESCRIPTION
## Summary

PR #2. PR #161 advertised Gate 4b (`min_synthetic_pass_rate_pct`) but never computed `ExperimentSummary.synthetic_pass_rate_pct` — it was always 0.0, so turning the gate on would reject every candidate. This adds the producer.

- `SyntheticIndicatorReader` duck-types the three methods `BacktestEngine` actually calls. It does **not** inherit `IndicatorReader` (that constructor wants DB config) and does **not** reimplement the MTF join: it calls `IndicatorReader._join_timeframes` so lookahead rules stay identical (`regime_close_time <= entry_open`).
- Indicators come from existing `compute_indicators(OhlcvSeries)`. Warmup is an explicit 200 bars (EMA200 / `trend_consistency` / `computer.py`).
- `evaluate_synthetic_pass_rate` runs the engine on 3 Markov paths + 3 scripted stresses and fills the summary field. `min_synthetic_pass_rate_pct` stays `0.0` everywhere. Turning it on is a later human decision.

## Type of Change

- [x] New feature
- [x] Tests

## Testing

- [x] `uv run pytest -v` — 1258 passed
- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`

## Observed pass rates (sol-1h-trend-pullback-overlay-live)

Same strategy stack and aggregator as `config/settings.sol_1h_trend_pullback_overlay_live.yaml` (buy_threshold 1.27, 6 strategies, futures paper semantics). Default runner: warmup 200, eval 240, start 140, seed 42. Pass = at least one trade AND compound return ≥ 0 AND trade-path max DD ≤ 10%. Zero-trade paths fail.

| path | trades | compound % | max DD % | pass |
|---|---:|---:|---:|---|
| regime_0 | 0 | 0.00 | 0.00 | no |
| regime_1 | 0 | 0.00 | 0.00 | no |
| regime_2 | 0 | 0.00 | 0.00 | no |
| march_2020_gap | 0 | 0.00 | 0.00 | no |
| funding_blowout | 0 | 0.00 | 0.00 | no |
| flat_wide_spread | 6 | -4.21 | 4.21 | no |

**Pass rate: 0.0% (0/6).** This is not a decorative 100% gate. Five paths never trade (the overlay is sparse at 1.27). The one path that does trade loses. Enabling the gate at any threshold above 0 would reject this already-disarmed candidate. I am **not** recommending a threshold from this sample.

## Checklist

- [x] Code follows project style
- [x] Self-review completed
- [x] Tests added/updated
- [x] Did not modify `engine.py`, `reader.py`, `requirements.txt`, or any settings YAML
- [x] Gate remains disabled (`0.0`)

## Notes

Step 2: the real reader already owns the no-lookahead join. Duplicating it would have been the redundant layer. The synthetic reader only generates rows and delegates the join.

Follow-ups (not this PR): generate `requirements.txt` from the lock or delete it; news-surprise scoring lives in `manual-trading-agent`.