### PR TITLE
feat(backtest): calibrate Gate 4b so the rate is not a fake verdict

### DIFF
--- a/docs/RBI_AUTORESEARCH_LOOP.md
+++ b/docs/RBI_AUTORESEARCH_LOOP.md
@@ -331,7 +331,13 @@ bootstrap=1000; treat that as the default expectation.
 Historical WFO and bootstrap only resample realised history. After that filter and before
 paper/live, a synthetic-path gate can reject a candidate that fails regime-switching paths
 or three scripted stresses (March-2020 gap, funding blowout, flat wide spread).
-`min_synthetic_pass_rate_pct` defaults to 0.0 (disabled) and must be set non-zero to enforce.
+The pass rate is **not** a robustness verdict when coverage is thin: zero-trade paths
+leave the denominator (they are not scored as FAIL), and fewer than 3 scored paths is
+**INCONCLUSIVE** — the report prints INCONCLUSIVE, not 0%. If the gate is later
+enabled, inconclusive is a coverage failure, not a scored 0%. The eval window is sized
+from historical trades-per-bar, not a fixed short window. Regime paths use a return
+floor; stress paths use drawdown containment only. `min_synthetic_pass_rate_pct` stays
+0.0 (disabled) and must be set non-zero to enforce.
 
 ### Gate 5: Independence and Portfolio Impact
 

--- a/scripts/experiment_autopilot.py
+++ b/scripts/experiment_autopilot.py
@@ -36,7 +36,7 @@ from src.backtest.factory import (
     resolve_global_trend_filter,
 )
 from src.backtest.models import ExecutionProfile
-from src.backtest.synthetic_eval import evaluate_synthetic_pass_rate
+from src.backtest.synthetic_eval import bars_from_range, evaluate_synthetic_pass_rate
 from src.db import close_pool, get_pool, init_pool  # noqa: E402
 from src.features.reader import IndicatorReader  # noqa: E402
 from src.main import _resolve_strategy_config, load_settings  # noqa: E402
@@ -276,7 +276,13 @@ def _render_markdown(
     lines.append(f"| Mean OOS Sharpe | {summary.wfo_mean_sharpe:.2f} |")
     lines.append(f"| Compound OOS return | {summary.wfo_total_return_pct:.2f}% |")
     lines.append(f"| Bootstrap P(loss) | {summary.bootstrap_p_loss_pct:.2f}% |")
-    lines.append(f"| Synthetic pass rate | {summary.synthetic_pass_rate_pct:.2f}% |")
+    if summary.synthetic_eval_status == "inconclusive":
+        lines.append(
+            "| Synthetic pass rate | INCONCLUSIVE "
+            f"({summary.synthetic_scored_paths}/{summary.synthetic_total_paths} paths traded) |"
+        )
+    else:
+        lines.append(f"| Synthetic pass rate | {summary.synthetic_pass_rate_pct:.2f}% |")
     lines.append(f"| Profit concentration | {summary.profit_concentration_pct:.2f}% |")
     lines.append(f"| Blocked BUY (session router) | {summary.blocked_buy_count} |")
     lines.append(f"| Blocked BUY (basis filter) | {summary.basis_blocked_buy_count} |")
@@ -474,7 +480,12 @@ async def run_experiment_evaluation(
             seed=seed,
         )
 
-        synthetic_rate = await evaluate_synthetic_pass_rate(base_config, seed=seed)
+        synthetic_result = await evaluate_synthetic_pass_rate(
+            base_config,
+            seed=seed,
+            historical_trades=baseline.total_trades,
+            historical_bars=bars_from_range(resolved_start, resolved_end, resolved_timeframe),
+        )
 
         oos_returns = [window.total_return_pct for window in window_results]
         oos_sharpes = [window.sharpe_ratio for window in window_results]
@@ -497,7 +508,10 @@ async def run_experiment_evaluation(
             bootstrap_p_loss_pct=path_metrics["p_loss_pct"],
             mc_drawdown_p95_pct=path_metrics["drawdown_p95_pct"],
             mc_drawdown_p50_pct=path_metrics["drawdown_p50_pct"],
-            synthetic_pass_rate_pct=synthetic_rate,
+            synthetic_pass_rate_pct=synthetic_result.pass_rate_pct,
+            synthetic_eval_status=synthetic_result.status,
+            synthetic_scored_paths=synthetic_result.scored_paths,
+            synthetic_total_paths=synthetic_result.total_paths,
             profit_concentration_pct=profit_concentration_pct(oos_returns),
             blocked_buy_count=baseline.blocked_buy_count,
             basis_blocked_buy_count=baseline.basis_blocked_buy_count,

--- a/src/backtest/experiment_autopilot.py
+++ b/src/backtest/experiment_autopilot.py
@@ -13,7 +13,8 @@ class GateConfig:
     drawdown Monte Carlo gate is disabled (default). Non-zero enables the check
     against summary.mc_drawdown_p95_pct. The same sentinel 0.0 disables
     min_synthetic_pass_rate_pct (default); a non-zero value enables the check
-    against summary.synthetic_pass_rate_pct.
+    against summary.synthetic_pass_rate_pct. Enabled checks treat
+    synthetic_eval_status == "inconclusive" as coverage failure, not a 0% verdict.
     """
 
     min_trades: int = 0
@@ -74,6 +75,9 @@ class ExperimentSummary:
     mc_drawdown_p95_pct: float = 0.0
     mc_drawdown_p50_pct: float = 0.0
     synthetic_pass_rate_pct: float = 0.0
+    synthetic_eval_status: str = ""  # "" | "scored" | "inconclusive"
+    synthetic_scored_paths: int = 0
+    synthetic_total_paths: int = 0
     profit_concentration_pct: float = 0.0
     passes_gates: bool = False
     failure_reasons: list[str] = field(default_factory=list)
@@ -299,7 +303,9 @@ def evaluate_gates(summary: ExperimentSummary, gates: GateConfig) -> list[str]:
             )
 
     if gates.min_synthetic_pass_rate_pct > 0:
-        if summary.synthetic_pass_rate_pct < gates.min_synthetic_pass_rate_pct:
+        if summary.synthetic_eval_status == "inconclusive":
+            failures.append("min_synthetic_pass_rate_pct failed (inconclusive coverage)")
+        elif summary.synthetic_pass_rate_pct < gates.min_synthetic_pass_rate_pct:
             failures.append(
                 "min_synthetic_pass_rate_pct failed "
                 f"({summary.synthetic_pass_rate_pct:.2f}% < {gates.min_synthetic_pass_rate_pct:.2f}%)"

--- a/src/backtest/synthetic_eval.py
+++ b/src/backtest/synthetic_eval.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+import math
 from collections.abc import Sequence
-from dataclasses import replace
+from dataclasses import dataclass, replace
+from datetime import UTC, datetime
+from typing import Literal
 
 from src.backtest.engine import BacktestEngine
 from src.backtest.experiment_autopilot import compound_returns_pct, max_drawdown_from_returns
@@ -12,12 +15,16 @@ from src.backtest.synthetic import (
     RegimeParams,
     generate_regime_path,
     generate_stress_path,
-    synthetic_pass_rate_pct,
 )
 from src.backtest.synthetic_reader import DEFAULT_WARMUP_BARS, SyntheticIndicatorReader
 from src.ingest.models import Ohlcv
 
 DEFAULT_EVAL_BARS = 240
+MIN_SCORED_PATHS = 3
+TARGET_TRADES_PER_PATH = 4
+MIN_EVAL_BARS = 480
+MAX_EVAL_BARS = 4000
+_TIMEFRAME_HOURS = {"15m": 0.25, "1h": 1.0, "4h": 4.0, "1d": 24.0}
 DEFAULT_REGIME_PARAMS = RegimeParams(
     mu_calm=0.0,
     sigma_calm=0.008,
@@ -30,20 +37,68 @@ DEFAULT_REGIME_PARAMS = RegimeParams(
 STRESS_SCENARIOS = ("march_2020_gap", "funding_blowout", "flat_wide_spread")
 
 
-def path_passes(
-    trade_returns_pct: Sequence[float],
+@dataclass(frozen=True)
+class SyntheticEvalResult:
+    status: str  # 'scored' | 'inconclusive'
+    pass_rate_pct: float  # 0.0 when inconclusive — not a verdict
+    scored_paths: int
+    total_paths: int
+    zero_trade_paths: int
+
+
+def _parse_iso(value: str) -> datetime:
+    parsed = datetime.fromisoformat(value)
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=UTC)
+    return parsed
+
+
+def bars_from_range(start: str, end: str, timeframe: str) -> int:
+    """Count bars between ISO datetimes for 1h/4h/1d/15m (naive timestamps = UTC)."""
+    elapsed_hours = (_parse_iso(end) - _parse_iso(start)).total_seconds() / 3600.0
+    bar_hours = _TIMEFRAME_HOURS.get(timeframe)
+    if bar_hours is None:
+        raise ValueError(f"unsupported timeframe: {timeframe}")
+    return max(1, math.floor(elapsed_hours / bar_hours))
+
+
+def eval_bars_from_trade_rate(
     *,
+    historical_trades: int,
+    historical_bars: int,
+    target_trades_per_path: int = TARGET_TRADES_PER_PATH,
+) -> int:
+    """Size the eval window from historical trades-per-bar, clamped to production bounds."""
+    if historical_trades <= 0 or historical_bars <= 0:
+        return MIN_EVAL_BARS
+    needed = math.ceil(target_trades_per_path / (historical_trades / historical_bars))
+    return min(MAX_EVAL_BARS, max(MIN_EVAL_BARS, needed))
+
+
+def score_path(
+    returns: Sequence[float],
+    *,
+    kind: Literal["regime", "stress"],
     max_drawdown_pct: float = 10.0,
     min_return_pct: float = 0.0,
-) -> bool:
-    """Empty (no-trade) paths fail. Otherwise require return and drawdown floors."""
-    if not trade_returns_pct:
-        return False
-    returns = list(trade_returns_pct)
-    return (
-        compound_returns_pct(returns) >= min_return_pct
-        and max_drawdown_from_returns(returns) <= max_drawdown_pct
-    )
+) -> bool | None:
+    """Score one path. Empty (no-trade) returns None and leaves the denominator."""
+    if not returns:
+        return None
+    values = list(returns)
+    if kind == "regime":
+        return compound_returns_pct(values) >= min_return_pct
+    return max_drawdown_from_returns(values) <= max_drawdown_pct
+
+
+def _rate_from_outcomes(outcomes: Sequence[bool | None]) -> SyntheticEvalResult:
+    scored = [outcome for outcome in outcomes if outcome is not None]
+    total = len(outcomes)
+    zeros = sum(1 for outcome in outcomes if outcome is None)
+    if len(scored) < MIN_SCORED_PATHS:
+        return SyntheticEvalResult("inconclusive", 0.0, len(scored), total, zeros)
+    rate = 100.0 * sum(1 for outcome in scored if outcome) / len(scored)
+    return SyntheticEvalResult("scored", rate, len(scored), total, zeros)
 
 
 def _config_for_window(config: BacktestConfig, start: str, end: str) -> BacktestConfig:
@@ -67,17 +122,24 @@ async def evaluate_synthetic_pass_rate(
     n_regime_paths: int = 3,
     include_stress: bool = True,
     warmup_bars: int = DEFAULT_WARMUP_BARS,
-    eval_bars: int = DEFAULT_EVAL_BARS,
+    eval_bars: int | None = None,
+    historical_trades: int = 0,
+    historical_bars: int = 0,
     seed: int = 42,
     start_price: float = 100.0,
     regime_params: RegimeParams | None = None,
     max_drawdown_pct: float = 10.0,
     min_return_pct: float = 0.0,
-) -> float:
-    """Percent of synthetic paths that pass return/drawdown checks. Computes only."""
+) -> SyntheticEvalResult:
+    """Score regime (return floor) and stress (drawdown) paths. Zero-trade paths leave the rate."""
+    if eval_bars is None:
+        eval_bars = eval_bars_from_trade_rate(
+            historical_trades=historical_trades,
+            historical_bars=historical_bars,
+        )
     params = regime_params if regime_params is not None else DEFAULT_REGIME_PARAMS
     n_bars = warmup_bars + eval_bars
-    path_returns: list[list[float]] = []
+    outcomes: list[bool | None] = []
 
     for i in range(n_regime_paths):
         candles, _states = generate_regime_path(
@@ -86,7 +148,14 @@ async def evaluate_synthetic_pass_rate(
             start_price=start_price,
             seed=seed + i,
         )
-        path_returns.append(await _run_path(config, candles, warmup_bars))
+        outcomes.append(
+            score_path(
+                await _run_path(config, candles, warmup_bars),
+                kind="regime",
+                max_drawdown_pct=max_drawdown_pct,
+                min_return_pct=min_return_pct,
+            )
+        )
 
     if include_stress:
         for j, scenario in enumerate(STRESS_SCENARIOS):
@@ -96,13 +165,13 @@ async def evaluate_synthetic_pass_rate(
                 start_price=start_price,
                 seed=seed + 100 + j,
             )
-            path_returns.append(await _run_path(config, candles, warmup_bars))
+            outcomes.append(
+                score_path(
+                    await _run_path(config, candles, warmup_bars),
+                    kind="stress",
+                    max_drawdown_pct=max_drawdown_pct,
+                    min_return_pct=min_return_pct,
+                )
+            )
 
-    return synthetic_pass_rate_pct(
-        path_returns,
-        lambda returns: path_passes(
-            returns,
-            max_drawdown_pct=max_drawdown_pct,
-            min_return_pct=min_return_pct,
-        ),
-    )
+    return _rate_from_outcomes(outcomes)

--- a/tests/test_synthetic_eval.py
+++ b/tests/test_synthetic_eval.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from src.backtest.experiment_autopilot import ExperimentSummary, GateConfig, evaluate_gates
+from src.backtest.synthetic_eval import (
+    MAX_EVAL_BARS,
+    MIN_EVAL_BARS,
+    _rate_from_outcomes,
+    eval_bars_from_trade_rate,
+    score_path,
+)
+
+
+def _passing_summary(**overrides: object) -> ExperimentSummary:
+    payload: dict[str, object] = {
+        "symbol": "SOLUSDT",
+        "timeframe": "4h",
+        "start": "2024-01-01",
+        "end": "2025-01-01",
+        "total_trades": 24,
+        "win_rate": 55.0,
+        "total_return_pct": 8.0,
+        "max_drawdown_pct": 9.0,
+        "sharpe_ratio": 0.8,
+        "wfo_windows": 2,
+        "wfo_total_trades": 24,
+        "wfo_mean_sharpe": 0.7,
+        "wfo_total_return_pct": 4.5,
+        "bootstrap_p_loss_pct": 20.0,
+        "mc_drawdown_p95_pct": 12.0,
+        "mc_drawdown_p50_pct": 6.0,
+        "synthetic_pass_rate_pct": 5.0,
+        "profit_concentration_pct": 35.0,
+        "passes_gates": False,
+        "failure_reasons": [],
+    }
+    payload.update(overrides)
+    return ExperimentSummary(**payload)  # type: ignore[arg-type]
+
+
+def test_path_passes_empty() -> None:
+    assert score_path([], kind="regime") is None
+    assert score_path([], kind="stress") is None
+
+
+def test_score_path_regime_ignores_drawdown() -> None:
+    assert score_path([-20.0], kind="regime", min_return_pct=-25.0) is True
+
+
+def test_score_path_stress_ignores_return() -> None:
+    assert score_path([-5.0], kind="stress", max_drawdown_pct=10.0) is True
+    assert score_path([-20.0], kind="stress", max_drawdown_pct=10.0) is False
+
+
+def test_rate_zero_trade_excluded_and_inconclusive() -> None:
+    result = _rate_from_outcomes([None, None, None, None, None, True])
+    assert result.status == "inconclusive"
+    assert result.pass_rate_pct == 0.0
+    assert result.scored_paths == 1
+    assert result.total_paths == 6
+    assert result.zero_trade_paths == 5
+
+
+def test_rate_scored_when_coverage_met() -> None:
+    result = _rate_from_outcomes([True, True, True, None, None, None])
+    assert result.status == "scored"
+    assert result.pass_rate_pct == 100.0
+    assert result.scored_paths == 3
+    assert result.zero_trade_paths == 3
+
+
+def test_eval_bars_from_trade_rate_scales_and_clamps() -> None:
+    higher_rate = eval_bars_from_trade_rate(historical_trades=100, historical_bars=1000)
+    lower_rate = eval_bars_from_trade_rate(historical_trades=8, historical_bars=1000)
+    assert higher_rate == MIN_EVAL_BARS
+    assert lower_rate > higher_rate
+    assert lower_rate >= MIN_EVAL_BARS
+    assert eval_bars_from_trade_rate(historical_trades=0, historical_bars=1000) == MIN_EVAL_BARS
+    assert eval_bars_from_trade_rate(historical_trades=1, historical_bars=100_000) == MAX_EVAL_BARS
+
+
+def test_gate_inert_at_zero() -> None:
+    summary = _passing_summary(
+        synthetic_pass_rate_pct=5.0,
+        synthetic_eval_status="inconclusive",
+    )
+    for gates in (GateConfig(), GateConfig(min_synthetic_pass_rate_pct=0.0)):
+        failures = evaluate_gates(summary, gates)
+        assert not any("min_synthetic_pass_rate_pct failed" in reason for reason in failures)
+
+
+def test_gate_inconclusive_fires_when_enabled() -> None:
+    summary = _passing_summary(synthetic_eval_status="inconclusive")
+    gates = GateConfig(min_synthetic_pass_rate_pct=50.0)
+    failures = evaluate_gates(summary, gates)
+    assert "min_synthetic_pass_rate_pct failed (inconclusive coverage)" in failures

--- a/tests/test_synthetic_paths.py
+++ b/tests/test_synthetic_paths.py
@@ -142,7 +142,10 @@ def test_synthetic_pass_rate_helper() -> None:
 
 
 def test_gate_inert_at_zero() -> None:
-    summary = _passing_summary(synthetic_pass_rate_pct=5.0)
+    summary = _passing_summary(
+        synthetic_pass_rate_pct=5.0,
+        synthetic_eval_status="inconclusive",
+    )
     for gates in (GateConfig(), GateConfig(min_synthetic_pass_rate_pct=0.0)):
         failures = evaluate_gates(summary, gates)
         assert not any("min_synthetic_pass_rate_pct failed" in reason for reason in failures)

--- a/tests/test_synthetic_reader.py
+++ b/tests/test_synthetic_reader.py
@@ -4,7 +4,7 @@ from datetime import UTC, datetime
 
 from src.backtest.models import BacktestConfig
 from src.backtest.synthetic import RegimeParams, generate_regime_path
-from src.backtest.synthetic_eval import evaluate_synthetic_pass_rate, path_passes
+from src.backtest.synthetic_eval import evaluate_synthetic_pass_rate, score_path
 from src.backtest.synthetic_reader import (
     SyntheticIndicatorReader,
     aggregate_ohlcv,
@@ -135,7 +135,7 @@ async def test_engine_yields_pass_rate() -> None:
         apply_global_trend_filter=False,
         initial_capital=10000,
     )
-    rate = await evaluate_synthetic_pass_rate(
+    result = await evaluate_synthetic_pass_rate(
         config,
         n_regime_paths=2,
         include_stress=True,
@@ -143,17 +143,18 @@ async def test_engine_yields_pass_rate() -> None:
         eval_bars=80,
         seed=7,
     )
-    assert isinstance(rate, float)
-    assert 0.0 <= rate <= 100.0
+    assert result.status in {"scored", "inconclusive"}
+    assert 0.0 <= result.pass_rate_pct <= 100.0
 
 
-def test_path_passes_empty_is_false() -> None:
-    assert path_passes([]) is False
+def test_path_passes_empty() -> None:
+    assert score_path([], kind="regime") is None
+    assert score_path([], kind="stress") is None
 
 
 def test_path_passes_known_sequence() -> None:
-    assert path_passes([1.0, 1.0, 1.0]) is True
-    assert path_passes([-20.0], max_drawdown_pct=10.0) is False
+    assert score_path([1.0, 1.0, 1.0], kind="regime") is True
+    assert score_path([-20.0], kind="stress", max_drawdown_pct=10.0) is False
 
 
 async def test_fetch_funding_settlements_empty_by_default() -> None:


### PR DESCRIPTION
## Summary

Gate 4b was emitting a number that read as a robustness verdict and was not one. The overlay-live candidate scored **0/6** on PR #163 because five paths never traded — those zeros were counted as FAIL.

Three scoring changes in `synthetic_eval.py`:

1. Zero-trade paths leave the denominator. Fewer than 3 scored paths is **INCONCLUSIVE** (report prints INCONCLUSIVE, not 0%). If the gate is later enabled, inconclusive is a coverage failure, not a scored 0%.
2. Production `eval_bars` is sized from the candidate's historical trades-per-bar (`target=4`, floor 480, cap 4000). Short windows stay test-only.
3. Split criteria: regime paths use a return floor; scripted stress paths use drawdown containment only.

The gate threshold stays `0.0`. No settings YAML changes.

## Type of Change

- [x] New feature
- [x] Tests
- [x] Documentation update

## Testing

- [x] `uv run pytest -v` — 1266 passed
- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`

## Remeasurement — sol-1h-trend-pullback-overlay-live

Same stack as #163. Seed 42, start 140.

**Same 240-bar window as #163 (was 0.0% FAIL):**

| path | kind | trades | compound % | max DD % | score |
|---|---|---:|---:|---:|---|
| regime_0 | regime | 0 | 0.00 | 0.00 | skip |
| regime_1 | regime | 0 | 0.00 | 0.00 | skip |
| regime_2 | regime | 0 | 0.00 | 0.00 | skip |
| march_2020_gap | stress | 0 | 0.00 | 0.00 | skip |
| funding_blowout | stress | 0 | 0.00 | 0.00 | skip |
| flat_wide_spread | stress | 6 | −4.21 | 4.21 | True |

**INCONCLUSIVE (1/6 traded).** The one traded path now *passes* stress DD (it used to fail the return floor). That 0% was a coverage artifact.

**Production floor (480 bars, zero-history sizing):**

| path | kind | trades | compound % | max DD % | score |
|---|---|---:|---:|---:|---|
| regime_0 | regime | 1 | −9.61 | 9.61 | False |
| regime_1 | regime | 0 | — | — | skip |
| regime_2 | regime | 0 | — | — | skip |
| march_2020_gap | stress | 0 | — | — | skip |
| funding_blowout | stress | 1 | +4.63 | 0.00 | True |
| flat_wide_spread | stress | 12 | −8.29 | 8.29 | True |

**scored 66.7% (2/3).** Longer window reached the coverage floor. Still not a threshold recommendation — one regime path lost, two stress paths contained DD. Gate stays off.

## Checklist

- [x] Code follows project style
- [x] Self-review completed
- [x] Documentation updated (Gate 4b)
- [x] Tests added/updated
- [x] Gate remains disabled

## Notes

Requirements.txt cleanup and news-surprise work still wait. Meta-allocator still gated on HYP-HTFR-001 `HAS_PULSE`.