### PR TITLE
feat: harden Sep-4 NFP pre-capture

### DIFF
--- a/docs/evidence_portfolio/DAY30_REVIEW.md
+++ b/docs/evidence_portfolio/DAY30_REVIEW.md
@@ -1,11 +1,11 @@
 # Day-30 Portfolio Review — 2026-08-06 (template, pre-drafted 2026-07-21)
 
-**Status:** DRAFT until ratified on or about 2026-08-06
+**Status:** DRAFT — NFP row refreshed 2026-08-13; awaiting human ratification
 **Purpose:** close the 30-day evidence portfolio (2026-07-07 → ~2026-08-06) with a
 15-minute ratification. All track verdicts are already determinate; blanks below are
 for anything that changes between drafting and review day.
 
-## Track outcomes (as of drafting, 2026-07-21)
+## Track outcomes (refreshed 2026-08-13; originally drafted 2026-07-21)
 
 | Track | Verdict | Evidence |
 |-------|---------|----------|
@@ -13,7 +13,7 @@ for anything that changes between drafting and review day.
 | Edge probe #2 (fee-marginal) | **DELETED_NOT_NAMED** (2026-07-09) | `FEE_MARGINAL_PREREG.md` — no eligible family; budget slot consumed, not replaced |
 | A1 incentive farming | **CLOSED, no Scale** (2026-07-14) | `A1_THRESHOLD_LOCK.md` — Legion = weekly watch only; galxe → controls; tick timer disabled |
 | cTrader FX (external) | _[fill at review: challenge status vs `CTRADER_EXTERNAL_GATE.md`]_ | external repo |
-| NFP forward gate | **SIGNED, in force** (2026-07-21) | `NFP_FORWARD_GATE.md`, PR #155 — first clean print 2026-08-07 |
+| NFP forward gate | **SIGNED, in force** (2026-07-21) | `NFP_FORWARD_GATE.md`, PR #155 — first print 2026-08-07 = `MISSED_CAPTURE` (1/3); booked in `data/macro_events/nfp_good_news_forward.csv` (commit `6860d13`). Next print 2026-09-04. |
 
 ## Kill-gate check
 

--- a/docs/specs/nfp-forward-capture-routine.md
+++ b/docs/specs/nfp-forward-capture-routine.md
@@ -25,13 +25,18 @@
 ## Suggested implementation (small)
 
 - `scripts/nfp_forward_capture.py` with two subcommands:
-  - `pre` — POST/GET `https://web.archive.org/save/https://www.investing.com/economic-calendar/nonfarm-payrolls-227`,
-    verify the snapshot resolves and its "Latest Release" date is the *previous*
-    release (i.e., the page predates the upcoming print), print the snapshot URL, and
-    stash it in `research/nfp_forward/pending_capture.json`.
+  - `pre` — GET `https://web.archive.org/save/...` with bounded retries (transient
+    network failures such as `ECONNRESET`), verify the snapshot resolves and its
+    "Latest Release" date is the *previous* release (i.e., the page predates the
+    upcoming print), print the snapshot URL, and stash it in
+    `research/nfp_forward/pending_capture.json`. If Save Page Now still fails,
+    capture a PIT mirror manually and pass `--snapshot-url <url>` (Wayback or
+    archive.ph); verification still runs.
   - `post --actual <n> --consensus <n>` — validate against the pending snapshot,
     compute surprise/z (full float precision — the OOS loader rejects rounded z),
     append the CSV row, clear the pending file.
+- Per-print checklist + portable runner under `research/nfp_forward/`
+  (`CHECKLIST_YYYY-MM-DD.md`, `run_pre_YYYY-MM-DD.sh`).
 - Reuse the validation logic pattern from
   `scripts/probe_nfp_good_news_oos.py::load_surprises` for self-checks.
 - No cron/systemd automation of the *decision*; scheduling the `pre` call before each

--- a/research/nfp_forward/CHECKLIST_2026-09-04.md
+++ b/research/nfp_forward/CHECKLIST_2026-09-04.md
@@ -1,0 +1,56 @@
+# NFP forward capture — 2026-09-04
+
+**Gate:** `docs/evidence_portfolio/NFP_FORWARD_GATE.md`
+**Tool:** `scripts/nfp_forward_capture.py`
+**Prior:** 2026-08-07 booked as `NFP_MISSED_CAPTURE` (1 of 3) after Wayback SPN
+`Connection reset by peer`. Capture tool now retries SPN and accepts `--snapshot-url`.
+
+## Verify before the window (human)
+
+- [ ] BLS Employment Situation schedule confirms **Friday, September 4, 2026, 08:30 ET**
+  (12:30 UTC): https://www.bls.gov/schedule/news_release/empsit.htm
+- [ ] Investing.com NFP page lists **Sep 04, 2026** (or equivalent).
+- [ ] Smoke-test Wayback Save Page Now *before* the window (or have archive.ph /
+  manual SPN ready for `--snapshot-url`).
+- Capture window: **2026-09-03T12:30:00Z → 2026-09-04T12:30:00Z**.
+
+## Automated pre
+
+- Runner: `research/nfp_forward/run_pre_2026-09-04.sh`
+- Target fire: **2026-09-03 12:32 UTC** (2 min after window open)
+- Log: `research/nfp_forward/pre-2026-09-04.log`
+- Pending stash (after success): `research/nfp_forward/pending_capture.json`
+
+If SPN still fails after retries, capture a PIT mirror manually (Wayback UI or
+archive.ph), then:
+
+```bash
+uv run python scripts/nfp_forward_capture.py pre \
+  --release-date 2026-09-04 \
+  --snapshot-url '<frozen-url>'
+```
+
+## Human after release (2026-09-04 ~12:30 UTC+)
+
+1. Open the snapshot URL from pending JSON.
+2. Read **consensus** (forecast) from that frozen page.
+3. Read **actual** headline NFP change (thousands) from BLS Employment Situation.
+4. Run:
+
+```bash
+uv run python scripts/nfp_forward_capture.py post \
+  --actual <n> \
+  --consensus <n>
+```
+
+5. Commit the new row in `data/macro_events/nfp_good_news_forward.csv` when ready.
+
+## If pre fails / missed
+
+```bash
+uv run python scripts/nfp_forward_capture.py miss \
+  --release-date 2026-09-04 \
+  --note 'reason'
+```
+
+Three misses cap the sample — do not use miss lightly. Current budget used: **1/3**.

--- a/research/nfp_forward/run_pre_2026-09-04.sh
+++ b/research/nfp_forward/run_pre_2026-09-04.sh
@@ -1,17 +1,16 @@
 #!/usr/bin/env bash
-# Gate-compliant NFP pre-capture for 2026-08-07 print.
-# Only valid inside 2026-08-06 12:30 UTC → 2026-08-07 12:30 UTC.
-# Window is closed; kept as the failure artifact + template for later prints.
+# Gate-compliant NFP pre-capture for 2026-09-04 print.
+# Only valid inside 2026-09-03 12:30 UTC → 2026-09-04 12:30 UTC.
 set -euo pipefail
 REPO="$(cd "$(dirname "$0")/../.." && pwd)"
 LOG_DIR="$REPO/research/nfp_forward"
-LOG="$LOG_DIR/pre-2026-08-07.log"
+LOG="$LOG_DIR/pre-2026-09-04.log"
 cd "$REPO"
 {
   echo "=== NFP pre start $(date -u -Iseconds) ==="
   uv run python scripts/nfp_forward_capture.py status
   set +e
-  uv run python scripts/nfp_forward_capture.py pre --release-date 2026-08-07
+  uv run python scripts/nfp_forward_capture.py pre --release-date 2026-09-04
   pre_rc=$?
   set -e
   echo "=== NFP pre exit ${pre_rc} at $(date -u -Iseconds) ==="

--- a/scripts/nfp_forward_capture.py
+++ b/scripts/nfp_forward_capture.py
@@ -27,6 +27,7 @@ import csv
 import json
 import re
 import sys
+import time
 from dataclasses import dataclass
 from datetime import UTC, date, datetime, timedelta
 from pathlib import Path
@@ -75,6 +76,9 @@ DEFAULT_PENDING_JSON = Path("research/nfp_forward/pending_capture.json")
 USER_AGENT = "crypto-agent-nfp-forward-capture/1.0 (research; read-only)"
 SAVE_TIMEOUT_SECONDS = 180.0
 FETCH_TIMEOUT_SECONDS = 60.0
+SAVE_MAX_ATTEMPTS = 3
+# Delays after attempt 1 and 2 (Aug-7 miss was a single ECONNRESET with no retry).
+SAVE_RETRY_DELAYS_SECONDS = (2.0, 5.0)
 
 
 class CaptureError(RuntimeError):
@@ -201,6 +205,32 @@ def _http_get(url: str, timeout: float) -> httpx.Response:
         return client.get(url)
 
 
+def _http_get_with_retries(
+    url: str,
+    timeout: float,
+    *,
+    attempts: int = SAVE_MAX_ATTEMPTS,
+    label: str = "request",
+) -> httpx.Response:
+    """GET with bounded retries for transient network failures (e.g. ECONNRESET)."""
+    last_exc: httpx.HTTPError | None = None
+    for attempt in range(attempts):
+        try:
+            return _http_get(url, timeout)
+        except httpx.HTTPError as exc:
+            last_exc = exc
+            if attempt >= attempts - 1:
+                break
+            delay = SAVE_RETRY_DELAYS_SECONDS[min(attempt, len(SAVE_RETRY_DELAYS_SECONDS) - 1)]
+            print(
+                f"[pre] {label} failed (attempt {attempt + 1}/{attempts}): {exc}; "
+                f"retrying in {delay:.0f}s"
+            )
+            time.sleep(delay)
+    assert last_exc is not None
+    raise last_exc
+
+
 def _snapshot_url_from_response(response: httpx.Response) -> str:
     candidates = [str(response.url)]
     content_location = response.headers.get("content-location")
@@ -221,6 +251,19 @@ def snapshot_timestamp(snapshot_url: str) -> datetime:
     if match is None:
         raise CaptureError(f"cannot read a Wayback timestamp from {snapshot_url!r}")
     return datetime.strptime(match.group(1), "%Y%m%d%H%M%S").replace(tzinfo=UTC)
+
+
+def resolve_snapshot_timestamp(snapshot_url: str, *, captured_at: datetime) -> datetime:
+    """Wayback URLs yield the archive timestamp; other PIT URLs use capture time."""
+    if SNAPSHOT_TS_RE.search(snapshot_url):
+        return snapshot_timestamp(snapshot_url)
+    if not snapshot_url.startswith(("http://", "https://")):
+        raise CaptureError(f"snapshot URL must be http(s): {snapshot_url!r}")
+    print(
+        "[pre] snapshot URL is not a Wayback /web/<ts>/ URL; "
+        f"using capture time {captured_at.strftime('%Y-%m-%dT%H:%M:%SZ')} as snapshot timestamp"
+    )
+    return captured_at.astimezone(UTC)
 
 
 def read_pending(path: Path) -> PendingCapture | None:
@@ -336,21 +379,40 @@ def cmd_pre(args: argparse.Namespace) -> int:
             "run `post` (or `miss`) first, or pass --force to replace it"
         )
 
-    print(f"[pre] requesting Wayback Save Page Now for {CONSENSUS_URL}")
-    response = _http_get(WAYBACK_SAVE_URL, SAVE_TIMEOUT_SECONDS)
-    snapshot_url = _snapshot_url_from_response(response)
-    snapshot_ts = snapshot_timestamp(snapshot_url)
-    print(f"[pre] snapshot: {snapshot_url}")
+    body = ""
+    if args.snapshot_url:
+        snapshot_url = str(args.snapshot_url).strip()
+        print("[pre] using manual --snapshot-url (skipped Wayback Save Page Now)")
+        print(f"[pre] snapshot: {snapshot_url}")
+        snapshot_ts = resolve_snapshot_timestamp(snapshot_url, captured_at=now)
+        body = _http_get_with_retries(
+            snapshot_url,
+            FETCH_TIMEOUT_SECONDS,
+            label="snapshot fetch",
+        ).text
+    else:
+        print(f"[pre] requesting Wayback Save Page Now for {CONSENSUS_URL}")
+        response = _http_get_with_retries(
+            WAYBACK_SAVE_URL,
+            SAVE_TIMEOUT_SECONDS,
+            label="Wayback Save Page Now",
+        )
+        snapshot_url = _snapshot_url_from_response(response)
+        snapshot_ts = resolve_snapshot_timestamp(snapshot_url, captured_at=now)
+        print(f"[pre] snapshot: {snapshot_url}")
+        body = response.text
+        if not body.strip():
+            body = _http_get_with_retries(
+                snapshot_url,
+                FETCH_TIMEOUT_SECONDS,
+                label="snapshot fetch",
+            ).text
 
     if snapshot_ts >= release_ts:
         raise CaptureError(
             f"snapshot timestamp {snapshot_ts.isoformat()} is not before the release "
             f"{release_ts.isoformat()}"
         )
-
-    body = response.text
-    if not body.strip():
-        body = _http_get(snapshot_url, FETCH_TIMEOUT_SECONDS).text
 
     verified, detail = verify_snapshot_is_point_in_time(body, release_date)
     if verified:
@@ -484,6 +546,13 @@ def build_parser() -> argparse.ArgumentParser:
 
     pre = subparsers.add_parser("pre", help="freeze the pre-release consensus via Wayback")
     pre.add_argument("--release-date", help="ISO release date; defaults to the next first Friday")
+    pre.add_argument(
+        "--snapshot-url",
+        help=(
+            "skip Save Page Now and stash this already-captured PIT URL "
+            "(Wayback or archive.ph / manual mirror); still verifies the page"
+        ),
+    )
     pre.add_argument(
         "--allow-unverified", action="store_true", help="stash despite a failed page check"
     )

--- a/tests/test_nfp_forward_capture.py
+++ b/tests/test_nfp_forward_capture.py
@@ -9,6 +9,7 @@ import csv
 from datetime import UTC, date, datetime
 from pathlib import Path
 
+import httpx
 import pytest
 
 from scripts.nfp_forward_capture import (
@@ -25,6 +26,7 @@ from scripts.nfp_forward_capture import (
     page_mentions_date,
     previous_scheduled_release,
     release_timestamp_utc,
+    resolve_snapshot_timestamp,
     snapshot_timestamp,
     verify_snapshot_is_point_in_time,
 )
@@ -93,6 +95,58 @@ def test_snapshot_timestamp_parsed_from_wayback_url():
 def test_snapshot_timestamp_rejects_non_wayback_url():
     with pytest.raises(CaptureError):
         snapshot_timestamp("https://www.investing.com/economic-calendar/nonfarm-payrolls-227")
+
+
+def test_resolve_snapshot_timestamp_uses_wayback_ts_when_present():
+    url = "https://web.archive.org/web/20260903124500/https://www.investing.com/x"
+    captured = datetime(2026, 9, 3, 12, 50, tzinfo=UTC)
+    assert resolve_snapshot_timestamp(url, captured_at=captured) == datetime(
+        2026, 9, 3, 12, 45, tzinfo=UTC
+    )
+
+
+def test_resolve_snapshot_timestamp_falls_back_to_capture_time_for_manual_mirrors(
+    capsys: pytest.CaptureFixture[str],
+):
+    url = "https://archive.ph/abcd1234"
+    captured = datetime(2026, 9, 3, 13, 0, tzinfo=UTC)
+    assert resolve_snapshot_timestamp(url, captured_at=captured) == captured
+    assert "not a Wayback" in capsys.readouterr().out
+
+
+def test_http_get_with_retries_retries_then_succeeds(monkeypatch: pytest.MonkeyPatch):
+    from scripts import nfp_forward_capture as mod
+
+    calls = {"n": 0}
+
+    def flaky(_url: str, _timeout: float):
+        calls["n"] += 1
+        if calls["n"] < 3:
+            raise httpx.ConnectError("Connection reset by peer")
+        return httpx.Response(200, text="ok")
+
+    sleeps: list[float] = []
+    monkeypatch.setattr(mod, "_http_get", flaky)
+    monkeypatch.setattr(mod.time, "sleep", sleeps.append)
+
+    response = mod._http_get_with_retries("https://example.test", 1.0, label="Wayback")
+    assert response.text == "ok"
+    assert calls["n"] == 3
+    assert sleeps == [2.0, 5.0]
+
+
+def test_http_get_with_retries_raises_after_exhaustion(monkeypatch: pytest.MonkeyPatch):
+    from scripts import nfp_forward_capture as mod
+
+    monkeypatch.setattr(
+        mod,
+        "_http_get",
+        lambda _url, _timeout: (_ for _ in ()).throw(httpx.ConnectError("boom")),
+    )
+    monkeypatch.setattr(mod.time, "sleep", lambda _delay: None)
+
+    with pytest.raises(httpx.ConnectError, match="boom"):
+        mod._http_get_with_retries("https://example.test", 1.0, attempts=2)
 
 
 def test_build_row_keeps_full_float_precision():


### PR DESCRIPTION
## Summary

Split out of #162. NFP-only: harden pre-capture before the 2026-09-04 print.

- Wayback Save Page Now retries after the Aug-7 `ECONNRESET` miss
- `--snapshot-url` for a manual PIT mirror (Wayback / archive.ph)
- Portable Sep-4 runner + checklist
- Day-30 NFP row updated for booked `MISSED_CAPTURE` (1/3); `Ratified by:` left blank

Does **not** include ChatResult / DeepSeek attribution (separate PR).
Does **not** run `pre` — window opens 2026-09-03 12:30 UTC. Do not fire before then.

## Type of Change

- [x] Bug fix
- [x] Documentation update
- [x] Tests

## Testing

- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run pytest -v`
- [x] `docker build -f Dockerfile.prod` + `import src.main`

## Notes

- Locked gate docs (`NFP_FORWARD_GATE.md`) untouched.
- No live trading / settings changes.
- Supersedes the NFP half of #162.
