### PR TITLE
fix(backtest): skip Gate 4b compute when disabled

### DIFF
--- a/docs/RBI_AUTORESEARCH_LOOP.md
+++ b/docs/RBI_AUTORESEARCH_LOOP.md
@@ -328,16 +328,11 @@ bootstrap=1000; treat that as the default expectation.
 
 ### Gate 4b: Synthetic-path stress
 
-Historical WFO and bootstrap only resample realised history. After that filter and before
-paper/live, a synthetic-path gate can reject a candidate that fails regime-switching paths
-or three scripted stresses (March-2020 gap, funding blowout, flat wide spread).
-The pass rate is **not** a robustness verdict when coverage is thin: zero-trade paths
-leave the denominator (they are not scored as FAIL), and fewer than 3 scored paths is
-**INCONCLUSIVE** — the report prints INCONCLUSIVE, not 0%. If the gate is later
-enabled, inconclusive is a coverage failure, not a scored 0%. The eval window is sized
-from historical trades-per-bar, not a fixed short window. Regime paths use a return
-floor; stress paths use drawdown containment only. `min_synthetic_pass_rate_pct` stays
-0.0 (disabled) and must be set non-zero to enforce.
+Gate 4b is a **diagnostic**, pending readiness. It is NOT a promotion gate.
+When disabled (threshold 0.0, not on CLI), synthetic eval is not run and the
+report records `not_run` (not 0.00%). Readiness still missing: futures-v2
+funding settlements, training-only regime fit, split coverage. Do not treat
+the field as a robustness verdict.
 
 ### Gate 5: Independence and Portfolio Impact
 

--- a/scripts/experiment_autopilot.py
+++ b/scripts/experiment_autopilot.py
@@ -36,7 +36,7 @@ from src.backtest.factory import (
     resolve_global_trend_filter,
 )
 from src.backtest.models import ExecutionProfile
-from src.backtest.synthetic_eval import bars_from_range, evaluate_synthetic_pass_rate
+from src.backtest.synthetic_eval import bars_from_range, maybe_evaluate_synthetic_pass_rate
 from src.db import close_pool, get_pool, init_pool  # noqa: E402
 from src.features.reader import IndicatorReader  # noqa: E402
 from src.main import _resolve_strategy_config, load_settings  # noqa: E402
@@ -276,7 +276,9 @@ def _render_markdown(
     lines.append(f"| Mean OOS Sharpe | {summary.wfo_mean_sharpe:.2f} |")
     lines.append(f"| Compound OOS return | {summary.wfo_total_return_pct:.2f}% |")
     lines.append(f"| Bootstrap P(loss) | {summary.bootstrap_p_loss_pct:.2f}% |")
-    if summary.synthetic_eval_status == "inconclusive":
+    if summary.synthetic_eval_status == "not_run":
+        lines.append("| Synthetic pass rate | not_run |")
+    elif summary.synthetic_eval_status == "inconclusive":
         lines.append(
             "| Synthetic pass rate | INCONCLUSIVE "
             f"({summary.synthetic_scored_paths}/{summary.synthetic_total_paths} paths traded) |"
@@ -480,8 +482,9 @@ async def run_experiment_evaluation(
             seed=seed,
         )
 
-        synthetic_result = await evaluate_synthetic_pass_rate(
+        synthetic_result = await maybe_evaluate_synthetic_pass_rate(
             base_config,
+            enabled=gates.min_synthetic_pass_rate_pct > 0,
             seed=seed,
             historical_trades=baseline.total_trades,
             historical_bars=bars_from_range(resolved_start, resolved_end, resolved_timeframe),

--- a/src/backtest/experiment_autopilot.py
+++ b/src/backtest/experiment_autopilot.py
@@ -13,8 +13,10 @@ class GateConfig:
     drawdown Monte Carlo gate is disabled (default). Non-zero enables the check
     against summary.mc_drawdown_p95_pct. The same sentinel 0.0 disables
     min_synthetic_pass_rate_pct (default); a non-zero value enables the check
-    against summary.synthetic_pass_rate_pct. Enabled checks treat
-    synthetic_eval_status == "inconclusive" as coverage failure, not a 0% verdict.
+    against summary.synthetic_pass_rate_pct. The threshold stays 0.0 and is
+    not wired through CLI/autoresearch; compute is skipped when disabled.
+    Enabled checks treat synthetic_eval_status == "inconclusive" as coverage
+    failure, not a 0% verdict, and treat "not_run" or "" as not_run failure.
     """
 
     min_trades: int = 0
@@ -75,7 +77,7 @@ class ExperimentSummary:
     mc_drawdown_p95_pct: float = 0.0
     mc_drawdown_p50_pct: float = 0.0
     synthetic_pass_rate_pct: float = 0.0
-    synthetic_eval_status: str = ""  # "" | "scored" | "inconclusive"
+    synthetic_eval_status: str = "not_run"  # not_run | scored | inconclusive
     synthetic_scored_paths: int = 0
     synthetic_total_paths: int = 0
     profit_concentration_pct: float = 0.0
@@ -303,7 +305,9 @@ def evaluate_gates(summary: ExperimentSummary, gates: GateConfig) -> list[str]:
             )
 
     if gates.min_synthetic_pass_rate_pct > 0:
-        if summary.synthetic_eval_status == "inconclusive":
+        if summary.synthetic_eval_status in {"not_run", ""}:
+            failures.append("min_synthetic_pass_rate_pct failed (not_run)")
+        elif summary.synthetic_eval_status == "inconclusive":
             failures.append("min_synthetic_pass_rate_pct failed (inconclusive coverage)")
         elif summary.synthetic_pass_rate_pct < gates.min_synthetic_pass_rate_pct:
             failures.append(

--- a/src/backtest/synthetic_eval.py
+++ b/src/backtest/synthetic_eval.py
@@ -39,11 +39,20 @@ STRESS_SCENARIOS = ("march_2020_gap", "funding_blowout", "flat_wide_spread")
 
 @dataclass(frozen=True)
 class SyntheticEvalResult:
-    status: str  # 'scored' | 'inconclusive'
-    pass_rate_pct: float  # 0.0 when inconclusive — not a verdict
+    status: str  # 'not_run' | 'scored' | 'inconclusive'
+    pass_rate_pct: float  # 0.0 when inconclusive or not_run — not a verdict
     scored_paths: int
     total_paths: int
     zero_trade_paths: int
+
+
+NOT_RUN_RESULT = SyntheticEvalResult(
+    status="not_run",
+    pass_rate_pct=0.0,
+    scored_paths=0,
+    total_paths=0,
+    zero_trade_paths=0,
+)
 
 
 def _parse_iso(value: str) -> datetime:
@@ -175,3 +184,38 @@ async def evaluate_synthetic_pass_rate(
             )
 
     return _rate_from_outcomes(outcomes)
+
+
+async def maybe_evaluate_synthetic_pass_rate(
+    config: BacktestConfig,
+    *,
+    enabled: bool,
+    n_regime_paths: int = 3,
+    include_stress: bool = True,
+    warmup_bars: int = DEFAULT_WARMUP_BARS,
+    eval_bars: int | None = None,
+    historical_trades: int = 0,
+    historical_bars: int = 0,
+    seed: int = 42,
+    start_price: float = 100.0,
+    regime_params: RegimeParams | None = None,
+    max_drawdown_pct: float = 10.0,
+    min_return_pct: float = 0.0,
+) -> SyntheticEvalResult:
+    """Skip path generation when the synthetic gate is disabled."""
+    if not enabled:
+        return NOT_RUN_RESULT
+    return await evaluate_synthetic_pass_rate(
+        config,
+        n_regime_paths=n_regime_paths,
+        include_stress=include_stress,
+        warmup_bars=warmup_bars,
+        eval_bars=eval_bars,
+        historical_trades=historical_trades,
+        historical_bars=historical_bars,
+        seed=seed,
+        start_price=start_price,
+        regime_params=regime_params,
+        max_drawdown_pct=max_drawdown_pct,
+        min_return_pct=min_return_pct,
+    )

--- a/tests/test_synthetic_eval.py
+++ b/tests/test_synthetic_eval.py
@@ -1,13 +1,24 @@
 from __future__ import annotations
 
+import inspect
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
 from src.backtest.experiment_autopilot import ExperimentSummary, GateConfig, evaluate_gates
+from src.backtest.models import BacktestConfig
 from src.backtest.synthetic_eval import (
     MAX_EVAL_BARS,
     MIN_EVAL_BARS,
+    SyntheticEvalResult,
     _rate_from_outcomes,
     eval_bars_from_trade_rate,
+    evaluate_synthetic_pass_rate,
+    maybe_evaluate_synthetic_pass_rate,
     score_path,
 )
+from src.strategy.simple_ma import SimpleMACrossoverStrategy
 
 
 def _passing_summary(**overrides: object) -> ExperimentSummary:
@@ -93,3 +104,100 @@ def test_gate_inconclusive_fires_when_enabled() -> None:
     gates = GateConfig(min_synthetic_pass_rate_pct=50.0)
     failures = evaluate_gates(summary, gates)
     assert "min_synthetic_pass_rate_pct failed (inconclusive coverage)" in failures
+
+
+def _dummy_config() -> BacktestConfig:
+    return BacktestConfig(
+        symbol="SYNTH",
+        timeframe="1h",
+        start_date="2020-01-01T00:00:00+00:00",
+        end_date="2020-02-01T00:00:00+00:00",
+    )
+
+
+async def test_disabled_skips_compute() -> None:
+    with patch(
+        "src.backtest.synthetic_eval.evaluate_synthetic_pass_rate",
+        new_callable=AsyncMock,
+    ) as mock_evaluate:
+        result = await maybe_evaluate_synthetic_pass_rate(_dummy_config(), enabled=False)
+
+    mock_evaluate.assert_not_awaited()
+    mock_evaluate.assert_not_called()
+    assert result.status == "not_run"
+    assert result.pass_rate_pct == 0.0
+
+
+async def test_enabled_forwards_to_evaluate() -> None:
+    scored = SyntheticEvalResult(
+        status="scored",
+        pass_rate_pct=80.0,
+        scored_paths=5,
+        total_paths=6,
+        zero_trade_paths=1,
+    )
+    with patch(
+        "src.backtest.synthetic_eval.evaluate_synthetic_pass_rate",
+        new_callable=AsyncMock,
+        return_value=scored,
+    ) as mock_evaluate:
+        result = await maybe_evaluate_synthetic_pass_rate(_dummy_config(), enabled=True)
+
+    mock_evaluate.assert_awaited_once()
+    assert result is scored
+
+
+def test_render_not_run_is_not_zero_percent() -> None:
+    from scripts.experiment_autopilot import _render_markdown
+
+    summary = _passing_summary(synthetic_eval_status="not_run", synthetic_pass_rate_pct=0.0)
+    markdown = _render_markdown(
+        summary=summary,
+        windows=[],
+        gates=GateConfig(),
+        config_path=Path("config/settings.yaml"),
+    )
+    assert "not_run" in markdown
+    synth_lines = [line for line in markdown.splitlines() if "Synthetic pass rate" in line]
+    assert synth_lines
+    assert "0.00%" not in synth_lines[0]
+
+
+def test_gate_not_run_inert_when_disabled() -> None:
+    summary = _passing_summary(synthetic_eval_status="not_run", synthetic_pass_rate_pct=0.0)
+    for gates in (GateConfig(), GateConfig(min_synthetic_pass_rate_pct=0.0)):
+        failures = evaluate_gates(summary, gates)
+        assert not any("min_synthetic_pass_rate_pct failed" in reason for reason in failures)
+
+
+def test_gate_not_run_fails_when_enabled() -> None:
+    gates = GateConfig(min_synthetic_pass_rate_pct=50.0)
+    for status in ("not_run", ""):
+        summary = _passing_summary(synthetic_eval_status=status)
+        failures = evaluate_gates(summary, gates)
+        assert "min_synthetic_pass_rate_pct failed (not_run)" in failures
+
+
+async def test_futures_v2_synthetic_eval_requires_settlements() -> None:
+    config = BacktestConfig(
+        symbol="SYNTH",
+        timeframe="1h",
+        start_date="2020-01-01T00:00:00+00:00",
+        end_date="2020-02-01T00:00:00+00:00",
+        execution_profile="execution_parity_v2",
+        futures_mode=True,
+        strategy_classes=[SimpleMACrossoverStrategy],
+        strategy_configs=[None],
+        apply_global_trend_filter=False,
+    )
+    with pytest.raises(ValueError, match="Missing historical funding settlements"):
+        await evaluate_synthetic_pass_rate(config, eval_bars=80, warmup_bars=200)
+
+
+def test_cli_has_no_synthetic_threshold() -> None:
+    from scripts.run_autoresearch import _gate_config_from_profile
+
+    autopilot = Path("scripts/experiment_autopilot.py").read_text(encoding="utf-8")
+    assert "--min-synthetic" not in autopilot
+    construction = inspect.getsource(_gate_config_from_profile)
+    assert "min_synthetic_pass_rate" not in construction

--- a/tests/test_synthetic_paths.py
+++ b/tests/test_synthetic_paths.py
@@ -152,7 +152,7 @@ def test_gate_inert_at_zero() -> None:
 
 
 def test_gate_fires_when_enabled() -> None:
-    summary = _passing_summary(synthetic_pass_rate_pct=20.0)
+    summary = _passing_summary(synthetic_pass_rate_pct=20.0, synthetic_eval_status="scored")
     gates = GateConfig(min_synthetic_pass_rate_pct=50.0)
     failures = evaluate_gates(summary, gates)
     assert "min_synthetic_pass_rate_pct failed (20.00% < 50.00%)" in failures


### PR DESCRIPTION
## Summary

Containment. Research runs were always generating synthetic paths even though the gate is off. That did two bad things:

1. Wrote `0.00%` into the autopilot report as if it were a robustness verdict.
2. Crashed `execution_parity_v2` + futures on `Missing historical funding settlements` — the default research profile.

Disabled now skips the evaluator and records `not_run`. The threshold stays `0.0` and is not on the CLI or in autoresearch profiles.

This does **not** make Gate 4b a promotion gate. RBI now says it is a diagnostic, pending readiness (funding settlements, training-only regime fit, split coverage).

## Type of Change

- [x] Bug fix
- [x] Tests
- [x] Documentation update

## Testing

- [x] `uv run pytest -v` — 1273 passed
- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`

Regression tests added:

- disabled path does not call `evaluate_synthetic_pass_rate`
- markdown prints `not_run`, not `0.00%`
- futures v2 eval still raises without 8h settlements (readiness gap, not a fix)
- `--min-synthetic` is absent from the CLI; autoresearch profiles do not set the threshold

## Checklist

- [x] Gate remains disabled and inaccessible
- [x] No `engine.py` / `reader.py` / settings YAML / `requirements.txt` changes

## Next (not this PR)

Semantic-readiness PR, then a preregistered calibration run, then a decision whether to wire a threshold or keep 4b diagnostic-only.