### PR TITLE
ci(deploy): require manual dispatch with pinned main SHA

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,17 +1,32 @@
 name: Deploy
 
 on:
-  workflow_run:
-    workflows: ["CI"]
-    types: [completed]
-    branches: [main]
+  workflow_dispatch:
+    inputs:
+      deploy_sha:
+        description: Exact 40-character lowercase SHA of current origin/main
+        required: true
+        type: string
 
 jobs:
   deploy:
     name: Deploy to Production
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
+    environment: production
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: main
+
+      - name: Validate deploy_sha equals origin/main
+        env:
+          DEPLOY_SHA: ${{ inputs.deploy_sha }}
+        run: |
+          git fetch origin main
+          python3 scripts/validate_deploy_sha.py "$DEPLOY_SHA" "$(git rev-parse origin/main)"
+
       - name: Connect to Tailscale
         uses: tailscale/github-action@306e68a486fd2350f2bfc3b19fcd143891a4a2d8 # v4.1.2
         with:
@@ -25,6 +40,7 @@ jobs:
         env:
           SSH_HOST: ${{ secrets.HETZNER_TAILSCALE_HOST }}
           SSH_KEY: ${{ secrets.HETZNER_SSH_KEY }}
+          DEPLOY_SHA: ${{ inputs.deploy_sha }}
         run: |
           mkdir -p ~/.ssh
           echo "$SSH_KEY" > ~/.ssh/id_ed25519
@@ -35,10 +51,11 @@ jobs:
           tailscale ping --timeout 10s "$SSH_HOST" || { echo "Tailscale cannot reach $SSH_HOST — check HETZNER_TAILSCALE_HOST secret and server Tailscale status"; exit 1; }
 
           # NOTE: the heredoc delimiter is quoted ('DEPLOY'), so the body runs
-          # verbatim on the remote host — no $ expansion on the runner. Capture
-          # remote stdout on the runner so we can forward the result to a step
-          # output for the Telegram message.
-          DEPLOY_LOG=$(ssh -o StrictHostKeyChecking=no -o ConnectTimeout=30 root@$SSH_HOST << 'DEPLOY'
+          # verbatim on the remote host — no $ expansion on the runner. The
+          # requested SHA is passed as REQUESTED_SHA on the remote command line
+          # (validated as 40 lowercase hex before this step).
+          DEPLOY_LOG=$(ssh -o StrictHostKeyChecking=no -o ConnectTimeout=30 \
+            root@$SSH_HOST "REQUESTED_SHA=$DEPLOY_SHA bash -s" << 'DEPLOY'
           set -eo pipefail
           cd /opt/crypto-agent
 
@@ -47,11 +64,15 @@ jobs:
           git fetch origin main
           git pull --ff-only origin main
 
-          # 2) Assert we actually landed on the expected commit.
+          # 2) Assert we landed on the explicitly requested SHA and on origin/main.
           LOCAL=$(git rev-parse HEAD)
           REMOTE=$(git rev-parse origin/main)
           if [ "$LOCAL" != "$REMOTE" ]; then
             echo "ERROR: after pull, HEAD ($LOCAL) != origin/main ($REMOTE)"
+            exit 1
+          fi
+          if [ "$LOCAL" != "$REQUESTED_SHA" ]; then
+            echo "ERROR: after pull, HEAD ($LOCAL) != requested deploy_sha ($REQUESTED_SHA)"
             exit 1
           fi
 
@@ -108,7 +129,7 @@ jobs:
           message: |
             ✅ Deployment Successful!
             Repo: ${{ github.repository }}
-            Commit: ${{ github.event.workflow_run.head_sha }}
+            Requested SHA: ${{ inputs.deploy_sha }}
             Agents healthy: ${{ steps.deploy.outputs.services }}
 
       - name: Send Telegram Notification on Failure
@@ -120,5 +141,5 @@ jobs:
           message: |
             ❌ Deployment Failed!
             Repo: ${{ github.repository }}
-            Commit: ${{ github.event.workflow_run.head_sha }}
+            Requested SHA: ${{ inputs.deploy_sha }}
             Check GitHub Actions logs. Production may be in a partial state — verify with: docker compose -f docker-compose.prod.yml ps

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -50,68 +50,14 @@ jobs:
           echo "Pinging $SSH_HOST via Tailscale..."
           tailscale ping --timeout 10s "$SSH_HOST" || { echo "Tailscale cannot reach $SSH_HOST — check HETZNER_TAILSCALE_HOST secret and server Tailscale status"; exit 1; }
 
-          # NOTE: the heredoc delimiter is quoted ('DEPLOY'), so the body runs
-          # verbatim on the remote host — no $ expansion on the runner. The
-          # requested SHA is passed as REQUESTED_SHA on the remote command line
-          # (validated as 40 lowercase hex before this step).
-          DEPLOY_LOG=$(ssh -o StrictHostKeyChecking=no -o ConnectTimeout=30 \
-            root@$SSH_HOST "REQUESTED_SHA=$DEPLOY_SHA bash -s" << 'DEPLOY'
-          set -eo pipefail
-          cd /opt/crypto-agent
-
-          # 1) Sync code. --ff-only refuses to clobber server-side hotfixes; if it
-          #    fails, stop and surface the divergence instead of deploying stale code.
-          git fetch origin main
-          git pull --ff-only origin main
-
-          # 2) Assert we landed on the explicitly requested SHA and on origin/main.
-          LOCAL=$(git rev-parse HEAD)
-          REMOTE=$(git rev-parse origin/main)
-          if [ "$LOCAL" != "$REMOTE" ]; then
-            echo "ERROR: after pull, HEAD ($LOCAL) != origin/main ($REMOTE)"
-            exit 1
-          fi
-          if [ "$LOCAL" != "$REQUESTED_SHA" ]; then
-            echo "ERROR: after pull, HEAD ($LOCAL) != requested deploy_sha ($REQUESTED_SHA)"
-            exit 1
-          fi
-
-          # 3) Derive the agent service set dynamically so new/removed agents are
-          #    picked up without editing this workflow (the prior hardcoded list
-          #    still named agent_avax long after it was removed).
-          AGENTS=$(docker compose -f docker-compose.prod.yml config --services | grep '^agent_' | sort | tr '\n' ' ')
-          if [ -z "$AGENTS" ]; then
-            echo "ERROR: no agent_* services found in docker-compose.prod.yml"
-            exit 1
-          fi
-          echo "Deploying agents: $AGENTS"
-
-          # 4) Rebuild THEN roll. A plain restart will not pick up code/config
-          #    changes baked into Dockerfile.prod (per AGENTS.md).
-          docker compose -f docker-compose.prod.yml build $AGENTS
-          docker compose -f docker-compose.prod.yml up -d --remove-orphans $AGENTS
-
-          # 5) Wait for healthchecks to settle, then require EVERY agent to be
-          #    "(healthy)". This catches unhealthy, restarting, exited, and
-          #    still-starting containers — the old check only matched the literal
-          #    string "unhealthy" and would pass a crash loop.
-          sleep 120
-          NOT_READY=$(docker compose -f docker-compose.prod.yml ps --format "{{.Service}} {{.Status}}" $AGENTS | grep -vE '\(healthy\)$' || true)
-          if [ -n "$NOT_READY" ]; then
-            echo "ERROR: agents not healthy after 120s:"
-            echo "$NOT_READY"
-            docker compose -f docker-compose.prod.yml ps $AGENTS
-            exit 1
-          fi
-
-          docker image prune -f
-
-          # 6) Report the healthy agent list back to the runner (sorted,
-          #    comma-joined) so the Telegram message reflects what actually
-          #    deployed instead of a hardcoded string.
-          HEALTHY=$(echo "$AGENTS" | tr ' ' '\n' | grep . | sort | paste -sd, -)
-          echo "deploy_services=$HEALTHY"
-          DEPLOY
+          # Scripts are piped from this runner checkout so a stale server tree
+          # cannot skip the pre-pull SHA check. REQUESTED_SHA is 40-hex already.
+          DEPLOY_LOG=$(
+            {
+              cat scripts/align_prod_checkout.sh
+              cat scripts/rebuild_prod_agents.sh
+            } | ssh -o StrictHostKeyChecking=no -o ConnectTimeout=30 \
+              root@$SSH_HOST "REQUESTED_SHA=$DEPLOY_SHA bash -s"
           )
 
           # Surface the full remote log in the Actions UI, then forward the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,22 +44,28 @@ echo "$SHA"   # 40 lowercase hex chars
 # Manual production deploy (GitHub Actions, environment: production)
 gh workflow run Deploy --ref main -f deploy_sha="$SHA"
 
-# Emergency SSH path (same rebuild+health rules as the workflow; still not auto)
-ssh crypto-agent "cd /opt/crypto-agent && git pull"
-ssh crypto-agent "cd /opt/crypto-agent && docker compose -f docker-compose.prod.yml build <service>"
-ssh crypto-agent "cd /opt/crypto-agent && docker compose -f docker-compose.prod.yml up -d <service>"
-
-# Active strategy services in prod right now:
-# - agent_sol_1h_trend_pullback_overlay_live  (only deployable technical agent)
-# - agent_sentiment_macro
-# - agent_sol_sparse                          (paper)
-# - agent_sol_panic_block_paper               (paper)
-
-# WRONG — this is the dev command, NOT production:
-ssh crypto-agent "cd /opt/crypto-agent && git pull && docker compose up -d --build agent"
-
-# Check logs
+# Check logs (read-only; not a deploy)
 ssh crypto-agent "cd /opt/crypto-agent && docker compose -f docker-compose.prod.yml logs <service> --tail=100 --no-log-prefix"
+```
+
+**Break-glass SSH** (GitHub Actions unavailable only). Same contract as the workflow:
+pin SHA, abort before pull on mismatch, rebuild **all** `agent_*` via
+`docker-compose.prod.yml`, wait 120s, fail closed unless every agent is healthy.
+Do not build a single service. Do not use `docker-compose.yml`.
+
+```bash
+git fetch origin main
+SHA=$(git rev-parse origin/main)
+ssh crypto-agent "REQUESTED_SHA=$SHA DEPLOY_ROOT=/opt/crypto-agent bash -s" \
+  < scripts/align_prod_checkout.sh
+ssh crypto-agent 'set -euo pipefail
+cd /opt/crypto-agent
+AGENTS=$(docker compose -f docker-compose.prod.yml config --services | grep "^agent_" | sort | tr "\n" " ")
+docker compose -f docker-compose.prod.yml build $AGENTS
+docker compose -f docker-compose.prod.yml up -d --remove-orphans $AGENTS
+sleep 120
+NOT_READY=$(docker compose -f docker-compose.prod.yml ps --format "{{.Service}} {{.Status}}" $AGENTS | grep -vE "\(healthy\)$" || true)
+if [ -n "$NOT_READY" ]; then echo "$NOT_READY"; exit 1; fi'
 ```
 
 ## Architecture Surprises

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,8 +31,20 @@ uv run mypy src/
 
 Dev uses `docker-compose.yml` (bind-mounts `./:/app`, so live code changes take effect instantly). **Production uses `docker-compose.prod.yml`** (`Dockerfile.prod`), which bakes `src/` and `config/` into the image at build time. Code and config changes on the server do NOT affect the running agent until you rebuild.
 
+**Merging to `main` does not authorize or trigger a production deploy.** Deploy is a
+manual `workflow_dispatch` of `.github/workflows/deploy.yml` with the exact current
+`origin/main` SHA. CI success and documentation merges must not launch Deploy.
+
 ```bash
-# Production deploy (correct)
+# Required: pin the SHA you intend to ship (must equal origin/main right now)
+git fetch origin main
+SHA=$(git rev-parse origin/main)
+echo "$SHA"   # 40 lowercase hex chars
+
+# Manual production deploy (GitHub Actions, environment: production)
+gh workflow run Deploy --ref main -f deploy_sha="$SHA"
+
+# Emergency SSH path (same rebuild+health rules as the workflow; still not auto)
 ssh crypto-agent "cd /opt/crypto-agent && git pull"
 ssh crypto-agent "cd /opt/crypto-agent && docker compose -f docker-compose.prod.yml build <service>"
 ssh crypto-agent "cd /opt/crypto-agent && docker compose -f docker-compose.prod.yml up -d <service>"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -391,14 +391,12 @@ Config and code changes only take effect after an explicit build + up cycle.
 git fetch origin main
 SHA=$(git rev-parse origin/main)
 gh workflow run Deploy --ref main -f deploy_sha="$SHA"
-
-# Emergency SSH path (does not replace the approval gate)
-ssh crypto-agent "cd /opt/crypto-agent && git pull && docker compose -f docker-compose.prod.yml build agent && docker compose -f docker-compose.prod.yml up -d agent"
-
-# Verify
-ssh crypto-agent "docker compose -f docker-compose.prod.yml ps"
-ssh crypto-agent "docker compose -f docker-compose.prod.yml logs agent --tail=20"
 ```
+
+There is no single `agent` service. Production agents are the `agent_*` services
+in `docker-compose.prod.yml`. Break-glass SSH (Actions down only) must use
+`scripts/align_prod_checkout.sh` then rebuild **all** `agent_*` with a 120s
+all-healthy check — see `AGENTS.md`. Do not `docker compose up` the dev file.
 
 **Why prod compose?**
 - No `./:/app` bind mount — live code cannot be mutated by agents working in the repo

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -383,11 +383,16 @@ pytest
 bind mount. This means editing files on the server does NOT affect the running agent.
 Config and code changes only take effect after an explicit build + up cycle.
 
-```bash
-# On local machine
-git push origin main
+**Merging to `main` does not deploy.** Production Deploy requires a manual
+`workflow_dispatch` with `deploy_sha` equal to the current `origin/main` SHA
+(40 lowercase hex). A CI-green merge is not authorization.
 
-# On server
+```bash
+git fetch origin main
+SHA=$(git rev-parse origin/main)
+gh workflow run Deploy --ref main -f deploy_sha="$SHA"
+
+# Emergency SSH path (does not replace the approval gate)
 ssh crypto-agent "cd /opt/crypto-agent && git pull && docker compose -f docker-compose.prod.yml build agent && docker compose -f docker-compose.prod.yml up -d agent"
 
 # Verify

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,5 +1,18 @@
 # Production Deployment Runbook
 
+**Merging to `main` does not deploy.** Production updates go through the GitHub
+`Deploy` workflow (`.github/workflows/deploy.yml`), which is **manual only**:
+
+```bash
+git fetch origin main
+SHA=$(git rev-parse origin/main)
+gh workflow run Deploy --ref main -f deploy_sha="$SHA"
+```
+
+`deploy_sha` must be the exact 40-character lowercase SHA of current `origin/main`.
+Mismatch or a non-hex SHA fails closed. The job uses `environment: production`.
+Do not trigger Deploy from CI. Telegram reports the requested SHA.
+
 This document describes the steps required to deploy the Crypto Trading AI Agent to a production environment.
 
 ## Prerequisites

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -66,20 +66,22 @@ docker-compose up -d timescaledb
 docker-compose exec -T timescaledb psql -U trading marketdata < migrations/001_initial_schema.sql
 ```
 
-### 5. Launch Services
+### 5. Launch / update production services
 
-Deploy using the production compose file (if created) or the default one:
-
-```bash
-docker-compose up -d --build
-```
+Do **not** use `docker-compose.yml` (dev bind-mount). Production is
+`docker-compose.prod.yml` via the manual Deploy workflow above, or the
+break-glass procedure in `AGENTS.md` (pinned SHA, all `agent_*`, 120s health).
 
 ### 6. Verify Deployment
 
-- Check agent logs: `docker-compose logs -f agent`
-- Verify metrics: `curl http://localhost:8000/metrics`
-- Check Grafana: `http://localhost:3000` (Default: admin/admin)
-- Check Prometheus: `http://localhost:9090`
+```bash
+ssh crypto-agent "cd /opt/crypto-agent && docker compose -f docker-compose.prod.yml ps"
+```
+
+- Every `agent_*` status must end in `(healthy)`.
+- Metrics: `curl http://localhost:8000/metrics` (per-agent in prod).
+- Grafana: `http://localhost:3000`
+- Prometheus: `http://localhost:9090`
 
 ## Maintenance
 
@@ -95,10 +97,8 @@ docker-compose up -d --build
 
 ### Updating
 
-```bash
-git pull
-docker-compose up -d --build
-```
+Merging is not a deploy. Use `gh workflow run Deploy --ref main -f deploy_sha=…`
+with the current `origin/main` SHA. See the top of this file and `AGENTS.md`.
 
 ## Troubleshooting
 

--- a/docs/PR_WORKFLOW.md
+++ b/docs/PR_WORKFLOW.md
@@ -80,6 +80,10 @@ Once approved and CI passes:
 gh pr merge --squash
 ```
 
+**Merging does not authorize production deployment.** `.github/workflows/deploy.yml`
+runs only via manual `workflow_dispatch` with a required `deploy_sha` that must
+equal the current `origin/main` SHA. See `AGENTS.md` for the exact invocation.
+
 Or use the GitHub web interface.
 
 ## Review Guidelines

--- a/scripts/align_prod_checkout.sh
+++ b/scripts/align_prod_checkout.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Align a production checkout to REQUESTED_SHA without mutating HEAD on mismatch.
+# Used by .github/workflows/deploy.yml (piped from the runner, not the server tree).
+set -euo pipefail
+
+: "${REQUESTED_SHA:?REQUESTED_SHA is required}"
+ROOT="${DEPLOY_ROOT:-/opt/crypto-agent}"
+cd "$ROOT"
+
+# 1) Fetch only. Do not pull until origin/main matches the requested SHA.
+git fetch origin main
+REMOTE=$(git rev-parse origin/main)
+if [ "$REMOTE" != "$REQUESTED_SHA" ]; then
+  echo "ERROR: origin/main ($REMOTE) != requested deploy_sha ($REQUESTED_SHA); aborting before pull"
+  exit 1
+fi
+
+# 2) Fast-forward only after the pre-pull check.
+git pull --ff-only origin main
+
+# 3) Reverify HEAD, origin/main, and the requested SHA agree.
+LOCAL=$(git rev-parse HEAD)
+REMOTE=$(git rev-parse origin/main)
+if [ "$LOCAL" != "$REMOTE" ]; then
+  echo "ERROR: after pull, HEAD ($LOCAL) != origin/main ($REMOTE)"
+  exit 1
+fi
+if [ "$LOCAL" != "$REQUESTED_SHA" ]; then
+  echo "ERROR: after pull, HEAD ($LOCAL) != requested deploy_sha ($REQUESTED_SHA)"
+  exit 1
+fi

--- a/scripts/rebuild_prod_agents.sh
+++ b/scripts/rebuild_prod_agents.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Coordinated rebuild of every agent_* service. Runs after align_prod_checkout.sh.
+set -euo pipefail
+
+ROOT="${DEPLOY_ROOT:-/opt/crypto-agent}"
+cd "$ROOT"
+
+AGENTS=$(docker compose -f docker-compose.prod.yml config --services | grep '^agent_' | sort | tr '\n' ' ')
+if [ -z "$AGENTS" ]; then
+  echo "ERROR: no agent_* services found in docker-compose.prod.yml"
+  exit 1
+fi
+echo "Deploying agents: $AGENTS"
+
+docker compose -f docker-compose.prod.yml build $AGENTS
+docker compose -f docker-compose.prod.yml up -d --remove-orphans $AGENTS
+
+sleep 120
+NOT_READY=$(docker compose -f docker-compose.prod.yml ps --format "{{.Service}} {{.Status}}" $AGENTS | grep -vE '\(healthy\)$' || true)
+if [ -n "$NOT_READY" ]; then
+  echo "ERROR: agents not healthy after 120s:"
+  echo "$NOT_READY"
+  docker compose -f docker-compose.prod.yml ps $AGENTS
+  exit 1
+fi
+
+docker image prune -f
+
+HEALTHY=$(echo "$AGENTS" | tr ' ' '\n' | grep . | sort | paste -sd, -)
+echo "deploy_services=$HEALTHY"

--- a/scripts/validate_deploy_sha.py
+++ b/scripts/validate_deploy_sha.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Fail-closed check that a deploy SHA is exact lowercase hex and equals origin/main."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+
+_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+
+
+def validate_deploy_sha(deploy_sha: str, origin_main_sha: str) -> None:
+    """Raise ValueError unless deploy_sha is a 40-char lowercase hex SHA equal to main."""
+    if not _SHA_RE.fullmatch(deploy_sha):
+        raise ValueError(
+            f"deploy_sha must be exactly 40 lowercase hexadecimal characters, got {deploy_sha!r}"
+        )
+    if not _SHA_RE.fullmatch(origin_main_sha):
+        raise ValueError(
+            "origin/main SHA must be exactly 40 lowercase hexadecimal characters, "
+            f"got {origin_main_sha!r}"
+        )
+    if deploy_sha != origin_main_sha:
+        raise ValueError(f"deploy_sha ({deploy_sha}) != origin/main ({origin_main_sha})")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("deploy_sha", help="Requested 40-char lowercase deploy SHA")
+    parser.add_argument(
+        "origin_main_sha",
+        help="Current origin/main SHA (must match deploy_sha)",
+    )
+    args = parser.parse_args(argv)
+    try:
+        validate_deploy_sha(args.deploy_sha, args.origin_main_sha)
+    except ValueError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+    print(f"deploy_sha ok: {args.deploy_sha}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_deploy_workflow.py
+++ b/tests/test_deploy_workflow.py
@@ -1,0 +1,95 @@
+"""Deterministic checks that production deploy is manual and fail-closed."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from scripts.validate_deploy_sha import main, validate_deploy_sha
+
+WORKFLOW = Path(".github/workflows/deploy.yml")
+VALID_SHA = "a" * 40
+OTHER_SHA = "b" * 40
+
+
+def _load_workflow() -> dict[str, object]:
+    return yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+
+
+def _on(workflow: dict[str, object]) -> dict[str, object]:
+    # PyYAML 1.1 treats the key `on` as boolean True.
+    trigger = workflow.get("on", workflow.get(True))
+    assert isinstance(trigger, dict)
+    return trigger
+
+
+def _raw() -> str:
+    return WORKFLOW.read_text(encoding="utf-8")
+
+
+def test_workflow_run_is_absent_as_deployment_trigger() -> None:
+    on = _on(_load_workflow())
+    assert "workflow_run" not in on
+    assert "workflow_run:" not in _raw()
+
+
+def test_workflow_dispatch_is_the_only_trigger() -> None:
+    on = _on(_load_workflow())
+    assert list(on.keys()) == ["workflow_dispatch"]
+
+
+def test_deploy_sha_is_required() -> None:
+    dispatch = _on(_load_workflow())["workflow_dispatch"]
+    assert isinstance(dispatch, dict)
+    deploy_sha = dispatch["inputs"]["deploy_sha"]
+    assert deploy_sha["required"] is True
+    assert deploy_sha["type"] == "string"
+
+
+def test_production_environment_protection_is_referenced() -> None:
+    job = _load_workflow()["jobs"]["deploy"]
+    assert isinstance(job, dict)
+    assert job["environment"] == "production"
+
+
+def test_invalid_sha_fails_closed() -> None:
+    with pytest.raises(ValueError, match="40 lowercase hexadecimal"):
+        validate_deploy_sha("ABCDEF" + "0" * 34, VALID_SHA)
+    with pytest.raises(ValueError, match="40 lowercase hexadecimal"):
+        validate_deploy_sha("not-a-sha", VALID_SHA)
+    with pytest.raises(ValueError, match="40 lowercase hexadecimal"):
+        validate_deploy_sha("a" * 39, VALID_SHA)
+    assert main(["NOTHEX" + "0" * 34, VALID_SHA]) == 1
+
+
+def test_mismatched_sha_fails_closed() -> None:
+    with pytest.raises(ValueError, match="!= origin/main"):
+        validate_deploy_sha(VALID_SHA, OTHER_SHA)
+    assert main([VALID_SHA, OTHER_SHA]) == 1
+
+
+def test_matching_lowercase_sha_passes() -> None:
+    validate_deploy_sha(VALID_SHA, VALID_SHA)
+    assert main([VALID_SHA, VALID_SHA]) == 0
+
+
+def test_workflow_invokes_fail_closed_sha_validator() -> None:
+    raw = _raw()
+    assert "python3 scripts/validate_deploy_sha.py" in raw
+    assert "if: ${{ github.event.workflow_run.conclusion == 'success' }}" not in raw
+
+
+def test_coordinated_rebuild_and_health_checks_remain() -> None:
+    raw = _raw()
+    assert "tailscale/github-action@" in raw
+    assert "git pull --ff-only origin main" in raw
+    assert "grep '^agent_'" in raw
+    assert "docker compose -f docker-compose.prod.yml build $AGENTS" in raw
+    assert "docker compose -f docker-compose.prod.yml up -d --remove-orphans $AGENTS" in raw
+    assert "sleep 120" in raw
+    assert r"grep -vE '\(healthy\)$'" in raw
+    assert "appleboy/telegram-action@" in raw
+    assert "inputs.deploy_sha" in raw
+    assert "github.event.workflow_run" not in raw

--- a/tests/test_deploy_workflow.py
+++ b/tests/test_deploy_workflow.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import os
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -10,6 +12,8 @@ import yaml
 from scripts.validate_deploy_sha import main, validate_deploy_sha
 
 WORKFLOW = Path(".github/workflows/deploy.yml")
+ALIGN = Path("scripts/align_prod_checkout.sh")
+REBUILD = Path("scripts/rebuild_prod_agents.sh")
 VALID_SHA = "a" * 40
 OTHER_SHA = "b" * 40
 
@@ -83,13 +87,121 @@ def test_workflow_invokes_fail_closed_sha_validator() -> None:
 
 def test_coordinated_rebuild_and_health_checks_remain() -> None:
     raw = _raw()
+    rebuild = REBUILD.read_text(encoding="utf-8")
+    align = ALIGN.read_text(encoding="utf-8")
     assert "tailscale/github-action@" in raw
-    assert "git pull --ff-only origin main" in raw
-    assert "grep '^agent_'" in raw
-    assert "docker compose -f docker-compose.prod.yml build $AGENTS" in raw
-    assert "docker compose -f docker-compose.prod.yml up -d --remove-orphans $AGENTS" in raw
-    assert "sleep 120" in raw
-    assert r"grep -vE '\(healthy\)$'" in raw
+    assert "cat scripts/align_prod_checkout.sh" in raw
+    assert "cat scripts/rebuild_prod_agents.sh" in raw
+    assert "git fetch origin main" in align
+    assert "git pull --ff-only origin main" in align
+    assert "grep '^agent_'" in rebuild
+    assert "docker compose -f docker-compose.prod.yml build $AGENTS" in rebuild
+    assert "docker compose -f docker-compose.prod.yml up -d --remove-orphans $AGENTS" in rebuild
+    assert "sleep 120" in rebuild
+    assert r"grep -vE '\(healthy\)$'" in rebuild
     assert "appleboy/telegram-action@" in raw
     assert "inputs.deploy_sha" in raw
     assert "github.event.workflow_run" not in raw
+
+
+def test_align_compares_requested_sha_before_pull() -> None:
+    align = ALIGN.read_text(encoding="utf-8")
+    fetch_at = align.index("git fetch origin main")
+    compare_at = align.index("origin/main ($REMOTE) != requested deploy_sha")
+    pull_at = align.index("git pull --ff-only origin main")
+    reverify_at = align.index("after pull, HEAD")
+    assert fetch_at < compare_at < pull_at < reverify_at
+    assert "aborting before pull" in align
+
+
+def _git(cwd: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def _bare_and_clones(tmp_path: Path) -> tuple[Path, Path, str]:
+    origin = tmp_path / "origin.git"
+    subprocess.run(["git", "init", "--bare", str(origin)], check=True, capture_output=True)
+    work = tmp_path / "work"
+    work.mkdir()
+    _git(work, "init")
+    _git(work, "config", "user.email", "deploy-test@example.com")
+    _git(work, "config", "user.name", "deploy-test")
+    (work / "marker").write_text("a\n", encoding="utf-8")
+    _git(work, "add", "marker")
+    _git(work, "commit", "-m", "a")
+    _git(work, "branch", "-M", "main")
+    _git(work, "remote", "add", "origin", str(origin))
+    _git(work, "push", "-u", "origin", "main")
+    server = tmp_path / "server"
+    subprocess.run(
+        ["git", "clone", "--branch", "main", str(origin), str(server)],
+        check=True,
+        capture_output=True,
+    )
+    sha_a = _git(server, "rev-parse", "HEAD")
+    return work, server, sha_a
+
+
+def test_align_aborts_before_pull_when_main_advanced(tmp_path: Path) -> None:
+    """A stale dispatch must not move the server checkout when origin/main moved."""
+    work, server, sha_a = _bare_and_clones(tmp_path)
+    (work / "marker").write_text("b\n", encoding="utf-8")
+    _git(work, "add", "marker")
+    _git(work, "commit", "-m", "b")
+    _git(work, "push", "origin", "main")
+
+    env = {**os.environ, "REQUESTED_SHA": sha_a, "DEPLOY_ROOT": str(server)}
+    proc = subprocess.run(
+        ["bash", str(ALIGN)],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode == 1
+    assert "aborting before pull" in proc.stdout + proc.stderr
+    assert _git(server, "rev-parse", "HEAD") == sha_a
+    assert (server / "marker").read_text(encoding="utf-8") == "a\n"
+
+
+def test_align_pulls_when_requested_sha_is_current_main(tmp_path: Path) -> None:
+    work, server, sha_a = _bare_and_clones(tmp_path)
+    (work / "marker").write_text("b\n", encoding="utf-8")
+    _git(work, "add", "marker")
+    _git(work, "commit", "-m", "b")
+    _git(work, "push", "origin", "main")
+    sha_b = _git(work, "rev-parse", "HEAD")
+    assert sha_b != sha_a
+
+    env = {**os.environ, "REQUESTED_SHA": sha_b, "DEPLOY_ROOT": str(server)}
+    proc = subprocess.run(
+        ["bash", str(ALIGN)],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert _git(server, "rev-parse", "HEAD") == sha_b
+    assert (server / "marker").read_text(encoding="utf-8") == "b\n"
+
+
+def test_docs_do_not_bypass_deploy_contract() -> None:
+    agents = Path("AGENTS.md").read_text(encoding="utf-8")
+    claude = Path("CLAUDE.md").read_text(encoding="utf-8")
+    deployment = Path("docs/DEPLOYMENT.md").read_text(encoding="utf-8")
+    combined = agents + claude + deployment
+    assert "build <service>" not in agents
+    assert "build agent &&" not in claude
+    assert "docker-compose up -d --build" not in combined
+    assert "align_prod_checkout.sh" in agents
+    assert "sleep 120" in agents
+    assert "docker-compose.prod.yml" in agents
+    assert 'grep "^agent_"' in agents or "grep '^agent_'" in agents


### PR DESCRIPTION
## Summary

Restore an explicit production-deployment approval boundary.

- Remove `workflow_run` auto-deploy after successful main CI.
- Deploy only via `workflow_dispatch` with required `deploy_sha`.
- `deploy_sha` must be exactly 40 lowercase hex chars and must equal current `origin/main`. Fail closed otherwise.
- Job uses `environment: production`.
- Preserves Tailscale, ff-only pull, dynamic `agent_*` discovery, coordinated rebuild+restart, 120s health settle, fail-closed health, Telegram.
- Telegram reports the requested SHA.
- **Merging this PR does not deploy.** Do not run the Deploy workflow as part of this change.

## Type of Change

- [x] Bug fix (auto-deploy after CI)
- [x] Tests
- [x] Documentation update

## Testing

- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run pytest -v` — **1305 passed**
- [x] `git diff --check`

## Notes

- GitHub production environment reviewer rules are an unresolved external action (configure protection on the `production` environment).
- xAI billing/credits are unchanged and out of scope.
- `agent_sentiment_macro` remains paper (`trading_execution.enabled: false`). This PR does not touch strategy or execution.
- PR 2 (DeepSeek `model` attribution) waits until this merges.