### PR TITLE
fix(overseer): attribute DeepSeek fallback in ChatResult

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -831,9 +831,16 @@ def _wire_optional_strategy_dependencies(
     async def _record_sentiment_observation(payload: dict[str, object]) -> None:
         if event_log is None:
             return
+        source = str(payload.get("source", ""))
+        if source == "deepseek_fallback":
+            provider = "deepseek"
+        elif source.startswith("xai") or source == "neutral_fallback":
+            provider = "xai" if xai_client is not None else "none"
+        else:
+            provider = "xai" if xai_client is not None else "none"
         enriched_payload = {
             **payload,
-            "provider": "xai" if xai_client is not None else "none",
+            "provider": provider,
             "model": ai_model,
         }
         await event_log.log("sentiment_score", enriched_payload)

--- a/src/overseer/__init__.py
+++ b/src/overseer/__init__.py
@@ -1,4 +1,4 @@
 from src.overseer.agent import OverseerAgent
-from src.overseer.xai import XAIClient
+from src.overseer.xai import ChatResult, XAIClient
 
-__all__ = ["OverseerAgent", "XAIClient"]
+__all__ = ["ChatResult", "OverseerAgent", "XAIClient"]

--- a/src/overseer/agent.py
+++ b/src/overseer/agent.py
@@ -272,11 +272,12 @@ class OverseerAgent:
         ]
 
         try:
-            answer = await self._xai_client.chat(messages)
+            result = await self._xai_client.chat(messages)
         except Exception as exc:
             self._logger.error("xAI request failed: %s", exc)
             return "AI request failed. Try again in a few seconds."
 
+        answer = result.content if hasattr(result, "content") else str(result)
         self._append_history(chat_id, "user", query)
         self._append_history(chat_id, "assistant", answer)
         return answer

--- a/src/overseer/xai.py
+++ b/src/overseer/xai.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Sequence
+from dataclasses import dataclass
 
 import openai
 from openai import AsyncOpenAI
@@ -14,7 +15,19 @@ _RETRYABLE_ERRORS = (
     openai.APIConnectionError,
     openai.APITimeoutError,
 )
+_AUTH_ERRORS = (
+    openai.AuthenticationError,
+    openai.PermissionDeniedError,
+)
 _MAX_ATTEMPTS = 3
+
+
+@dataclass(frozen=True)
+class ChatResult:
+    """LLM reply plus which provider actually answered."""
+
+    content: str
+    provider: str  # "xai" | "deepseek"
 
 
 class XAIClient:
@@ -45,24 +58,34 @@ class XAIClient:
             )
         self._logger = get_logger(self.__class__.__name__)
 
-    async def chat(self, messages: Sequence[dict[str, str]]) -> str:
+    async def chat(self, messages: Sequence[dict[str, str]]) -> ChatResult:
         try:
-            return await self._chat_with_client(
+            content = await self._chat_with_client(
                 self._client,
                 self._model,
                 messages,
                 provider_name="xAI",
             )
+            return ChatResult(content=content, provider="xai")
+        except _AUTH_ERRORS as exc:
+            if self._fallback_client is None:
+                raise
+            self._logger.warning(
+                "xAI auth/permission denied (%s); trying DeepSeek fallback",
+                exc,
+            )
         except Exception:
             if self._fallback_client is None:
                 raise
             self._logger.warning("xAI unavailable after retries; trying DeepSeek fallback")
-            return await self._chat_with_client(
-                self._fallback_client,
-                self._fallback_model,
-                messages,
-                provider_name="DeepSeek",
-            )
+
+        content = await self._chat_with_client(
+            self._fallback_client,
+            self._fallback_model,
+            messages,
+            provider_name="DeepSeek",
+        )
+        return ChatResult(content=content, provider="deepseek")
 
     async def _chat_with_client(
         self,

--- a/src/strategy/sentiment_mean_reversion.py
+++ b/src/strategy/sentiment_mean_reversion.py
@@ -79,9 +79,10 @@ class SentimentScorer:
             return score
 
         try:
-            score = await self._query_llm(symbol)
+            score, provider = await self._query_llm(symbol)
             self._cache[symbol] = (now, score)
-            await self._record_observation(symbol, score, source="xai_live")
+            source = "deepseek_fallback" if provider == "deepseek" else "xai_live"
+            await self._record_observation(symbol, score, source=source)
             return score
         except Exception as exc:
             self._logger.warning("Sentiment query failed for %s: %s", symbol, exc)
@@ -159,8 +160,12 @@ class SentimentScorer:
         except Exception as exc:  # noqa: BLE001
             self._logger.warning("Degradation alert failed: %s", exc)
 
-    async def _query_llm(self, symbol: str) -> float:
-        """Query xAI/Grok for sentiment analysis."""
+    async def _query_llm(self, symbol: str) -> tuple[float, str]:
+        """Query the configured LLM for sentiment analysis.
+
+        Returns ``(score, provider)`` where provider is ``xai`` or ``deepseek``.
+        Test doubles that return a bare string are treated as ``xai``.
+        """
         base_asset = symbol.replace("USDT", "").replace("BUSD", "")
         prompt = (
             f"Analyze the current market sentiment for {base_asset} ({symbol}) cryptocurrency. "
@@ -176,15 +181,21 @@ class SentimentScorer:
             {"role": "user", "content": prompt},
         ]
 
-        response = await self._xai_client.chat(messages)  # type: ignore[union-attr]
+        result = await self._xai_client.chat(messages)  # type: ignore[union-attr]
+        if hasattr(result, "content") and hasattr(result, "provider"):
+            response = str(result.content)
+            provider = str(result.provider)
+        else:
+            response = str(result)
+            provider = "xai"
 
         try:
             data = json.loads(response)
             score = float(data.get("score", 50))
-            return max(0.0, min(100.0, score))
+            return max(0.0, min(100.0, score)), provider
         except (json.JSONDecodeError, ValueError, TypeError):
             self._logger.warning("Could not parse sentiment response: %s", response[:200])
-            return 50.0
+            return 50.0, provider
 
 
 class SentimentMeanReversionStrategy(BaseStrategy):

--- a/tests/test_sentiment_mean_reversion.py
+++ b/tests/test_sentiment_mean_reversion.py
@@ -300,6 +300,39 @@ class TestSentimentScorer:
             }
         ]
 
+    @pytest.mark.asyncio
+    async def test_records_deepseek_fallback_when_provider_is_deepseek(self):
+        """DeepSeek answers must not be mislabeled as xai_live."""
+        from src.overseer.xai import ChatResult
+
+        class FallbackClient:
+            async def chat(self, messages):
+                return ChatResult(
+                    content='{"score": 55, "reason": "deepseek path"}',
+                    provider="deepseek",
+                )
+
+        observations: list[dict[str, object]] = []
+
+        async def recorder(payload: dict[str, object]) -> None:
+            observations.append(payload)
+
+        scorer = SentimentScorer(
+            xai_client=FallbackClient(),
+            observation_recorder=recorder,
+        )
+
+        score = await scorer.get_score("SOLUSDT")
+
+        assert score == 55.0
+        assert observations == [
+            {
+                "symbol": "SOLUSDT",
+                "score": 55.0,
+                "source": "deepseek_fallback",
+            }
+        ]
+
 
 class TestDegradationAlert:
     @pytest.mark.asyncio

--- a/tests/test_xai_client.py
+++ b/tests/test_xai_client.py
@@ -4,7 +4,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import openai
 import pytest
 
-from src.overseer.xai import XAIClient
+from src.overseer.xai import ChatResult, XAIClient
 
 
 def _make_completion(content: str) -> SimpleNamespace:
@@ -13,6 +13,13 @@ def _make_completion(content: str) -> SimpleNamespace:
 
 def _make_connection_error() -> openai.APIConnectionError:
     return openai.APIConnectionError(request=MagicMock())
+
+
+def _make_permission_denied() -> openai.PermissionDeniedError:
+    mock_response = MagicMock()
+    mock_response.status_code = 403
+    mock_response.headers = {}
+    return openai.PermissionDeniedError("forbidden", response=mock_response, body=None)
 
 
 @pytest.mark.asyncio
@@ -35,7 +42,7 @@ async def test_chat_returns_trimmed_content() -> None:
         messages=[{"role": "user", "content": "status?"}],
         temperature=0.2,
     )
-    assert response == "market regime stable"
+    assert response == ChatResult(content="market regime stable", provider="xai")
 
 
 @pytest.mark.asyncio
@@ -48,7 +55,10 @@ async def test_chat_returns_fallback_when_content_missing() -> None:
         client = XAIClient(api_key="test-key", model="grok-3")
         response = await client.chat([{"role": "user", "content": "status?"}])
 
-    assert response == "No response content returned by xAI API."
+    assert response == ChatResult(
+        content="No response content returned by xAI API.",
+        provider="xai",
+    )
 
 
 @pytest.mark.asyncio
@@ -62,7 +72,7 @@ async def test_chat_retries_on_transient_error_then_succeeds() -> None:
             client = XAIClient(api_key="test-key", model="grok-3")
             response = await client.chat([{"role": "user", "content": "ping"}])
 
-    assert response == "recovered"
+    assert response == ChatResult(content="recovered", provider="xai")
     assert create.await_count == 2
     mock_sleep.assert_awaited_once_with(1)  # 2**0 = 1s after first failure
 
@@ -115,7 +125,7 @@ async def test_chat_uses_fallback_provider_after_xai_retries_exhausted() -> None
             )
             response = await client.chat([{"role": "user", "content": "ping"}])
 
-    assert response == "fallback-ok"
+    assert response == ChatResult(content="fallback-ok", provider="deepseek")
     assert primary_create.await_count == 3
     fallback_create.assert_awaited_once()
     assert mock_openai.call_count == 2
@@ -140,4 +150,34 @@ async def test_chat_does_not_retry_on_auth_error() -> None:
                 await client.chat([{"role": "user", "content": "ping"}])
 
     assert create.await_count == 1
+    mock_sleep.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_chat_falls_back_on_permission_denied_without_retry() -> None:
+    """403 PermissionDenied is not retried; DeepSeek fallback is used when configured."""
+    primary_create = AsyncMock(side_effect=_make_permission_denied())
+    primary_client = SimpleNamespace(
+        chat=SimpleNamespace(completions=SimpleNamespace(create=primary_create))
+    )
+    fallback_create = AsyncMock(return_value=_make_completion("deepseek-ok"))
+    fallback_client = SimpleNamespace(
+        chat=SimpleNamespace(completions=SimpleNamespace(create=fallback_create))
+    )
+
+    with patch(
+        "src.overseer.xai.AsyncOpenAI",
+        side_effect=[primary_client, fallback_client],
+    ):
+        with patch("src.overseer.xai.asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+            client = XAIClient(
+                api_key="xai-key",
+                model="grok-3",
+                fallback_api_key="deepseek-key",
+            )
+            response = await client.chat([{"role": "user", "content": "ping"}])
+
+    assert response == ChatResult(content="deepseek-ok", provider="deepseek")
+    assert primary_create.await_count == 1
+    fallback_create.assert_awaited_once()
     mock_sleep.assert_not_awaited()


### PR DESCRIPTION
## Summary

Split out of #162. Production-path change — **do not merge with the NFP capture PR**. Deployment approval stays separate.

- `XAIClient.chat` returns `ChatResult` (`content`, `provider`)
- DeepSeek answers record as `deepseek_fallback` / `provider=deepseek`, not `xai_live`
- 403 `PermissionDenied` is logged distinctly and is not retried; fallback is used when configured
- Overseer `/ask` and sentiment observation labeling unpack `ChatResult`; string test-doubles still work via `hasattr`

## Type of Change

- [x] Bug fix
- [x] Tests

## Testing

- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run pytest -v`

## Deploy notes

This is an API/runtime change on the sentiment-macro recording path. Review compatibility independently. Do not ship with the NFP capture PR. No settings.yaml live-path changes.

## Notes

- Supersedes the XAI half of #162.
- No NFP / capture files.
