### PR TITLE
feat(backtest): add Gate 4b diagnostic evidence contract

### DIFF
--- a/docs/RBI_AUTORESEARCH_LOOP.md
+++ b/docs/RBI_AUTORESEARCH_LOOP.md
@@ -330,9 +330,10 @@ bootstrap=1000; treat that as the default expectation.
 
 Gate 4b is a **diagnostic**, pending readiness. It is NOT a promotion gate.
 When disabled (threshold 0.0, not on CLI), synthetic eval is not run and the
-report records `not_run` (not 0.00%). Readiness still missing: futures-v2
-funding settlements, training-only regime fit, split coverage. Do not treat
-the field as a robustness verdict.
+report records `not_run` (not 0.00%). Optional `--synthetic-diagnostic` with
+an explicit frozen `--synthetic-fit-start`/`--synthetic-fit-end` records
+path/fit/runtime evidence; it does not affect promotion or `passes_gates`.
+The threshold stays 0.0.
 
 ### Gate 5: Independence and Portfolio Impact
 

--- a/scripts/experiment_autopilot.py
+++ b/scripts/experiment_autopilot.py
@@ -36,7 +36,11 @@ from src.backtest.factory import (
     resolve_global_trend_filter,
 )
 from src.backtest.models import ExecutionProfile
-from src.backtest.synthetic_eval import bars_from_range, maybe_evaluate_synthetic_pass_rate
+from src.backtest.synthetic_eval import (  # noqa: E402
+    SyntheticEvalResult,
+    bars_from_range,
+    maybe_evaluate_synthetic_pass_rate,
+)
 from src.db import close_pool, get_pool, init_pool  # noqa: E402
 from src.features.reader import IndicatorReader  # noqa: E402
 from src.main import _resolve_strategy_config, load_settings  # noqa: E402
@@ -119,7 +123,25 @@ def parse_args() -> argparse.Namespace:
         default="execution_parity_v2",
         help="New research defaults to next-open execution parity",
     )
-    return parser.parse_args()
+    parser.add_argument(
+        "--synthetic-diagnostic",
+        action="store_true",
+        help="Record synthetic-path diagnostic evidence (does not affect gates)",
+    )
+    parser.add_argument(
+        "--synthetic-fit-start",
+        help="Frozen ISO start for diagnostic regime fit",
+    )
+    parser.add_argument(
+        "--synthetic-fit-end",
+        help="Frozen ISO end for diagnostic regime fit",
+    )
+    args = parser.parse_args()
+    if args.synthetic_diagnostic and (not args.synthetic_fit_start or not args.synthetic_fit_end):
+        parser.error(
+            "--synthetic-diagnostic requires --synthetic-fit-start and --synthetic-fit-end"
+        )
+    return args
 
 
 def _db_config_from_settings(settings: object) -> dict[str, object]:
@@ -292,6 +314,9 @@ def _render_markdown(
         f"| Blocked BUY (cross-venue dislocation) | {summary.dislocation_blocked_buy_count} |"
     )
     lines.append("")
+    if summary.synthetic_eval_status != "not_run":
+        lines.append("diagnostic only; does not affect Gate result")
+        lines.append("")
 
     if windows:
         lines.append("## WFO Windows")
@@ -335,6 +360,14 @@ def _render_markdown(
     return "\n".join(lines)
 
 
+def _synthetic_audit_payload(result: SyntheticEvalResult) -> dict[str, object]:
+    payload = asdict(result)
+    payload["path_definitions"] = [
+        {"name": rec.name, "kind": rec.kind, "seed": rec.seed} for rec in result.paths
+    ]
+    return payload
+
+
 async def run_experiment_evaluation(
     *,
     settings_path: Path,
@@ -355,8 +388,15 @@ async def run_experiment_evaluation(
     db_config: dict[str, object] | None = None,
     manage_pool: bool = True,
     execution_profile: ExecutionProfile = "legacy_v1",
+    synthetic_diagnostic: bool = False,
+    synthetic_fit_start: str | None = None,
+    synthetic_fit_end: str | None = None,
 ) -> tuple[ExperimentSummary, GateConfig, list[WfoWindowResult], BacktestConfig, dict[str, object]]:
     """Run baseline + WFO + bootstrap gates; return summary and resolved baseline config."""
+    if synthetic_diagnostic and (not synthetic_fit_start or not synthetic_fit_end):
+        raise ValueError(
+            "--synthetic-diagnostic requires --synthetic-fit-start and --synthetic-fit-end"
+        )
     settings = load_settings(settings_path)
 
     result = _resolve_strategy_config(settings.strategy)
@@ -425,6 +465,8 @@ async def run_experiment_evaluation(
             execution_profile=execution_profile,
         )
 
+        fit_closes: list[float] | None = None
+        fit_rows = None
         reader = IndicatorReader(resolved_db)
         async with reader:
             baseline = await _run_backtest(reader, base_config)
@@ -475,6 +517,18 @@ async def run_experiment_evaluation(
                     )
                 )
 
+            if synthetic_diagnostic:
+                fit_start = str(synthetic_fit_start)
+                fit_end = str(synthetic_fit_end)
+                fetched = await reader.fetch_range(
+                    resolved_symbol,
+                    resolved_timeframe,
+                    fit_start,
+                    fit_end,
+                )
+                fit_rows = list(fetched)
+                fit_closes = [float(row["close_price"]) for row in fetched]
+
         trade_returns = [trade.return_pct for trade in baseline.trades]
         path_metrics = bootstrap_trade_path_metrics(
             trade_returns_pct=trade_returns,
@@ -484,10 +538,14 @@ async def run_experiment_evaluation(
 
         synthetic_result = await maybe_evaluate_synthetic_pass_rate(
             base_config,
-            enabled=gates.min_synthetic_pass_rate_pct > 0,
+            enabled=synthetic_diagnostic,
             seed=seed,
             historical_trades=baseline.total_trades,
             historical_bars=bars_from_range(resolved_start, resolved_end, resolved_timeframe),
+            fit_start=synthetic_fit_start,
+            fit_end=synthetic_fit_end,
+            fit_closes=fit_closes,
+            fit_rows=fit_rows,
         )
 
         oos_returns = [window.total_return_pct for window in window_results]
@@ -548,6 +606,7 @@ async def run_experiment_evaluation(
                 "source": base_config.global_trend_filter_source,
                 "config_explicit": base_config.config_global_trend_filter_enabled,
             },
+            "synthetic_diagnostic": _synthetic_audit_payload(synthetic_result),
         }
         return summary, gates, window_results, base_config, audit_payload
     finally:
@@ -587,6 +646,9 @@ async def main() -> None:
         replay_sentiment_path=args.replay_sentiment_log,
         replay_sentiment_max_age_hours=args.replay_sentiment_max_age_hours,
         execution_profile=args.execution_profile,
+        synthetic_diagnostic=args.synthetic_diagnostic,
+        synthetic_fit_start=args.synthetic_fit_start,
+        synthetic_fit_end=args.synthetic_fit_end,
     )
 
     timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")

--- a/src/backtest/synthetic_eval.py
+++ b/src/backtest/synthetic_eval.py
@@ -3,16 +3,20 @@
 from __future__ import annotations
 
 import math
-from collections.abc import Sequence
-from dataclasses import dataclass, replace
+import time
+from collections.abc import Mapping, Sequence
+from dataclasses import asdict, dataclass, replace
 from datetime import UTC, datetime
+from decimal import Decimal
 from typing import Literal
 
+from src.backtest.artifacts import fingerprint_rows
 from src.backtest.engine import BacktestEngine
 from src.backtest.experiment_autopilot import compound_returns_pct, max_drawdown_from_returns
 from src.backtest.models import BacktestConfig, BacktestResult
 from src.backtest.synthetic import (
     RegimeParams,
+    fit_two_state_regime,
     generate_regime_path,
     generate_stress_path,
 )
@@ -27,6 +31,8 @@ from src.ingest.models import Ohlcv
 
 DEFAULT_EVAL_BARS = 240
 MIN_SCORED_PATHS = 3
+MIN_REGIME_SCORED_PATHS = 2
+MIN_STRESS_SCORED_PATHS = 2
 TARGET_TRADES_PER_PATH = 4
 MIN_EVAL_BARS = 480
 MAX_EVAL_BARS = 4000
@@ -44,12 +50,49 @@ STRESS_SCENARIOS = ("march_2020_gap", "funding_blowout", "flat_wide_range")
 
 
 @dataclass(frozen=True)
+class SyntheticPathRecord:
+    name: str
+    kind: str
+    seed: int
+    trades: int
+    total_return_pct: float
+    max_drawdown_pct: float
+    outcome: str  # pass|fail|skip
+
+
+@dataclass(frozen=True)
+class SyntheticFitRecord:
+    fit_start: str
+    fit_end: str
+    row_count: int
+    row_fingerprint: str
+    params: dict[str, float]
+
+
+@dataclass(frozen=True)
+class SyntheticRuntimeEvidence:
+    min_eval_bars: int
+    max_eval_bars: int
+    generate_min_ms: float
+    generate_max_ms: float
+
+
+@dataclass(frozen=True)
 class SyntheticEvalResult:
     status: str  # 'not_run' | 'scored' | 'inconclusive'
     pass_rate_pct: float  # 0.0 when inconclusive or not_run — not a verdict
     scored_paths: int
     total_paths: int
     zero_trade_paths: int
+    regime_scored: int = 0
+    stress_scored: int = 0
+    regime_pass_rate_pct: float = 0.0
+    stress_pass_rate_pct: float = 0.0
+    paths: tuple[SyntheticPathRecord, ...] = ()
+    fit: SyntheticFitRecord | None = None
+    seed: int = 0
+    eval_bars_used: int = 0
+    runtime: SyntheticRuntimeEvidence | None = None
 
 
 NOT_RUN_RESULT = SyntheticEvalResult(
@@ -90,6 +133,19 @@ def eval_bars_from_trade_rate(
     return min(MAX_EVAL_BARS, max(MIN_EVAL_BARS, needed))
 
 
+def decimal_close_returns(closes: Sequence[float]) -> list[float]:
+    """Close-to-close fractional returns using Decimal(str(price))."""
+    if len(closes) < 2:
+        return []
+    out: list[float] = []
+    for prev, curr in zip(closes, closes[1:], strict=False):
+        if prev == 0.0:
+            out.append(0.0)
+        else:
+            out.append(float(Decimal(str(curr)) / Decimal(str(prev)) - 1))
+    return out
+
+
 def score_path(
     returns: Sequence[float],
     *,
@@ -106,6 +162,33 @@ def score_path(
     return max_drawdown_from_returns(values) <= max_drawdown_pct
 
 
+def score_engine_result(
+    result: BacktestResult,
+    *,
+    kind: Literal["regime", "stress"],
+    max_drawdown_pct: float = 10.0,
+    min_return_pct: float = 0.0,
+) -> bool | None:
+    """Score engine equity metrics. Zero-trade paths leave the denominator."""
+    if result.total_trades == 0:
+        return None
+    if kind == "regime":
+        return result.total_return_pct >= min_return_pct
+    return result.max_drawdown * 100.0 <= max_drawdown_pct
+
+
+def _outcome_label(passed: bool | None) -> str:
+    if passed is None:
+        return "skip"
+    return "pass" if passed else "fail"
+
+
+def _class_pass_rate(records: Sequence[SyntheticPathRecord]) -> float:
+    if not records:
+        return 0.0
+    return 100.0 * sum(1 for rec in records if rec.outcome == "pass") / len(records)
+
+
 def _rate_from_outcomes(outcomes: Sequence[bool | None]) -> SyntheticEvalResult:
     scored = [outcome for outcome in outcomes if outcome is not None]
     total = len(outcomes)
@@ -114,6 +197,31 @@ def _rate_from_outcomes(outcomes: Sequence[bool | None]) -> SyntheticEvalResult:
         return SyntheticEvalResult("inconclusive", 0.0, len(scored), total, zeros)
     rate = 100.0 * sum(1 for outcome in scored if outcome) / len(scored)
     return SyntheticEvalResult("scored", rate, len(scored), total, zeros)
+
+
+def _rate_from_named(records: Sequence[SyntheticPathRecord]) -> SyntheticEvalResult:
+    regime = [rec for rec in records if rec.kind == "regime" and rec.outcome != "skip"]
+    stress = [rec for rec in records if rec.kind == "stress" and rec.outcome != "skip"]
+    scored = [rec for rec in records if rec.outcome != "skip"]
+    zeros = sum(1 for rec in records if rec.outcome == "skip")
+    coverage_ok = len(regime) >= MIN_REGIME_SCORED_PATHS and len(stress) >= MIN_STRESS_SCORED_PATHS
+    status = "scored" if coverage_ok else "inconclusive"
+    if not scored or status == "inconclusive":
+        rate = 0.0
+    else:
+        rate = 100.0 * sum(1 for rec in scored if rec.outcome == "pass") / len(scored)
+    return SyntheticEvalResult(
+        status=status,
+        pass_rate_pct=rate,
+        scored_paths=len(scored),
+        total_paths=len(records),
+        zero_trade_paths=zeros,
+        regime_scored=len(regime),
+        stress_scored=len(stress),
+        regime_pass_rate_pct=_class_pass_rate(regime),
+        stress_pass_rate_pct=_class_pass_rate(stress),
+        paths=tuple(records),
+    )
 
 
 def _config_for_window(config: BacktestConfig, start: str, end: str) -> BacktestConfig:
@@ -147,6 +255,110 @@ def _settlements_for(
     return eight_hour_settlements(start, end, rate=0.0)
 
 
+def _generation_ms(
+    n_bars: int,
+    *,
+    seed: int,
+    symbol: str,
+    timeframe: str,
+    start_time: datetime,
+    params: RegimeParams,
+) -> float:
+    started = time.perf_counter()
+    generate_regime_path(
+        params,
+        n_bars=n_bars,
+        start_price=100.0,
+        seed=seed,
+        symbol=symbol,
+        timeframe=timeframe,
+        start_time=start_time,
+    )
+    return (time.perf_counter() - started) * 1000.0
+
+
+def runtime_bound_evidence(
+    *,
+    seed: int,
+    symbol: str,
+    timeframe: str,
+    start_time: datetime,
+    params: RegimeParams,
+) -> SyntheticRuntimeEvidence:
+    return SyntheticRuntimeEvidence(
+        min_eval_bars=MIN_EVAL_BARS,
+        max_eval_bars=MAX_EVAL_BARS,
+        generate_min_ms=_generation_ms(
+            MIN_EVAL_BARS,
+            seed=seed,
+            symbol=symbol,
+            timeframe=timeframe,
+            start_time=start_time,
+            params=params,
+        ),
+        generate_max_ms=_generation_ms(
+            MAX_EVAL_BARS,
+            seed=seed,
+            symbol=symbol,
+            timeframe=timeframe,
+            start_time=start_time,
+            params=params,
+        ),
+    )
+
+
+def _path_record(
+    *,
+    name: str,
+    kind: Literal["regime", "stress"],
+    seed: int,
+    result: BacktestResult,
+    passed: bool | None,
+) -> SyntheticPathRecord:
+    return SyntheticPathRecord(
+        name=name,
+        kind=kind,
+        seed=seed,
+        trades=result.total_trades,
+        total_return_pct=result.total_return_pct,
+        max_drawdown_pct=result.max_drawdown * 100.0,
+        outcome=_outcome_label(passed),
+    )
+
+
+def _resolve_fit(
+    *,
+    require_fit: bool,
+    fit_start: str | None,
+    fit_end: str | None,
+    fit_closes: Sequence[float] | None,
+    fit_rows: Sequence[Mapping[str, object]] | None,
+    regime_params: RegimeParams | None,
+) -> tuple[RegimeParams, SyntheticFitRecord | None]:
+    if require_fit and (not fit_start or not fit_end or fit_closes is None or len(fit_closes) < 2):
+        raise ValueError("require_fit needs fit_start, fit_end, and at least two fit_closes")
+    if fit_closes is None:
+        params = regime_params if regime_params is not None else DEFAULT_REGIME_PARAMS
+        return params, None
+    returns = decimal_close_returns(fit_closes)
+    params = fit_two_state_regime(returns)
+    rows_for_fp: Sequence[Mapping[str, object]]
+    if fit_rows is not None:
+        rows_for_fp = fit_rows
+        row_count = len(fit_rows)
+    else:
+        rows_for_fp = [{"close": close} for close in fit_closes]
+        row_count = len(fit_closes)
+    fit = SyntheticFitRecord(
+        fit_start=fit_start or "",
+        fit_end=fit_end or "",
+        row_count=row_count,
+        row_fingerprint=fingerprint_rows(rows_for_fp),
+        params={key: float(value) for key, value in asdict(params).items()},
+    )
+    return params, fit
+
+
 async def evaluate_synthetic_pass_rate(
     config: BacktestConfig,
     *,
@@ -161,6 +373,11 @@ async def evaluate_synthetic_pass_rate(
     regime_params: RegimeParams | None = None,
     max_drawdown_pct: float = 10.0,
     min_return_pct: float = 0.0,
+    fit_start: str | None = None,
+    fit_end: str | None = None,
+    fit_closes: Sequence[float] | None = None,
+    fit_rows: Sequence[Mapping[str, object]] | None = None,
+    require_fit: bool = False,
 ) -> SyntheticEvalResult:
     """Score regime (return floor) and stress (drawdown) paths. Zero-trade paths leave the rate."""
     if eval_bars is None:
@@ -168,57 +385,92 @@ async def evaluate_synthetic_pass_rate(
             historical_trades=historical_trades,
             historical_bars=historical_bars,
         )
-    params = regime_params if regime_params is not None else DEFAULT_REGIME_PARAMS
+    params, fit_record = _resolve_fit(
+        require_fit=require_fit,
+        fit_start=fit_start,
+        fit_end=fit_end,
+        fit_closes=fit_closes,
+        fit_rows=fit_rows,
+        regime_params=regime_params,
+    )
     n_bars = warmup_bars + eval_bars
-    outcomes: list[bool | None] = []
+    records: list[SyntheticPathRecord] = []
     path_symbol = config.symbol
     path_timeframe = config.timeframe
     path_start = _parse_iso(config.start_date)
 
     for i in range(n_regime_paths):
+        path_seed = seed + i
         candles, _states = generate_regime_path(
             params,
             n_bars=n_bars,
             start_price=start_price,
-            seed=seed + i,
+            seed=path_seed,
             symbol=path_symbol,
             timeframe=path_timeframe,
             start_time=path_start,
         )
         settlements = _settlements_for(config, candles, warmup_bars, None)
         result = await _run_path(config, candles, warmup_bars, settlements=settlements)
-        outcomes.append(
-            score_path(
-                [trade.return_pct for trade in result.trades],
+        records.append(
+            _path_record(
+                name=f"regime_{i}",
                 kind="regime",
-                max_drawdown_pct=max_drawdown_pct,
-                min_return_pct=min_return_pct,
+                seed=path_seed,
+                result=result,
+                passed=score_engine_result(
+                    result,
+                    kind="regime",
+                    max_drawdown_pct=max_drawdown_pct,
+                    min_return_pct=min_return_pct,
+                ),
             )
         )
 
     if include_stress:
         for j, scenario in enumerate(STRESS_SCENARIOS):
+            path_seed = seed + 100 + j
             candles = generate_stress_path(
                 scenario,
                 n_bars=n_bars,
                 start_price=start_price,
-                seed=seed + 100 + j,
+                seed=path_seed,
                 symbol=path_symbol,
                 timeframe=path_timeframe,
                 start_time=path_start,
             )
             settlements = _settlements_for(config, candles, warmup_bars, scenario)
             result = await _run_path(config, candles, warmup_bars, settlements=settlements)
-            outcomes.append(
-                score_path(
-                    [trade.return_pct for trade in result.trades],
+            records.append(
+                _path_record(
+                    name=scenario,
                     kind="stress",
-                    max_drawdown_pct=max_drawdown_pct,
-                    min_return_pct=min_return_pct,
+                    seed=path_seed,
+                    result=result,
+                    passed=score_engine_result(
+                        result,
+                        kind="stress",
+                        max_drawdown_pct=max_drawdown_pct,
+                        min_return_pct=min_return_pct,
+                    ),
                 )
             )
 
-    return _rate_from_outcomes(outcomes)
+    rated = _rate_from_named(records)
+    runtime = runtime_bound_evidence(
+        seed=seed,
+        symbol=path_symbol,
+        timeframe=path_timeframe,
+        start_time=path_start,
+        params=params,
+    )
+    return replace(
+        rated,
+        fit=fit_record,
+        seed=seed,
+        eval_bars_used=eval_bars,
+        runtime=runtime,
+    )
 
 
 async def maybe_evaluate_synthetic_pass_rate(
@@ -236,6 +488,10 @@ async def maybe_evaluate_synthetic_pass_rate(
     regime_params: RegimeParams | None = None,
     max_drawdown_pct: float = 10.0,
     min_return_pct: float = 0.0,
+    fit_start: str | None = None,
+    fit_end: str | None = None,
+    fit_closes: Sequence[float] | None = None,
+    fit_rows: Sequence[Mapping[str, object]] | None = None,
 ) -> SyntheticEvalResult:
     """Skip path generation when the synthetic gate is disabled."""
     if not enabled:
@@ -253,4 +509,9 @@ async def maybe_evaluate_synthetic_pass_rate(
         regime_params=regime_params,
         max_drawdown_pct=max_drawdown_pct,
         min_return_pct=min_return_pct,
+        fit_start=fit_start,
+        fit_end=fit_end,
+        fit_closes=fit_closes,
+        fit_rows=fit_rows,
+        require_fit=True,
     )

--- a/tests/test_synthetic_eval.py
+++ b/tests/test_synthetic_eval.py
@@ -2,25 +2,31 @@ from __future__ import annotations
 
 import inspect
 from collections.abc import Mapping
+from decimal import Decimal
 from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from src.backtest.artifacts import fingerprint_rows
 from src.backtest.engine import BacktestEngine
 from src.backtest.experiment_autopilot import ExperimentSummary, GateConfig, evaluate_gates
-from src.backtest.models import BacktestConfig
-from src.backtest.synthetic import generate_regime_path, generate_stress_path
+from src.backtest.models import BacktestConfig, BacktestResult
+from src.backtest.synthetic import fit_two_state_regime, generate_regime_path, generate_stress_path
 from src.backtest.synthetic_eval import (
     DEFAULT_REGIME_PARAMS,
     MAX_EVAL_BARS,
     MIN_EVAL_BARS,
     SyntheticEvalResult,
+    SyntheticPathRecord,
+    _rate_from_named,
     _rate_from_outcomes,
     _run_path,
+    decimal_close_returns,
     eval_bars_from_trade_rate,
     evaluate_synthetic_pass_rate,
     maybe_evaluate_synthetic_pass_rate,
+    score_engine_result,
     score_path,
 )
 from src.backtest.synthetic_reader import (
@@ -302,3 +308,184 @@ def test_cli_has_no_synthetic_threshold() -> None:
     assert "--min-synthetic" not in autopilot
     construction = inspect.getsource(_gate_config_from_profile)
     assert "min_synthetic_pass_rate" not in construction
+
+
+def _engine_result(
+    *,
+    total_trades: int,
+    total_return_pct: float,
+    max_drawdown: float,
+) -> BacktestResult:
+    return BacktestResult(
+        total_return=0.0,
+        total_return_pct=total_return_pct,
+        max_drawdown=max_drawdown,
+        win_rate=0.0,
+        total_trades=total_trades,
+        trades=[],
+        final_equity=10000.0,
+        sharpe_ratio=0.0,
+        sortino_ratio=0.0,
+        profit_factor=0.0,
+        avg_win_loss_ratio=0.0,
+    )
+
+
+def _named_path(
+    *,
+    name: str,
+    kind: str,
+    outcome: str,
+    seed: int = 0,
+) -> SyntheticPathRecord:
+    return SyntheticPathRecord(
+        name=name,
+        kind=kind,
+        seed=seed,
+        trades=0 if outcome == "skip" else 1,
+        total_return_pct=1.0 if outcome == "pass" else -1.0,
+        max_drawdown_pct=1.0,
+        outcome=outcome,
+    )
+
+
+def test_decimal_close_returns() -> None:
+    assert decimal_close_returns([]) == []
+    assert decimal_close_returns([100.0]) == []
+    returns = decimal_close_returns([100, 110, 99])
+    assert returns[0] == 0.1
+    assert returns[1] == float(Decimal("99") / Decimal("110") - 1)
+    assert decimal_close_returns([0.0, 10.0]) == [0.0]
+
+
+def test_score_engine_regime_uses_total_return() -> None:
+    empty = _engine_result(total_trades=0, total_return_pct=5.0, max_drawdown=0.5)
+    assert score_engine_result(empty, kind="regime") is None
+    passed = score_engine_result(
+        _engine_result(total_trades=2, total_return_pct=1.0, max_drawdown=0.5),
+        kind="regime",
+    )
+    failed = score_engine_result(
+        _engine_result(total_trades=2, total_return_pct=-1.0, max_drawdown=0.01),
+        kind="regime",
+    )
+    assert passed is True
+    assert failed is False
+
+
+def test_score_engine_stress_uses_max_drawdown() -> None:
+    passed = score_engine_result(
+        _engine_result(total_trades=2, total_return_pct=-50.0, max_drawdown=0.05),
+        kind="stress",
+        max_drawdown_pct=10.0,
+    )
+    failed = score_engine_result(
+        _engine_result(total_trades=2, total_return_pct=50.0, max_drawdown=0.20),
+        kind="stress",
+        max_drawdown_pct=10.0,
+    )
+    assert passed is True
+    assert failed is False
+
+
+def test_separate_coverage_inconclusive() -> None:
+    records = [
+        _named_path(name="regime_0", kind="regime", outcome="pass"),
+        _named_path(name="regime_1", kind="regime", outcome="pass"),
+        _named_path(name="regime_2", kind="regime", outcome="pass"),
+    ]
+    result = _rate_from_named(records)
+    assert result.status == "inconclusive"
+    assert result.pass_rate_pct == 0.0
+    assert result.regime_scored == 3
+    assert result.stress_scored == 0
+    assert result.regime_pass_rate_pct == 100.0
+
+
+def test_separate_coverage_scored() -> None:
+    records = [
+        _named_path(name="regime_0", kind="regime", outcome="pass"),
+        _named_path(name="regime_1", kind="regime", outcome="pass"),
+        _named_path(name="march_2020_gap", kind="stress", outcome="pass"),
+        _named_path(name="funding_blowout", kind="stress", outcome="pass"),
+    ]
+    result = _rate_from_named(records)
+    assert result.status == "scored"
+    assert result.pass_rate_pct == 100.0
+    assert result.regime_scored == 2
+    assert result.stress_scored == 2
+
+
+async def test_evaluate_requires_fit_when_require_fit() -> None:
+    with pytest.raises(ValueError, match="require_fit"):
+        await evaluate_synthetic_pass_rate(_dummy_config(), require_fit=True)
+
+
+async def test_evaluate_fits_two_state() -> None:
+    fit_closes = [100.0, 100.2, 100.1, 99.8, 95.0, 93.5, 94.0, 100.5, 101.0]
+    result = await evaluate_synthetic_pass_rate(
+        _dummy_config(),
+        require_fit=True,
+        fit_start="2020-01-01T00:00:00+00:00",
+        fit_end="2020-06-01T00:00:00+00:00",
+        fit_closes=fit_closes,
+        eval_bars=80,
+        n_regime_paths=1,
+        include_stress=False,
+    )
+    assert result.status == "inconclusive"
+    assert result.fit is not None
+    expected = fit_two_state_regime(decimal_close_returns(fit_closes))
+    assert result.fit.params["mu_calm"] == expected.mu_calm
+    assert result.fit.params["sigma_calm"] == expected.sigma_calm
+    assert result.fit.params["mu_stress"] == expected.mu_stress
+    assert result.fit.params["sigma_stress"] == expected.sigma_stress
+    assert result.fit.params["p_calm_to_stress"] == expected.p_calm_to_stress
+    assert result.fit.params["p_stress_to_calm"] == expected.p_stress_to_calm
+    assert result.fit.params["p_start_stress"] == expected.p_start_stress
+    assert result.fit.row_fingerprint == fingerprint_rows(
+        [{"close": close} for close in fit_closes]
+    )
+    assert result.fit.fit_start == "2020-01-01T00:00:00+00:00"
+    assert result.fit.fit_end == "2020-06-01T00:00:00+00:00"
+
+
+async def test_runtime_evidence_records_bounds() -> None:
+    result = await evaluate_synthetic_pass_rate(
+        _dummy_config(),
+        require_fit=True,
+        fit_start="2020-01-01T00:00:00+00:00",
+        fit_end="2020-06-01T00:00:00+00:00",
+        fit_closes=[100.0, 101.0, 99.0, 102.0, 90.0, 91.0],
+        eval_bars=80,
+        n_regime_paths=1,
+        include_stress=False,
+    )
+    assert result.runtime is not None
+    assert result.runtime.min_eval_bars == MIN_EVAL_BARS
+    assert result.runtime.max_eval_bars == MAX_EVAL_BARS
+    assert result.runtime.min_eval_bars == 480
+    assert result.runtime.max_eval_bars == 4000
+    assert result.runtime.generate_min_ms >= 0.0
+    assert result.runtime.generate_max_ms >= 0.0
+
+
+def test_diagnostic_does_not_affect_passes_gates() -> None:
+    scored_zero = _passing_summary(
+        synthetic_eval_status="scored",
+        synthetic_pass_rate_pct=0,
+    )
+    failures = evaluate_gates(scored_zero, GateConfig())
+    assert not any("min_synthetic" in reason for reason in failures)
+
+    passing = _passing_summary()
+    passing_failures = evaluate_gates(passing, GateConfig())
+    assert passing_failures == []
+    assert not any("min_synthetic" in reason for reason in passing_failures)
+
+
+def test_cli_has_synthetic_diagnostic_not_threshold() -> None:
+    autopilot = Path("scripts/experiment_autopilot.py").read_text(encoding="utf-8")
+    assert "--synthetic-diagnostic" in autopilot
+    assert "--synthetic-fit-start" in autopilot
+    assert "--min-synthetic" not in autopilot


### PR DESCRIPTION
## Summary

Diagnostic evidence contract for Gate 4b. It records evidence; it does not promote.

- `--synthetic-diagnostic` plus frozen `--synthetic-fit-start` / `--synthetic-fit-end` (required together).
- Fetches exact fit rows, computes Decimal close returns, calls `fit_two_state_regime()`.
- JSON audit persists fit bounds, row fingerprint, fitted params, seed, path definitions, and named per-path engine metrics.
- Regime paths score `BacktestResult.total_return_pct`. Stress paths score engine `max_drawdown` (not reconstructed trade returns).
- Coverage is split: at least 2 scored regime **and** 2 scored stress. One class cannot satisfy the other.
- Runtime evidence records generation time at 480 and 4,000 bars.
- `min_synthetic_pass_rate_pct` stays 0.0 and off CLI/autoresearch. Diagnostic never affects `passes_gates`.

## Type of Change

- [x] New feature
- [x] Tests
- [x] Documentation update

## Testing

- [x] `uv run pytest -v` — 1290 passed
- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`

## Checklist

- [x] No threshold CLI
- [x] Diagnostic does not change `evaluate_gates` when threshold is 0.0
- [x] Fit range is explicit, not derived after seeing results

## After this merges

Calibration charter must freeze controls **before** any run. If no defensible positive control exists, record INCONCLUSIVE — do not invent one.