### PR TITLE
fix(overseer): persist the answering model on ChatResult

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -834,14 +834,13 @@ def _wire_optional_strategy_dependencies(
         source = str(payload.get("source", ""))
         if source == "deepseek_fallback":
             provider = "deepseek"
-        elif source.startswith("xai") or source == "neutral_fallback":
-            provider = "xai" if xai_client is not None else "none"
         else:
             provider = "xai" if xai_client is not None else "none"
+        supplied_model = str(payload.get("model") or "").strip()
         enriched_payload = {
             **payload,
             "provider": provider,
-            "model": ai_model,
+            "model": supplied_model or ai_model,
         }
         await event_log.log("sentiment_score", enriched_payload)
 

--- a/src/overseer/xai.py
+++ b/src/overseer/xai.py
@@ -24,10 +24,11 @@ _MAX_ATTEMPTS = 3
 
 @dataclass(frozen=True)
 class ChatResult:
-    """LLM reply plus which provider actually answered."""
+    """LLM reply plus which provider and model actually answered."""
 
     content: str
     provider: str  # "xai" | "deepseek"
+    model: str
 
 
 class XAIClient:
@@ -66,7 +67,7 @@ class XAIClient:
                 messages,
                 provider_name="xAI",
             )
-            return ChatResult(content=content, provider="xai")
+            return ChatResult(content=content, provider="xai", model=self._model)
         except _AUTH_ERRORS as exc:
             if self._fallback_client is None:
                 raise
@@ -85,7 +86,7 @@ class XAIClient:
             messages,
             provider_name="DeepSeek",
         )
-        return ChatResult(content=content, provider="deepseek")
+        return ChatResult(content=content, provider="deepseek", model=self._fallback_model)
 
     async def _chat_with_client(
         self,

--- a/src/strategy/sentiment_mean_reversion.py
+++ b/src/strategy/sentiment_mean_reversion.py
@@ -79,10 +79,10 @@ class SentimentScorer:
             return score
 
         try:
-            score, provider = await self._query_llm(symbol)
+            score, provider, answering_model = await self._query_llm(symbol)
             self._cache[symbol] = (now, score)
             source = "deepseek_fallback" if provider == "deepseek" else "xai_live"
-            await self._record_observation(symbol, score, source=source)
+            await self._record_observation(symbol, score, source=source, model=answering_model)
             return score
         except Exception as exc:
             self._logger.warning("Sentiment query failed for %s: %s", symbol, exc)
@@ -101,6 +101,7 @@ class SentimentScorer:
         *,
         source: str,
         error: str | None = None,
+        model: str | None = None,
     ) -> None:
         # Track for degradation detection regardless of recorder
         self._recent_sources.append(source)
@@ -114,6 +115,8 @@ class SentimentScorer:
             "score": round(float(score), 4),
             "source": source,
         }
+        if model:
+            payload["model"] = model
         if error:
             payload["error"] = error[:500]
         try:
@@ -160,11 +163,11 @@ class SentimentScorer:
         except Exception as exc:  # noqa: BLE001
             self._logger.warning("Degradation alert failed: %s", exc)
 
-    async def _query_llm(self, symbol: str) -> tuple[float, str]:
+    async def _query_llm(self, symbol: str) -> tuple[float, str, str | None]:
         """Query the configured LLM for sentiment analysis.
 
-        Returns ``(score, provider)`` where provider is ``xai`` or ``deepseek``.
-        Test doubles that return a bare string are treated as ``xai``.
+        Returns ``(score, provider, model)``. Bare-string test doubles are
+        treated as ``xai`` with no model (the recorder may fall back).
         """
         base_asset = symbol.replace("USDT", "").replace("BUSD", "")
         prompt = (
@@ -185,17 +188,19 @@ class SentimentScorer:
         if hasattr(result, "content") and hasattr(result, "provider"):
             response = str(result.content)
             provider = str(result.provider)
+            answering_model = str(getattr(result, "model", "") or "") or None
         else:
             response = str(result)
             provider = "xai"
+            answering_model = None
 
         try:
             data = json.loads(response)
             score = float(data.get("score", 50))
-            return max(0.0, min(100.0, score)), provider
+            return max(0.0, min(100.0, score)), provider, answering_model
         except (json.JSONDecodeError, ValueError, TypeError):
             self._logger.warning("Could not parse sentiment response: %s", response[:200])
-            return 50.0, provider
+            return 50.0, provider, answering_model
 
 
 class SentimentMeanReversionStrategy(BaseStrategy):

--- a/tests/test_sentiment_mean_reversion.py
+++ b/tests/test_sentiment_mean_reversion.py
@@ -310,6 +310,7 @@ class TestSentimentScorer:
                 return ChatResult(
                     content='{"score": 55, "reason": "deepseek path"}',
                     provider="deepseek",
+                    model="deepseek-v4-pro",
                 )
 
         observations: list[dict[str, object]] = []
@@ -330,8 +331,41 @@ class TestSentimentScorer:
                 "symbol": "SOLUSDT",
                 "score": 55.0,
                 "source": "deepseek_fallback",
+                "model": "deepseek-v4-pro",
             }
         ]
+
+    @pytest.mark.asyncio
+    async def test_ten_deepseek_observations_degrade_and_suppress_buy(self):
+        """Ten DeepSeek answers remain non-xai_live and block new BUY entries."""
+        from src.overseer.xai import ChatResult
+
+        class FallbackClient:
+            async def chat(self, messages):
+                return ChatResult(
+                    content='{"score": 70, "reason": "deepseek"}',
+                    provider="deepseek",
+                    model="deepseek-v4-pro",
+                )
+
+        scorer = SentimentScorer(
+            xai_client=FallbackClient(),
+            cache_ttl_seconds=0,
+            degradation_window=10,
+        )
+        for i in range(10):
+            await scorer.get_score(f"SYM{i}USDT")
+
+        assert scorer.degraded is True
+
+        strategy = _make_strategy()
+        strategy.set_scorer(scorer)
+        signal = await strategy.evaluate(
+            "BTCUSDT",
+            _indicators(rsi=25.0, bb_lower_dist=0.001),
+        )
+        assert signal.type == SignalType.HOLD
+        assert "SentimentDegraded" in signal.reason
 
 
 class TestDegradationAlert:

--- a/tests/test_settings_integration.py
+++ b/tests/test_settings_integration.py
@@ -274,6 +274,70 @@ async def test_wire_optional_strategy_dependencies_records_enriched_sentiment_ev
 
 
 @pytest.mark.asyncio
+async def test_wire_records_deepseek_fallback_model_from_chat_result():
+    """End-to-end: DeepSeek ChatResult model is persisted, not the xAI model."""
+    from src.overseer.xai import ChatResult
+
+    class FallbackClient:
+        async def chat(self, messages):
+            return ChatResult(
+                content='{"score": 58, "reason": "fallback"}',
+                provider="deepseek",
+                model="deepseek-v4-pro",
+            )
+
+    class FakeEventLog:
+        def __init__(self) -> None:
+            self.events: list[tuple[str, dict[str, object]]] = []
+
+        async def log(self, event_type: str, payload: dict[str, object]) -> None:
+            self.events.append((event_type, payload))
+
+    reader = MagicMock()
+    engine = StrategyEngine(
+        EngineConfig(
+            symbols=["BTCUSDT"],
+            strategy_classes=[SentimentMeanReversionStrategy],
+            strategy_configs=[{}],
+        ),
+        reader,
+    )
+    event_log = FakeEventLog()
+
+    _wire_optional_strategy_dependencies(
+        engine,
+        xai_client=FallbackClient(),
+        event_log=event_log,
+        ai_model="grok-4-1-fast-reasoning",
+    )
+
+    strategy = engine._strategies["BTCUSDT"][0]  # pylint: disable=protected-access
+    await strategy.evaluate(
+        "BTCUSDT",
+        {
+            "rsi_14": 25.0,
+            "bb_lower_dist": 0.001,
+            "bb_upper_dist": 0.05,
+            "close_price": 50000.0,
+        },
+    )
+
+    assert event_log.events == [
+        (
+            "sentiment_score",
+            {
+                "symbol": "BTCUSDT",
+                "score": 58.0,
+                "source": "deepseek_fallback",
+                "model": "deepseek-v4-pro",
+                "provider": "deepseek",
+            },
+        )
+    ]
+    assert event_log.events[0][1]["model"] != "grok-4-1-fast-reasoning"
+
+
+@pytest.mark.asyncio
 async def test_full_flow_engine_to_executor():
     """Test full flow: IndicatorReader → StrategyEngine → Signal → Executor."""
     from src.features.reader import IndicatorReader

--- a/tests/test_xai_client.py
+++ b/tests/test_xai_client.py
@@ -42,7 +42,7 @@ async def test_chat_returns_trimmed_content() -> None:
         messages=[{"role": "user", "content": "status?"}],
         temperature=0.2,
     )
-    assert response == ChatResult(content="market regime stable", provider="xai")
+    assert response == ChatResult(content="market regime stable", provider="xai", model="grok-3")
 
 
 @pytest.mark.asyncio
@@ -58,6 +58,7 @@ async def test_chat_returns_fallback_when_content_missing() -> None:
     assert response == ChatResult(
         content="No response content returned by xAI API.",
         provider="xai",
+        model="grok-3",
     )
 
 
@@ -72,7 +73,7 @@ async def test_chat_retries_on_transient_error_then_succeeds() -> None:
             client = XAIClient(api_key="test-key", model="grok-3")
             response = await client.chat([{"role": "user", "content": "ping"}])
 
-    assert response == ChatResult(content="recovered", provider="xai")
+    assert response == ChatResult(content="recovered", provider="xai", model="grok-3")
     assert create.await_count == 2
     mock_sleep.assert_awaited_once_with(1)  # 2**0 = 1s after first failure
 
@@ -125,7 +126,7 @@ async def test_chat_uses_fallback_provider_after_xai_retries_exhausted() -> None
             )
             response = await client.chat([{"role": "user", "content": "ping"}])
 
-    assert response == ChatResult(content="fallback-ok", provider="deepseek")
+    assert response == ChatResult(content="fallback-ok", provider="deepseek", model="deepseek-chat")
     assert primary_create.await_count == 3
     fallback_create.assert_awaited_once()
     assert mock_openai.call_count == 2
@@ -174,10 +175,13 @@ async def test_chat_falls_back_on_permission_denied_without_retry() -> None:
                 api_key="xai-key",
                 model="grok-3",
                 fallback_api_key="deepseek-key",
+                fallback_model="deepseek-v4-pro",
             )
             response = await client.chat([{"role": "user", "content": "ping"}])
 
-    assert response == ChatResult(content="deepseek-ok", provider="deepseek")
+    assert response == ChatResult(
+        content="deepseek-ok", provider="deepseek", model="deepseek-v4-pro"
+    )
     assert primary_create.await_count == 1
     fallback_create.assert_awaited_once()
     mock_sleep.assert_not_awaited()


### PR DESCRIPTION
## Summary

Complete DeepSeek model attribution after #171/#175.

- `ChatResult` now has `content`, `provider`, and the **actual answering model**.
- xAI replies record the configured xAI model; DeepSeek fallback records `fallback_model`.
- `SentimentScorer` forwards that model on observation payloads.
- `_record_sentiment_observation` persists the supplied model; bare-string doubles still fall back to `ai_model`.
- Collapsed the redundant `elif`/`else` provider branch.
- DeepSeek answers remain `deepseek_fallback` / non-`xai_live` (degradation unchanged).
- No scoring, prompt, threshold, signal, or config changes.

## Type of Change

- [x] Bug fix
- [x] Tests

## Testing

- [x] Focused: `tests/test_xai_client.py`, `tests/test_sentiment_mean_reversion.py`, `tests/test_settings_integration.py`
- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run pytest -v` — **1311 passed**
- [x] `git diff --check`

## Notes

- **Merging does not authorize deployment.** After #175, Deploy is manual `workflow_dispatch` with `deploy_sha`.
- `agent_sentiment_macro` remains paper (`trading_execution.enabled: false`).
- Do not deploy from this PR.

## Runtime verification (document only — after a later authorized deploy)

- Trigger Deploy with the exact current `origin/main` SHA.
- Confirm remote HEAD equals that SHA and every `agent_*` is healthy.
- Confirm `agent_sentiment_macro` starts in paper with `PaperExecutor`.
- Confirm one natural fallback event in the **Docker volume** file is:
  `source=deepseek_fallback`, `provider=deepseek`, `model=deepseek-v4-pro`.
- Confirm no real orders. Do not force an LLM request for testing.